### PR TITLE
feat: added delete method to redis message

### DIFF
--- a/faststream/redis/annotations.py
+++ b/faststream/redis/annotations.py
@@ -7,6 +7,7 @@ from typing_extensions import Annotated
 from faststream import Depends
 from faststream.annotations import ContextRepo, Logger, NoCast
 from faststream.redis.broker.broker import RedisBroker as RB
+from faststream.redis.message import RedisStreamMessage as RSM
 from faststream.redis.message import UnifyRedisMessage
 from faststream.utils.context import Context
 
@@ -29,6 +30,7 @@ __all__ = (
 )
 
 RedisMessage = Annotated[UnifyRedisMessage, Context("message")]
+RedisStreamMessage = Annotated[RSM, Context("message")]
 RedisBroker = Annotated[RB, Context("broker")]
 Redis = Annotated[RedisClient, Context("broker._connection")]
 

--- a/faststream/redis/message.py
+++ b/faststream/redis/message.py
@@ -146,6 +146,12 @@ class _RedisStreamMessageMixin(BrokerStreamMessage[_StreamMsgType]):
     ) -> None:
         await super().reject()
 
+    async def delete(self, redis: Optional["Redis[bytes]"]) -> None:
+        if redis is not None:
+            ids = self.raw_message["message_ids"]
+            channel = self.raw_message["channel"]
+            await redis.xdel(channel, *ids)
+
 
 class RedisStreamMessage(_RedisStreamMessageMixin[DefaultStreamMessage]):
     pass

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -6,6 +6,7 @@ import pytest
 from redis.asyncio import Redis
 
 from faststream.redis import ListSub, PubSub, RedisBroker, RedisMessage, StreamSub
+from faststream.redis.annotations import RedisStreamMessage
 from tests.brokers.base.consume import BrokerRealConsumeTestcase
 from tests.tools import spy_decorator
 
@@ -662,6 +663,68 @@ class TestConsumeStream:
 
                 m.mock.assert_called_once()
 
+        assert event.is_set()
+
+    async def test_consume_and_delete_acked(self, queue: str, event: asyncio.Event):
+        consume_broker = self.get_broker(apply_types=True)
+
+        @consume_broker.subscriber(
+            stream=StreamSub(queue, group="group", consumer=queue)
+        )
+        async def handler(msg: RedisStreamMessage):
+            event.set()
+            await msg.delete(consume_broker._connection)
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+
+            with patch.object(Redis, "xdel", spy_decorator(Redis.xdel)) as m:
+                await asyncio.wait(
+                    (
+                        asyncio.create_task(br.publish("hello", stream=queue)),
+                        asyncio.create_task(event.wait()),
+                    ),
+                    timeout=300,
+                )
+
+                m.mock.assert_called_once()
+
+            queue_len = await br._connection.xlen(queue)
+            assert queue_len == 0, (
+                f"Redis stream must be empty here, found {queue_len} messages"
+            )
+        assert event.is_set()
+
+    async def test_consume_and_delete_nacked(self, queue: str, event: asyncio.Event):
+        consume_broker = self.get_broker(apply_types=True)
+
+        @consume_broker.subscriber(
+            stream=StreamSub(queue, group="group", consumer=queue),
+            no_ack=True,
+        )
+        async def handler(msg: RedisStreamMessage):
+            event.set()
+            assert not msg.committed
+            await msg.delete(consume_broker._connection)
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+
+            with patch.object(Redis, "xdel", spy_decorator(Redis.xdel)) as m:
+                await asyncio.wait(
+                    (
+                        asyncio.create_task(br.publish("hello", stream=queue)),
+                        asyncio.create_task(event.wait()),
+                    ),
+                    timeout=300,
+                )
+
+                m.mock.assert_called_once()
+
+            queue_len = await br._connection.xlen(queue)
+            assert queue_len == 0, (
+                f"Redis stream must be empty here, found {queue_len} messages"
+            )
         assert event.is_set()
 
     async def test_get_one(


### PR DESCRIPTION
# Description

Added `delete` method to `_RedisStreamMessageMixin` to make it possible to delete the message from the stream after processing. And added new type alias RedisStreamMessage in annotations module to make it visible for language servers

Fixes #2223

## Type of change

Please delete options that are not relevant.

- [ ] New feature (a non-breaking change that adds functionality)


## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
