### PR TITLE
docs: add information about manual AsyncAPI hosting

### DIFF
--- a/docs/docs/en/getting-started/asyncapi/hosting.md
+++ b/docs/docs/en/getting-started/asyncapi/hosting.md
@@ -52,6 +52,156 @@ And you should be able to see the following page in your browser:
 !!! tip
     The command also offers options to serve the documentation on a different host and port.
 
+## Manual AsyncAPI Hosting
+
+While the CLI is convenient for most cases, you may need to integrate AsyncAPI documentation into your existing application or customize the hosting behavior. FastStream provides public API functions for manual AsyncAPI hosting.
+
+### Using the Public API
+
+FastStream exposes two key functions in the `faststream.asyncapi` module:
+
+```python
+from faststream.asyncapi import get_app_schema, get_asyncapi_html
+```
+
+- `get_app_schema`: Generates the AsyncAPI schema from a FastStream application
+- `get_asyncapi_html`: Converts the schema to HTML for browser viewing
+
+Here's an example of how to use these functions:
+
+```python
+from contextlib import asynccontextmanager
+import asyncio
+from faststream import FastStream
+from faststream.nats import NatsBroker
+from faststream.asyncapi import get_app_schema, get_asyncapi_html
+import http.server
+import socketserver
+from threading import Thread
+
+# Create your FastStream application
+broker = NatsBroker()
+app = FastStream(broker)
+
+# Add your subscribers and publishers
+@broker.subscriber("test.subject")
+async def handle_message(msg: str):
+    return f"Processed: {msg}"
+
+# Generate the AsyncAPI schema before starting the application
+schema = get_app_schema(app)
+
+# Convert the schema to HTML
+html_content = get_asyncapi_html(
+    schema=schema,
+    title="My Custom API Docs",
+    # Optional: customize display options
+    sidebar=True,
+    operations=True,
+    messages=True,
+    schemas=True,
+)
+
+# Create a simple HTTP server to serve the documentation
+class AsyncAPIHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(html_content.encode())
+    
+    # Make the server quieter by overriding log_message
+    def log_message(self, format, *args):
+        pass
+
+# Start the HTTP server in a separate thread
+def run_http_server():
+    with socketserver.TCPServer(("localhost", 8000), AsyncAPIHandler) as httpd:
+        print("AsyncAPI docs available at http://localhost:8000")
+        httpd.serve_forever()
+
+http_thread = Thread(target=run_http_server, daemon=True)
+http_thread.start()
+
+# Start the FastStream application
+async def main():
+    async with broker:
+        # Start the broker
+        await broker.start()
+        print("FastStream application is running. Press Ctrl+C to stop.")
+        
+        try:
+            # Keep the application running
+            while True:
+                await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            print("Shutting down...")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+This example demonstrates:
+1. Generating the AsyncAPI schema documentation
+2. Converting it to HTML
+3. Serving the HTML via a simple HTTP server in a separate thread
+4. Running the FastStream application in the main thread
+
+For a production environment, you might want to use a more robust web server like FastAPI, Starlette, or any other ASGI-compatible framework.
+
+### Integration with ASGI Frameworks
+
+For more advanced use cases, you may want to integrate AsyncAPI documentation with your existing ASGI application. FastStream provides built-in support for this via the `make_asyncapi_asgi` function.
+
+For details and examples on how to mount AsyncAPI documentation in ASGI applications, refer to the [FastStream Object Reuse](../asgi/#faststream-object-reuse) section in the ASGI documentation.
+
+Here's a simple example of how to integrate AsyncAPI documentation with FastAPI:
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from faststream import FastStream
+from faststream.nats import NatsBroker
+from faststream.asgi import make_asyncapi_asgi
+
+# Create a broker and FastStream application
+broker = NatsBroker()
+
+@broker.subscriber("test.subject")
+async def handle_message(msg: str):
+    return f"Processed: {msg}"
+
+app_stream = FastStream(broker)
+
+# Create a lifespan context manager for the FastAPI app
+@asynccontextmanager
+async def lifespan(app):
+    # Start the broker
+    async with broker:
+        await broker.start()
+        yield
+        # Shutdown will be handled by the context manager
+
+# Create a FastAPI application with the lifespan
+app = FastAPI(lifespan=lifespan)
+
+# Mount the AsyncAPI documentation at the /asyncapi path
+app.mount("/asyncapi", make_asyncapi_asgi(app_stream))
+
+# Add your FastAPI routes
+@app.get("/")
+async def root():
+    return {"message": "Hello World"}
+```
+
+You can then run this application with any ASGI server:
+
+```shell
+uvicorn main:app
+```
+
+The AsyncAPI documentation will be available at `http://localhost:8000/asyncapi`.
+
 ## Customizing AsyncAPI Documentation
 
 FastStream also provides query parameters to show and hide specific sections of AsyncAPI documentation.

--- a/docs/docs/en/getting-started/asyncapi/hosting.md
+++ b/docs/docs/en/getting-started/asyncapi/hosting.md
@@ -109,7 +109,7 @@ class AsyncAPIHandler(http.server.BaseHTTPRequestHandler):
         self.send_header("Content-type", "text/html")
         self.end_headers()
         self.wfile.write(html_content.encode())
-    
+
     # Make the server quieter by overriding log_message
     def log_message(self, format, *args):
         pass
@@ -129,7 +129,7 @@ async def main():
         # Start the broker
         await broker.start()
         print("FastStream application is running. Press Ctrl+C to stop.")
-        
+
         try:
             # Keep the application running
             while True:


### PR DESCRIPTION
# Description

This PR adds comprehensive documentation about manual AsyncAPI hosting using FastStream's public API functions. It addresses issue #2163 by providing detailed examples and explanations of how to use `get_app_schema` and `get_asyncapi_html` functions for custom AsyncAPI documentation hosting.

The changes include:
- A new section on manual AsyncAPI hosting
- Examples of using the public API functions
- Integration examples with ASGI frameworks
- Proper lifecycle management examples
- Links to related documentation

Fixes #2163

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have included code examples to illustrate the modifications