### PR TITLE
Import types from correct place

### DIFF
--- a/docs/docs/en/getting-started/serialization/decoder.md
+++ b/docs/docs/en/getting-started/serialization/decoder.md
@@ -66,7 +66,7 @@ Alternatively, you can reuse the original decoder function with the following si
 
 === "AIOKafka"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.types import DecodedMessage
     from faststream.kafka import KafkaMessage
 
@@ -79,7 +79,7 @@ Alternatively, you can reuse the original decoder function with the following si
 
 === "Confluent"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.types import DecodedMessage
     from faststream.confluent import KafkaMessage
 
@@ -92,7 +92,7 @@ Alternatively, you can reuse the original decoder function with the following si
 
 === "RabbitMQ"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.types import DecodedMessage
     from faststream.rabbit import RabbitMessage
 
@@ -105,7 +105,7 @@ Alternatively, you can reuse the original decoder function with the following si
 
 === "NATS"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.types import DecodedMessage
     from faststream.nats import NatsMessage
 
@@ -118,7 +118,7 @@ Alternatively, you can reuse the original decoder function with the following si
 
 === "Redis"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.types import DecodedMessage
     from faststream.redis import RedisMessage
 

--- a/docs/docs/en/getting-started/serialization/parser.md
+++ b/docs/docs/en/getting-started/serialization/parser.md
@@ -69,7 +69,7 @@ Alternatively, you can reuse the original parser function with the following sig
 
 === "AIOKafka"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.kafka import ConsumerRecord, KafkaMessage
 
     async def parser(
@@ -82,7 +82,7 @@ Alternatively, you can reuse the original parser function with the following sig
 === "Confluent"
     ```python
     from confluent_kafka import Message
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.confluent import KafkaMessage
 
     async def parser(
@@ -94,7 +94,7 @@ Alternatively, you can reuse the original parser function with the following sig
 
 === "RabbitMQ"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from aio_pika import IncomingMessage
     from faststream.rabbit import RabbitMessage
 
@@ -107,7 +107,7 @@ Alternatively, you can reuse the original parser function with the following sig
 
 === "NATS"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from nats.aio.msg import Msg
     from faststream.nats import NatsMessage
 
@@ -120,7 +120,7 @@ Alternatively, you can reuse the original parser function with the following sig
 
 === "Redis"
     ```python
-    from types import Callable, Awaitable
+    from typing import Callable, Awaitable
     from faststream.redis import RedisMessage
     from faststream.redis.message import PubSubMessage
 


### PR DESCRIPTION
- `types` never had these annotations
- `collections.abc` is the proper place, but 3.8 does not have subscriptable generics there yet
- `typing` is the reasonable choice, but later it should be changed to `collections.abc`