### PR TITLE
docs: Simplify `JSON Basic Serialization` section

### DIFF
--- a/docs/docs/en/getting-started/subscription/annotation.md
+++ b/docs/docs/en/getting-started/subscription/annotation.md
@@ -65,31 +65,9 @@ But it doesn't looks like a correct message validation, does it?
 
 For this reason, **FastStream** supports per-argument message serialization: you can declare multiple arguments with various types and your message will unpack to them:
 
-=== "AIOKafka"
-    ```python hl_lines="3-4"
-    {!> docs_src/getting_started/subscription/kafka/annotation.py [ln:8-14] !}
-    ```
-
-=== "Confluent"
-    ```python hl_lines="3-4"
-    {!> docs_src/getting_started/subscription/confluent/annotation.py [ln:8-14] !}
-    ```
-
-=== "RabbitMQ"
-    ```python hl_lines="3-4"
-    {!> docs_src/getting_started/subscription/rabbit/annotation.py [ln:8-14] !}
-    ```
-
-=== "NATS"
-    ```python hl_lines="3-4"
-    {!> docs_src/getting_started/subscription/nats/annotation.py [ln:8-14] !}
-    ```
-
-=== "Redis"
-    ```python hl_lines="3-4"
-    {!> docs_src/getting_started/subscription/redis/annotation.py [ln:8-14] !}
-    ```
-
+```python hl_lines="3-4"
+{!> docs_src/getting_started/subscription/kafka/annotation.py [ln:8-14] !}
+```
 
 !!! tip
     By default **FastStream** uses `json.loads` to decode and `json.dumps` to encode your messages. But if you prefer [**orjson**](https://github.com/ijl/orjson){.external-link target="_blank"}, just install it and framework will use it automatically.


### PR DESCRIPTION
It used to have 5 identical tabs:
<img width="706" alt="Снимок экрана 2025-06-01 в 17 20 26" src="https://github.com/user-attachments/assets/8d4d2dba-893a-4fad-944a-bf94eca26b14" />

Only channel names were different, but it is not important.