### PR TITLE
feat: add batch publish support for redis stream

### DIFF
--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -1069,6 +1069,7 @@ search:
                         - [AsyncAPIListBatchPublisher](api/faststream/redis/publisher/asyncapi/AsyncAPIListBatchPublisher.md)
                         - [AsyncAPIListPublisher](api/faststream/redis/publisher/asyncapi/AsyncAPIListPublisher.md)
                         - [AsyncAPIPublisher](api/faststream/redis/publisher/asyncapi/AsyncAPIPublisher.md)
+                        - [AsyncAPIStreamBatchPublisher](api/faststream/redis/publisher/asyncapi/AsyncAPIStreamBatchPublisher.md)
                         - [AsyncAPIStreamPublisher](api/faststream/redis/publisher/asyncapi/AsyncAPIStreamPublisher.md)
                     - producer
                         - [RedisFastProducer](api/faststream/redis/publisher/producer/RedisFastProducer.md)
@@ -1077,6 +1078,7 @@ search:
                         - [ListBatchPublisher](api/faststream/redis/publisher/usecase/ListBatchPublisher.md)
                         - [ListPublisher](api/faststream/redis/publisher/usecase/ListPublisher.md)
                         - [LogicPublisher](api/faststream/redis/publisher/usecase/LogicPublisher.md)
+                        - [StreamBatchPublisher](api/faststream/redis/publisher/usecase/StreamBatchPublisher.md)
                         - [StreamPublisher](api/faststream/redis/publisher/usecase/StreamPublisher.md)
                 - response
                     - [RedisResponse](api/faststream/redis/response/RedisResponse.md)

--- a/docs/docs/en/api/faststream/redis/publisher/asyncapi/AsyncAPIStreamBatchPublisher.md
+++ b/docs/docs/en/api/faststream/redis/publisher/asyncapi/AsyncAPIStreamBatchPublisher.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.redis.publisher.asyncapi.AsyncAPIStreamBatchPublisher

--- a/docs/docs/en/api/faststream/redis/publisher/usecase/StreamBatchPublisher.md
+++ b/docs/docs/en/api/faststream/redis/publisher/usecase/StreamBatchPublisher.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.redis.publisher.usecase.StreamBatchPublisher


### PR DESCRIPTION
## Description

The `batch=True` option in the stream configuration now also applies to **publisher**, enabling it to publish multiple messages to the stream in a single `publish()` call.

This improves performance and efficiency, especially in high-throughput scenarios.

closes #2195 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications