### PR TITLE
Fix/deprecate log fmt

### DIFF
--- a/docs/docs/en/getting-started/observability/logging.md
+++ b/docs/docs/en/getting-started/observability/logging.md
@@ -160,15 +160,6 @@ Faststream supported few file formats to logging configure. See examples below:
         handlers: ["app"]
     ```
 
-## Formatting Logs
-
-If you are not satisfied with the current format of your application logs, you can change it directly in your broker's constructor.
-
-```python
-from faststream.rabbit import RabbitBroker
-broker = RabbitBroker(log_fmt="%(asctime)s %(levelname)s - %(message)s")
-```
-
 ## Using Your Own Loggers
 
 Since **FastStream** works with the standard `logging.Logger` object, you can initiate an application and a broker

--- a/faststream/broker/core/logging.py
+++ b/faststream/broker/core/logging.py
@@ -1,7 +1,7 @@
 import logging
+import warnings
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Optional
-import warnings
 
 from typing_extensions import Annotated, Doc, deprecated
 

--- a/faststream/broker/core/logging.py
+++ b/faststream/broker/core/logging.py
@@ -1,8 +1,9 @@
 import logging
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Optional
+import warnings
 
-from typing_extensions import Annotated, Doc
+from typing_extensions import Annotated, Doc, deprecated
 
 from faststream.broker.core.abc import ABCBroker
 from faststream.broker.types import MsgType
@@ -43,8 +44,12 @@ class LoggingBroker(ABCBroker[MsgType]):
         ],
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ],
+        ] = EMPTY,
         **kwargs: Any,
     ) -> None:
         if logger is not EMPTY:
@@ -55,6 +60,15 @@ class LoggingBroker(ABCBroker[MsgType]):
             self.use_custom = False
 
         self._msg_log_level = log_level
+
+        if log_fmt is not EMPTY:
+            warnings.warn(
+                DeprecationWarning(
+                    "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                    "Pass a pre-configured `logger` instead."
+                ),
+                stacklevel=2,
+            )
         self._fmt = log_fmt
 
         super().__init__(*args, **kwargs)

--- a/faststream/broker/core/usecase.py
+++ b/faststream/broker/core/usecase.py
@@ -16,7 +16,7 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Annotated, Doc, Self
+from typing_extensions import Annotated, Doc, Self, deprecated
 
 from faststream._compat import is_test_env
 from faststream.broker.core.logging import LoggingBroker
@@ -33,6 +33,7 @@ from faststream.broker.types import (
 )
 from faststream.exceptions import NOT_CONNECTED_YET
 from faststream.log.logging import set_logger_fmt
+from faststream.types import EMPTY
 from faststream.utils.context.repository import context
 from faststream.utils.functions import return_input, to_async
 
@@ -99,8 +100,12 @@ class BrokerUsecase(
         ],
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ],
+        ] = EMPTY,
         # FastDepends args
         apply_types: Annotated[
             bool,

--- a/faststream/confluent/broker/broker.py
+++ b/faststream/confluent/broker/broker.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 import anyio
-from typing_extensions import Annotated, Doc, override
+from typing_extensions import Annotated, Doc, deprecated, override
 
 from faststream.__about__ import SERVICE_NAME
 from faststream.broker.message import gen_cor_id
@@ -313,8 +313,12 @@ class KafkaBroker(  # type: ignore[misc]
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # FastDepends args
         apply_types: Annotated[
             bool,

--- a/faststream/confluent/broker/logging.py
+++ b/faststream/confluent/broker/logging.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Tuple, Union
 
+from typing_extensions import Annotated, deprecated
+
 from faststream.broker.core.usecase import BrokerUsecase
 from faststream.confluent.client import AsyncConfluentConsumer
 from faststream.log.logging import get_broker_logger
@@ -29,7 +31,13 @@ class KafkaLoggingBroker(
         *args: Any,
         logger: Optional["LoggerProto"] = EMPTY,
         log_level: int = logging.INFO,
-        log_fmt: Optional[str] = None,
+        log_fmt: Annotated[
+            Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
+        ] = EMPTY,
         **kwargs: Any,
     ) -> None:
         """Initialize the class."""

--- a/faststream/confluent/fastapi/fastapi.py
+++ b/faststream/confluent/fastapi/fastapi.py
@@ -314,8 +314,12 @@ class KafkaRouter(StreamRouter[Union[Message, Tuple[Message, ...]]]):
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # StreamRouter options
         setup_state: Annotated[
             bool,

--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -23,7 +23,7 @@ import aiokafka.admin
 import anyio
 from aiokafka.partitioner import DefaultPartitioner
 from aiokafka.producer.producer import _missing
-from typing_extensions import Annotated, Doc, override
+from typing_extensions import Annotated, Doc, deprecated, override
 
 from faststream.__about__ import SERVICE_NAME
 from faststream.broker.message import gen_cor_id
@@ -495,8 +495,12 @@ class KafkaBroker(
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # FastDepends args
         apply_types: Annotated[
             bool,

--- a/faststream/kafka/broker/logging.py
+++ b/faststream/kafka/broker/logging.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, Tuple, Union
 
+from typing_extensions import Annotated, deprecated
+
 from faststream.broker.core.usecase import BrokerUsecase
 from faststream.log.logging import get_broker_logger
 from faststream.types import EMPTY
@@ -28,7 +30,13 @@ class KafkaLoggingBroker(
         *args: Any,
         logger: Optional["LoggerProto"] = EMPTY,
         log_level: int = logging.INFO,
-        log_fmt: Optional[str] = None,
+        log_fmt: Annotated[
+            Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
+        ] = EMPTY,
         **kwargs: Any,
     ) -> None:
         """Initialize the class."""

--- a/faststream/kafka/fastapi/fastapi.py
+++ b/faststream/kafka/fastapi/fastapi.py
@@ -323,8 +323,12 @@ class KafkaRouter(StreamRouter[Union[ConsumerRecord, Tuple[ConsumerRecord, ...]]
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # StreamRouter options
         setup_state: Annotated[
             bool,

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -436,8 +436,12 @@ class NatsBroker(
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # FastDepends args
         apply_types: Annotated[
             bool,

--- a/faststream/nats/broker/logging.py
+++ b/faststream/nats/broker/logging.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from nats.aio.client import Client
 from nats.aio.msg import Msg
+from typing_extensions import Annotated, deprecated
 
 from faststream.broker.core.usecase import BrokerUsecase
 from faststream.log.logging import get_broker_logger
@@ -24,7 +25,13 @@ class NatsLoggingBroker(BrokerUsecase[Msg, Client]):
         *args: Any,
         logger: Optional["LoggerProto"] = EMPTY,
         log_level: int = logging.INFO,
-        log_fmt: Optional[str] = None,
+        log_fmt: Annotated[
+            Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
+        ] = EMPTY,
         **kwargs: Any,
     ) -> None:
         """Initialize the NATS logging mixin."""

--- a/faststream/nats/fastapi/fastapi.py
+++ b/faststream/nats/fastapi/fastapi.py
@@ -278,8 +278,12 @@ class NatsRouter(StreamRouter["Msg"]):
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # StreamRouter options
         setup_state: Annotated[
             bool,

--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -135,7 +135,13 @@ class RabbitBroker(
         tags: Optional[Iterable[Union["asyncapi.Tag", "asyncapi.TagDict"]]] = None,
         logger: Optional["LoggerProto"] = EMPTY,
         log_level: int = logging.INFO,
-        log_fmt: Optional[str] = None,
+        log_fmt: Annotated[
+            Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
+        ] = EMPTY,
         apply_types: bool = True,
         validate: bool = True,
         _get_dependant: Optional[Callable[..., Any]] = None,

--- a/faststream/rabbit/broker/logging.py
+++ b/faststream/rabbit/broker/logging.py
@@ -2,6 +2,7 @@ import logging
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 from aio_pika import IncomingMessage, RobustConnection
+from typing_extensions import Annotated, deprecated
 
 from faststream.broker.core.usecase import BrokerUsecase
 from faststream.log.logging import get_broker_logger
@@ -23,7 +24,13 @@ class RabbitLoggingBroker(BrokerUsecase[IncomingMessage, RobustConnection]):
         *args: Any,
         logger: Optional["LoggerProto"] = EMPTY,
         log_level: int = logging.INFO,
-        log_fmt: Optional[str] = None,
+        log_fmt: Annotated[
+            Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
+        ] = EMPTY,
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/faststream/rabbit/fastapi/router.py
+++ b/faststream/rabbit/fastapi/router.py
@@ -195,8 +195,12 @@ class RabbitRouter(StreamRouter["IncomingMessage"]):
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # StreamRouter options
         setup_state: Annotated[
             bool,

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -177,8 +177,12 @@ class RedisBroker(
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # FastDepends args
         apply_types: Annotated[
             bool,

--- a/faststream/redis/broker/logging.py
+++ b/faststream/redis/broker/logging.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
+from typing_extensions import Annotated, deprecated
+
 from faststream.broker.core.usecase import BrokerUsecase
 from faststream.log.logging import get_broker_logger
 from faststream.redis.message import UnifyRedisDict
@@ -23,7 +25,13 @@ class RedisLoggingBroker(BrokerUsecase[UnifyRedisDict, "Redis[bytes]"]):
         *args: Any,
         logger: Optional["LoggerProto"] = EMPTY,
         log_level: int = logging.INFO,
-        log_fmt: Optional[str] = None,
+        log_fmt: Annotated[
+            Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
+        ] = EMPTY,
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/faststream/redis/fastapi/fastapi.py
+++ b/faststream/redis/fastapi/fastapi.py
@@ -144,8 +144,12 @@ class RedisRouter(StreamRouter[UnifyRedisDict]):
         ] = logging.INFO,
         log_fmt: Annotated[
             Optional[str],
+            deprecated(
+                "Argument `log_fmt` is deprecated since 0.5.42 and will be removed in 0.6.0. "
+                "Pass a pre-configured `logger` instead."
+            ),
             Doc("Default logger log format."),
-        ] = None,
+        ] = EMPTY,
         # StreamRouter options
         setup_state: Annotated[
             bool,


### PR DESCRIPTION
# Description

Deprecated `log_fmt` parameter in `broker()` in favor of pre-configured `logger`. 
All related documentation, examples and tests have been updated. 
The parameter will be completely removed in 0.6.0 release.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] Breaking change (a fix or feature that would disrupt existing functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
