### PR TITLE
fix(redis): prevent memory leak by deleting acknowledged stream messages, added test coverage for message deletion behaviour

### DIFF
--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,6 +12,23 @@ hide:
 ---
 
 # Release Notes
+## 0.5.42
+
+### What's Changed
+
+* Feature: add deprecate on retry arg by [@Flosckow](https://github.com/Flosckow){.external-link target="_blank"} in [#2224](https://github.com/ag2ai/faststream/pull/2224){.external-link target="_blank"}
+* Fix default rabbit timestamp by [@dmder](https://github.com/dmder){.external-link target="_blank"} in [#2226](https://github.com/ag2ai/faststream/pull/2226){.external-link target="_blank"}
+* Fix ASGIMultiprocess args mismatch by [@dolfinus](https://github.com/dolfinus){.external-link target="_blank"} in [#2228](https://github.com/ag2ai/faststream/pull/2228){.external-link target="_blank"}
+* Add docs about cli --log-file by [@RenameMe1](https://github.com/RenameMe1){.external-link target="_blank"} in [#2229](https://github.com/ag2ai/faststream/pull/2229){.external-link target="_blank"}
+* fix (#2227): use ms as generated timestamp in Kafka by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2230](https://github.com/ag2ai/faststream/pull/2230){.external-link target="_blank"}
+* feat: Add AsyncAPI HTTP Support by [@tmulligan98](https://github.com/tmulligan98){.external-link target="_blank"} in [#2142](https://github.com/ag2ai/faststream/pull/2142){.external-link target="_blank"}
+
+### New Contributors
+* [@dmder](https://github.com/dmder){.external-link target="_blank"} made their first contribution in [#2226](https://github.com/ag2ai/faststream/pull/2226){.external-link target="_blank"}
+* [@tmulligan98](https://github.com/tmulligan98){.external-link target="_blank"} made their first contribution in [#2142](https://github.com/ag2ai/faststream/pull/2142){.external-link target="_blank"}
+
+**Full Changelog**: [#0.5.41...0.5.42](https://github.com/ag2ai/faststream/compare/0.5.41...0.5.42){.external-link target="_blank"}
+
 ## 0.5.41
 
 ### What's Changed

--- a/faststream/redis/message.py
+++ b/faststream/redis/message.py
@@ -128,6 +128,7 @@ class _RedisStreamMessageMixin(BrokerStreamMessage[_StreamMsgType]):
             ids = self.raw_message["message_ids"]
             channel = self.raw_message["channel"]
             await redis.xack(channel, group, *ids)  # type: ignore[no-untyped-call]
+            await redis.xdel(channel, *ids)  # type: ignore[no-untyped-call]
         await super().ack()
 
     @override

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -692,7 +692,7 @@ class TestConsumeStream:
             await asyncio.sleep(0.1)
 
             final_length = await br._connection.xlen(queue)
-            
+
             assert final_length == 0, f"Expected stream to be empty, but found {final_length} messages"
 
         assert event.is_set()

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -693,7 +693,9 @@ class TestConsumeStream:
 
             final_length = await br._connection.xlen(queue)
 
-            assert final_length == 0, f"Expected stream to be empty, but found {final_length} messages"
+            assert final_length == 0, (
+                f"Expected stream to be empty, but found {final_length} messages"
+            )
 
         assert event.is_set()
 


### PR DESCRIPTION

# Description

This PR implements automatic deletion of Redis Stream messages after acknowledgment to prevent memory accumulation in long-running FastStream applications.

**Problem**: Redis Stream messages were only being acknowledged (XACK) but never deleted from the stream, causing Redis memory to grow indefinitely as processed messages accumulated.

**Solution**: Added `XDEL` call immediately after `XACK` in the `_RedisStreamMessageMixin.ack()` method to automatically remove messages from the stream after successful processing.

**Impact**: This changes Redis Streams behavior from persistent event log to message queue semantics, preventing memory leaks while maintaining backward compatibility for typical use cases.

Fixes #2223

## Type of change

Please delete options that are not relevant.

- [x ] New feature (a non-breaking change that adds functionality)

## Checklist

- [ x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x ] My changes do not generate any new warnings
- [ x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
