### PR TITLE
fix: Prioritize user-defined config parameters over default ones

### DIFF
--- a/faststream/confluent/client.py
+++ b/faststream/confluent/client.py
@@ -101,9 +101,9 @@ class AsyncConfluentProducer:
         }
 
         final_config = {
-            **config.as_config_dict(),
             **config_from_params,
             **dict(security_config or {}),
+            **config.as_config_dict(),
         }
 
         self.producer = Producer(final_config, logger=self.logger)  # type: ignore[call-arg]
@@ -261,17 +261,15 @@ class AsyncConfluentConsumer:
                 ]
             )
 
-        final_config = config.as_config_dict()
-
         config_from_params = {
             "allow.auto.create.topics": allow_auto_create_topics,
             "topic.metadata.refresh.interval.ms": 1000,
             "bootstrap.servers": bootstrap_servers,
             "client.id": client_id,
             "group.id": group_id
-            or final_config.get("group.id", "faststream-consumer-group"),
+            or config.config.get("group.id", "faststream-consumer-group"),
             "group.instance.id": group_instance_id
-            or final_config.get("group.instance.id", None),
+            or config.config.get("group.instance.id", None),
             "fetch.wait.max.ms": fetch_max_wait_ms,
             "fetch.max.bytes": fetch_max_bytes,
             "fetch.min.bytes": fetch_min_bytes,
@@ -291,11 +289,13 @@ class AsyncConfluentConsumer:
             "isolation.level": isolation_level,
         }
         self.allow_auto_create_topics = allow_auto_create_topics
-        final_config.update(config_from_params)
-        final_config.update(**dict(security_config or {}))
 
-        self.config = final_config
-        self.consumer = Consumer(final_config, logger=self.logger)  # type: ignore[call-arg]
+        self.config = {
+            **config_from_params,
+            **dict(security_config or {}),
+            **config.as_config_dict(),
+        }
+        self.consumer = Consumer(self.config, logger=self.logger)  # type: ignore[call-arg]
 
         # We shouldn't read messages and close consumer concurrently
         # https://github.com/airtai/faststream/issues/1904#issuecomment-2506990895


### PR DESCRIPTION
# Description

Motivation: we want to configure `confluent_kafka` client from environment. This is needed to avoid changing code each time we want to pass a new kafka setting. To achieve this we pass all [librdkafka settings](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) through `config: ConfluentFastConfig` broker parameter. 

Problem: when `faststream` creates `AsyncConfluentProducer` or `AsyncConfluentConsumer` it overrides our settings in `config` using some default values.

Solution: prioritize user-defined config parameters over default ones

## Type of change

- [?] Bug fix (a non-breaking change that resolves an issue)
- [?] Breaking change (a fix or feature that would disrupt existing functionality)

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
