### PR TITLE
docs: alwayse use `'` in dependency groupds

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ That's **FastStream** in a nutshell—easy, efficient, and powerful. Whether you
 You can install it with `pip` as usual:
 
 ```sh
-pip install faststream[kafka]
+pip install 'faststream[kafka]'
 # or
-pip install faststream[rabbit]
+pip install 'faststream[rabbit]'
 # or
-pip install faststream[nats]
+pip install 'faststream[nats]'
 # or
-pip install faststream[redis]
+pip install 'faststream[redis]'
 ```
 
 By default **FastStream** uses **PydanticV2** written in **Rust**, but you can downgrade it manually, if your platform has no **Rust** support - **FastStream** will work correctly with **PydanticV1** as well.

--- a/docs/docs/en/faststream.md
+++ b/docs/docs/en/faststream.md
@@ -116,27 +116,27 @@ You can install it with `pip` as usual:
 
 === "AIOKafka"
     ```sh
-    pip install faststream[kafka]
+    pip install 'faststream[kafka]'
     ```
 
 === "Confluent"
     ```sh
-    pip install faststream[confluent]
+    pip install 'faststream[confluent]'
     ```
 
 === "RabbitMQ"
     ```sh
-    pip install faststream[rabbit]
+    pip install 'faststream[rabbit]'
     ```
 
 === "NATS"
     ```sh
-    pip install faststream[nats]
+    pip install 'faststream[nats]'
     ```
 
 === "Redis"
     ```sh
-    pip install faststream[redis]
+    pip install 'faststream[redis]'
     ```
 
 

--- a/docs/docs/en/getting-started/cli/index.md
+++ b/docs/docs/en/getting-started/cli/index.md
@@ -20,7 +20,7 @@ search:
 To install the **FastStream CLI**, you need to run the following command:
 
 ```shell
-pip install faststream[cli]
+pip install 'faststream[cli]'
 ```
 
 After installation, you can check which commands are available by executing:

--- a/docs/docs/en/getting-started/observability/healthcheks.md
+++ b/docs/docs/en/getting-started/observability/healthcheks.md
@@ -127,7 +127,7 @@ FROM python:3.12-slim
 RUN apt-get update && apt-get install -y curl
 
 WORKDIR /app
-RUN pip install faststream[rabbit] uvicorn redis asyncpg
+RUN pip install 'faststream[rabbit]' uvicorn redis asyncpg
 COPY main.py /app
 ```
 

--- a/docs/docs/en/getting-started/observability/opentelemetry/tracing.md
+++ b/docs/docs/en/getting-started/observability/opentelemetry/tracing.md
@@ -48,7 +48,7 @@ To enable tracing your broker:
 1. Install `FastStream` with the `opentelemetry-sdk`:
 
     ```shell
-    pip install faststream[otel]
+    pip install 'faststream[otel]'
     ```
 
 2. Configure `TracerProvider`:

--- a/docs/docs/en/getting-started/observability/prometheus.md
+++ b/docs/docs/en/getting-started/observability/prometheus.md
@@ -23,7 +23,7 @@ To add a metrics to your broker, you need to:
 1. Install `FastStream` with `prometheus-client`
 
     ```shell
-    pip install faststream[prometheus]
+    pip install 'faststream[prometheus]'
     ```
 
 2. Add `PrometheusMiddleware` to your broker

--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -331,7 +331,7 @@ Special thanks to @roma-frolov and @draincoder (again) for it!
 To collect **Prometheus** metrics for your **FastStream** application you just need to install special distribution
 
 ```cmd
-pip install faststream[prometheus]
+pip install 'faststream[prometheus]'
 ```
 
 And use **PrometheusMiddleware**. Also, it could be helpful to use our [**ASGI**](https://faststream.airt.ai/latest/getting-started/asgi/) to serve metrics endpoint in the same app.
@@ -449,7 +449,7 @@ Also, current release has little bugfixes related to **CLI** and **AsyncAPI** sc
 
 We made last release just a few days ago, but there are some big changes here already!
 
-1. First of all - you can't use `faststream run ...` command without `pip install faststream[cli]` distribution anymore. It was made to minify default (and production) distribution by removing **typer** (**rich** and **click**) dependencies. **CLI** is a development-time feature, so if you don't need - just don't install! Special thanks to @RubenRibGarcia for this change
+1. First of all - you can't use `faststream run ...` command without `pip install 'faststream[cli]'` distribution anymore. It was made to minify default (and production) distribution by removing **typer** (**rich** and **click**) dependencies. **CLI** is a development-time feature, so if you don't need - just don't install! Special thanks to @RubenRibGarcia for this change
 
 2. The next big change - **Kafka** publish confirmations by default! Previous **FastStream** version was working in *publish & forgot* style, but the new one blocks your `broker.publish(...)` call until **Kafka** confirmation frame received. To fallback to previous logic just use a new flag `broker.publish(..., no_confirm=True)`
 
@@ -950,7 +950,7 @@ Finally, FastStream supports [OpenTelemetry](https://opentelemetry.io/) in a nat
 First of all you need to install required dependencies to support OpenTelemetry:
 
 ```bash
-pip install faststream[otel]
+pip install 'faststream[otel]'
 ```
 
 Then you can just add a middleware for your broker and that's it!

--- a/faststream/exceptions.py
+++ b/faststream/exceptions.py
@@ -137,25 +137,26 @@ pip install watchfiles
 
 INSTALL_FASTSTREAM_RABBIT = """
 To use RabbitMQ with FastStream, please install dependencies:\n
-pip install faststream[rabbit]
+pip install 'faststream[rabbit]'
 """
 
 INSTALL_FASTSTREAM_KAFKA = """
 To use Apache Kafka with FastStream, please install dependencies:\n
-pip install faststream[kafka]
+pip install 'faststream[kafka]'
 """
 
 INSTALL_FASTSTREAM_CONFLUENT = """
 To use Confluent Kafka with FastStream, please install dependencies:\n
-pip install faststream[confluent]"""
+pip install 'faststream[confluent]'
+"""
 
 
 INSTALL_FASTSTREAM_REDIS = """
 To use Redis with FastStream, please install dependencies:\n
-pip install faststream[redis]
+pip install 'faststream[redis]'
 """
 
 INSTALL_FASTSTREAM_NATS = """
 To use NATS with FastStream, please install dependencies:\n
-pip install faststream[nats]
+pip install 'faststream[nats]'
 """


### PR DESCRIPTION
Without `'` you can have problems in many shells, see:

```sh
» pip install faststream[redis]
zsh: no matches found: faststream[redis]  # zsh
```