### PR TITLE
feat: added option to read from pending messages list in redis streams with group mode

### DIFF
--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,6 +12,25 @@ hide:
 ---
 
 # Release Notes
+## 0.5.40
+
+### What's Changed
+* fix: repair AsyncAPI render by [@Sehat1137](https://github.com/Sehat1137){.external-link target="_blank"} in [#2175](https://github.com/ag2ai/faststream/pull/2175){.external-link target="_blank"}
+* fix: prevent redis stream subscriber timeout when polling_interval exceeds 3000ms by [@caozheliang](https://github.com/caozheliang){.external-link target="_blank"} in [#2200](https://github.com/ag2ai/faststream/pull/2200){.external-link target="_blank"}
+* feat: auto flush confluent broker by [@mdaffad](https://github.com/mdaffad){.external-link target="_blank"} in [#2182](https://github.com/ag2ai/faststream/pull/2182){.external-link target="_blank"}
+* feat (#2169): Error on faststream.Context instead of faststream.[broker].fastapi.Context by [@NelsonNotes](https://github.com/NelsonNotes){.external-link target="_blank"} in [#2181](https://github.com/ag2ai/faststream/pull/2181){.external-link target="_blank"}
+* docs: add information about manual AsyncAPI hosting by [@Sehat1137](https://github.com/Sehat1137){.external-link target="_blank"} in [#2177](https://github.com/ag2ai/faststream/pull/2177){.external-link target="_blank"}
+* docs: update Django integration guide and add FastStream ORM access e… by [@Lodimup](https://github.com/Lodimup){.external-link target="_blank"} in [#2187](https://github.com/ag2ai/faststream/pull/2187){.external-link target="_blank"}
+* docs: add  Django management command integration by [@Lodimup](https://github.com/Lodimup){.external-link target="_blank"} in [#2190](https://github.com/ag2ai/faststream/pull/2190){.external-link target="_blank"}
+* chore: bump redis to 6.0.0 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2201](https://github.com/ag2ai/faststream/pull/2201){.external-link target="_blank"}
+* chore: deprecate connect options by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2202](https://github.com/ag2ai/faststream/pull/2202){.external-link target="_blank"}
+
+### New Contributors
+* [@Lodimup](https://github.com/Lodimup){.external-link target="_blank"} made their first contribution in [#2187](https://github.com/ag2ai/faststream/pull/2187){.external-link target="_blank"}
+* [@caozheliang](https://github.com/caozheliang){.external-link target="_blank"} made their first contribution in [#2200](https://github.com/ag2ai/faststream/pull/2200){.external-link target="_blank"}
+
+**Full Changelog**: [#0.5.39...0.5.40](https://github.com/ag2ai/faststream/compare/0.5.39...0.5.40){.external-link target="_blank"}
+
 ## 0.5.39
 
 ### What's Changed

--- a/faststream/redis/schemas/stream_sub.py
+++ b/faststream/redis/schemas/stream_sub.py
@@ -12,6 +12,7 @@ class StreamSub(NameRequired):
         "batch",
         "consumer",
         "group",
+        "last_history_id",
         "last_id",
         "max_records",
         "maxlen",
@@ -29,6 +30,7 @@ class StreamSub(NameRequired):
         batch: bool = False,
         no_ack: bool = False,
         last_id: Optional[str] = None,
+        last_history_id: Optional[str] = None,
         maxlen: Optional[int] = None,
         max_records: Optional[int] = None,
     ) -> None:
@@ -45,6 +47,9 @@ class StreamSub(NameRequired):
         if last_id is None:
             last_id = "$"
 
+        if last_history_id is None:
+            last_history_id = ">"
+
         super().__init__(stream)
 
         self.group = group
@@ -53,6 +58,7 @@ class StreamSub(NameRequired):
         self.batch = batch
         self.no_ack = no_ack
         self.last_id = last_id
+        self.last_history_id = last_history_id
         self.maxlen = maxlen
         self.max_records = max_records
 

--- a/faststream/redis/subscriber/usecase.py
+++ b/faststream/redis/subscriber/usecase.py
@@ -666,7 +666,7 @@ class _StreamHandlerMixin(LogicSubscriber):
                 return client.xreadgroup(
                     groupname=stream.group,
                     consumername=stream.consumer,
-                    streams={stream.name: ">"},
+                    streams={stream.name: stream.last_history_id},
                     count=stream.max_records,
                     block=stream.polling_interval,
                     noack=stream.no_ack,

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -682,3 +682,42 @@ class TestConsumeStream:
 
             mock(await subscriber.get_one(timeout=1e-24))
             mock.assert_called_once_with(None)
+
+    async def test_get_message_from_pending_messages_list(
+        self,
+        queue: str,
+        event: asyncio.Event,
+        mock: MagicMock,
+    ):
+        consume_broker = self.get_broker(apply_types=True)
+        history_consume_broker = self.get_broker(apply_types=True)
+
+        @consume_broker.subscriber(
+            stream=StreamSub(queue, group="group", consumer=queue), no_ack=True
+        )
+        async def handler_no_ack(msg): ...
+
+        @history_consume_broker.subscriber(
+            stream=StreamSub(queue, group="group", consumer=queue, last_history_id="0")
+        )
+        async def handler_history(msg):
+            mock(msg)
+            event.set()
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+
+            await asyncio.wait(
+                (asyncio.create_task(br.publish("hello", stream=queue)),),
+                timeout=3,
+            )
+
+        async with self.patch_broker(history_consume_broker) as br:
+            await br.start()
+
+            await asyncio.wait(
+                (asyncio.create_task(event.wait()),),
+                timeout=3,
+            )
+
+        mock.assert_called_once_with("hello")


### PR DESCRIPTION
# Description

Added functional to provide option to change first reading message from Redis Streams in group mode.
Added  

Fixes #2197

## Type of change

Please delete options that are not relevant.

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (scripts/lint.sh shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running scripts/test-cov.sh (tested all, without kafka, rabbit, nats)
- [x] I have ensured that static analysis tests are passing by running scripts/static-analysis.sh
- [ ] I have included code examples to illustrate the modifications
