### PR TITLE
docs: access the msg attribute of BaseMiddleware

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,7 +160,7 @@
         "filename": "docs/docs/en/release.md",
         "hashed_secret": "35675e68f4b5af7b995d9205ad0fc43842f16450",
         "is_verified": false,
-        "line_number": 2035,
+        "line_number": 2052,
         "is_secret": false
       }
     ],
@@ -185,5 +185,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-21T16:04:45Z"
+  "generated_at": "2025-04-07T05:01:59Z"
 }

--- a/docs/docs/en/getting-started/middlewares/index.md
+++ b/docs/docs/en/getting-started/middlewares/index.md
@@ -32,7 +32,7 @@ from faststream import BaseMiddleware
 
 class MyMiddleware(BaseMiddleware):
     async def on_receive(self):
-        print(f"Received: {self.message}")
+        print(f"Received: {self.msg}")
         return await super().on_receive()
 
     async def after_processed(self, exc_type, exc_val, exc_tb):

--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,6 +12,23 @@ hide:
 ---
 
 # Release Notes
+## 0.5.38
+
+### What's Changed
+
+* Update Release Notes for 0.5.37 by @airt-release-notes-updater in [#2140](https://github.com/ag2ai/faststream/pull/2140){.external-link target="_blank"}
+* chore(deps): bump the pip group with 6 updates by [@dependabot](https://github.com/dependabot){.external-link target="_blank"} in [#2144](https://github.com/ag2ai/faststream/pull/2144){.external-link target="_blank"}
+* fix: pydantic211 compat by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2150](https://github.com/ag2ai/faststream/pull/2150){.external-link target="_blank"}
+* Tweak RabbitMQ queue argument lists by @Arseniy-Popov in [#2148](https://github.com/ag2ai/faststream/pull/2148){.external-link target="_blank"}
+* fix: prevent duplicate logging handler registration when calling broker.start() by [@banksemi](https://github.com/banksemi){.external-link target="_blank"} in [#2153](https://github.com/ag2ai/faststream/pull/2153){.external-link target="_blank"}
+* chore(deps): bump the pip group with 5 updates by [@dependabot](https://github.com/dependabot){.external-link target="_blank"} in [#2154](https://github.com/ag2ai/faststream/pull/2154){.external-link target="_blank"}
+* Move to ag2ai organization by [@davorrunje](https://github.com/davorrunje){.external-link target="_blank"} in [#2156](https://github.com/ag2ai/faststream/pull/2156){.external-link target="_blank"}
+
+### New Contributors
+* [@banksemi](https://github.com/banksemi){.external-link target="_blank"} made their first contribution in [#2153](https://github.com/ag2ai/faststream/pull/2153){.external-link target="_blank"}
+
+**Full Changelog**: [#0.5.37...0.5.38](https://github.com/ag2ai/faststream/compare/0.5.37...0.5.38){.external-link target="_blank"}
+
 ## 0.5.37
 
 ### What's Changed


### PR DESCRIPTION
# Description

It seems that a `BaseMiddleware` instance has no attribute `message`

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
