### PR TITLE
docs: update Django integration guide and add FastStream ORM access e…

### DIFF
--- a/docs/docs/en/getting-started/integrations/django/index.md
+++ b/docs/docs/en/getting-started/integrations/django/index.md
@@ -173,7 +173,7 @@ application = Starlette(
 
 This way we can easily integrate our **FastStream** application with the **Django**!
 
-# Accessing Django ORM from within FastStream consumer
+# Accessing Django ORM from within a FastStream Consumer
 
 In order to access the **Django** ORM from within a FastStream consumer, you need to ensure that the Django settings are properly configured and that the Django application is initialized before accessing the ORM. Here is how to do it using `serve_faststream.py` as an entry point for your FastStream consumer application.
 
@@ -192,7 +192,7 @@ import django
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 django.setup()
-# These lines are necessary to set up Django, call them at before any Django Related imports.
+# These lines are necessary to set up Django, call them before any Django Related imports.
 ###############################################################################
 from django.contrib.auth.models import User  # This line must be after django.setup()
 
@@ -215,9 +215,9 @@ async def faststream_django_orm_demo_handler(message: str):
 app = FastStream(broker)
 ```
 
-Start consumer with
+Start consumer with:
 ```bash
 faststream run serve_faststream:app
 ```
 
-It is advisable to use FastSteam's router to keep `serve_faststream.py` clean, and ensure `django.setup()` is always called first. See [FastStream Router](https://faststream.airt.ai/latest/getting-started/routers/) for more information.
+It is advisable to use FastStream's router to keep `serve_faststream.py` clean and to ensure `django.setup()` is always called first. See [FastStream Router](https://faststream.airt.ai/latest/getting-started/routers/) for more information.

--- a/docs/docs/en/getting-started/integrations/django/index.md
+++ b/docs/docs/en/getting-started/integrations/django/index.md
@@ -178,12 +178,12 @@ This way we can easily integrate our **FastStream** application with the **Djang
 In order to access the **Django** ORM from within a FastStream consumer, you need to ensure that the Django settings are properly configured and that the Django application is initialized before accessing the ORM. Here is how to do it using `serve_faststream.py` as an entry point for your FastStream consumer application.
 
 ```
-project-root/  
-├── manage.py  
-├── serve_faststream.py  
+project-root/
+├── manage.py
+├── serve_faststream.py
 ```
 ```Python
-# serve_faststream.py 
+# serve_faststream.py
 # ruff: noqa: E402
 ###############################################################################
 import os

--- a/docs/docs/en/getting-started/integrations/django/index.md
+++ b/docs/docs/en/getting-started/integrations/django/index.md
@@ -70,7 +70,7 @@ django_asgi = get_asgi_application()
 from starlette.applications import Starlette
 from starlette.routing import Mount
 
-app = Starlette(
+application = Starlette(
     routes=(
         Mount("/", django_asgi()),  # redirect all requests to Django
     ),
@@ -100,7 +100,7 @@ It creates a `static/` directory in the root of your project, so you can serve i
 
 from starlette.staticfiles import StaticFiles
 
-app = Starlette(
+application = Starlette(
     routes=(
         # /static is your STATIC_URL setting
         Mount("/static", StaticFiles(directory="static"), name="static"),
@@ -129,7 +129,7 @@ async def broker_lifespan(app):
     finally:
         await broker.close()
 
-app = Starlette(
+application = Starlette(
     ...,
     lifespan=broker_lifespan,
 )
@@ -162,7 +162,7 @@ app = Starlette(
         finally:
             await broker.close()
 
-    app = Starlette(
+    application = Starlette(
         routes=(
             Mount("/static", StaticFiles(directory="static"), name="static"),
             Mount("/", get_asgi_application()),
@@ -172,3 +172,52 @@ app = Starlette(
     ```
 
 This way we can easily integrate our **FastStream** application with the **Django**!
+
+# Accessing Django ORM from within FastStream consumer
+
+In order to access the **Django** ORM from within a FastStream consumer, you need to ensure that the Django settings are properly configured and that the Django application is initialized before accessing the ORM. Here is how to do it using `serve_faststream.py` as an entry point for your FastStream consumer application.
+
+```
+project-root/  
+├── manage.py  
+├── serve_faststream.py  
+```
+```Python
+# serve_faststream.py 
+# ruff: noqa: E402
+###############################################################################
+import os
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+django.setup()
+# These lines are necessary to set up Django, call them at before any Django Related imports.
+###############################################################################
+from django.contrib.auth.models import User  # This line must be after django.setup()
+
+from faststream import FastStream
+from faststream.rabbit import RabbitBroker
+
+
+broker = RabbitBroker("amqp://guest:guest@localhost:5672")
+
+@broker.subscriber("demo")
+async def faststream_django_orm_demo_handler(message: str):
+    """
+    This demonstrates how to access Django ORM from within a FastStream consumer.
+    """
+    qs = User.objects.all()
+    async for user in qs:  # async django ORM is accessible
+        print(user)
+    print(message)
+
+app = FastStream(broker)
+```
+
+Start consumer with
+```bash
+faststream run serve_faststream:app
+```
+
+It is advisable to use FastSteam's router to keep `serve_faststream.py` clean, and ensure `django.setup()` is always called first. See [FastStream Router](https://faststream.airt.ai/latest/getting-started/routers/) for more information.


### PR DESCRIPTION
# Description
- fix: typo in Django guide
- add: instructions on how to access django ORM in consumer


Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
