### PR TITLE
channels_async_routes

### DIFF
--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,6 +12,52 @@ hide:
 ---
 
 # Release Notes
+## 0.5.43
+
+### What's Changed
+
+* feat (#2291): add global_qos option to Channel by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2297](https://github.com/ag2ai/faststream/pull/2297){.external-link target="_blank"}
+* feat: added delete method to redis message by @ilya-4real in [#2294](https://github.com/ag2ai/faststream/pull/2294){.external-link target="_blank"}
+* feat: add CLI extra options by [@Sehat1137](https://github.com/Sehat1137){.external-link target="_blank"} in [#2231](https://github.com/ag2ai/faststream/pull/2231){.external-link target="_blank"}
+* feat: redis pipeline by [@Maclovi](https://github.com/Maclovi){.external-link target="_blank"} in [#2270](https://github.com/ag2ai/faststream/pull/2270){.external-link target="_blank"}
+* fix: replace passive with declare by [@Maclovi](https://github.com/Maclovi){.external-link target="_blank"} in [#2236](https://github.com/ag2ai/faststream/pull/2236){.external-link target="_blank"}
+* fix: deprecate log fmt by [@Maclovi](https://github.com/Maclovi){.external-link target="_blank"} in [#2240](https://github.com/ag2ai/faststream/pull/2240){.external-link target="_blank"}
+* fix (#2252): remove useless code snippet by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2256](https://github.com/ag2ai/faststream/pull/2256){.external-link target="_blank"}
+* fix (depends): removed SetupError if correct fastapi.Depends is included to annotation by [@NelsonNotes](https://github.com/NelsonNotes){.external-link target="_blank"} in [#2280](https://github.com/ag2ai/faststream/pull/2280){.external-link target="_blank"}
+* Improve license badge by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2241](https://github.com/ag2ai/faststream/pull/2241){.external-link target="_blank"}
+* chore: use stricter mypy settings by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2243](https://github.com/ag2ai/faststream/pull/2243){.external-link target="_blank"}
+* docs: alwayse use `'` in dependency groupds by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2242](https://github.com/ag2ai/faststream/pull/2242){.external-link target="_blank"}
+* docs: better highlight first example by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2245](https://github.com/ag2ai/faststream/pull/2245){.external-link target="_blank"}
+* docs: add more links to readme by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2246](https://github.com/ag2ai/faststream/pull/2246){.external-link target="_blank"}
+* docs: Improve README code examples by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2247](https://github.com/ag2ai/faststream/pull/2247){.external-link target="_blank"}
+* docs: reword `Multiple Subscriptions` section by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2250](https://github.com/ag2ai/faststream/pull/2250){.external-link target="_blank"}
+* docs: Improve README code examples by [@mxnoob](https://github.com/mxnoob){.external-link target="_blank"} in [#2253](https://github.com/ag2ai/faststream/pull/2253){.external-link target="_blank"}
+* docs: highlight more code by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2255](https://github.com/ag2ai/faststream/pull/2255){.external-link target="_blank"}
+* docs: Fix code style in `Context Fields Declaration` by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2269](https://github.com/ag2ai/faststream/pull/2269){.external-link target="_blank"}
+* docs: Improve `Context` docs by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2265](https://github.com/ag2ai/faststream/pull/2265){.external-link target="_blank"}
+* docs: Reword `publishing/decorator.md` by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2260](https://github.com/ag2ai/faststream/pull/2260){.external-link target="_blank"}
+* docs: Imporve dependencies docs by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2263](https://github.com/ag2ai/faststream/pull/2263){.external-link target="_blank"}
+* docs: Refactor `publishing/index.md` docs by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2259](https://github.com/ag2ai/faststream/pull/2259){.external-link target="_blank"}
+* docs: Improve wordings in test docs by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2258](https://github.com/ag2ai/faststream/pull/2258){.external-link target="_blank"}
+* docs: Link to test.md from initial tutorial by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2257](https://github.com/ag2ai/faststream/pull/2257){.external-link target="_blank"}
+* docs: Improve the documentation page with `Response` class  by [@anywindblows](https://github.com/anywindblows){.external-link target="_blank"} in [#2238](https://github.com/ag2ai/faststream/pull/2238){.external-link target="_blank"}
+* docs: fix broken links by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2271](https://github.com/ag2ai/faststream/pull/2271){.external-link target="_blank"}
+* docs: Fix `serialization/index.md` wording and syntax by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2277](https://github.com/ag2ai/faststream/pull/2277){.external-link target="_blank"}
+* docs: import types from correct place by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2278](https://github.com/ag2ai/faststream/pull/2278){.external-link target="_blank"}
+* docs: Improve serialization examples by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2282](https://github.com/ag2ai/faststream/pull/2282){.external-link target="_blank"}
+* docs: improve `Lifespan: Hooks` page by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2284](https://github.com/ag2ai/faststream/pull/2284){.external-link target="_blank"}
+* docs: -1/+1 fix mistake by [@Sehat1137](https://github.com/Sehat1137){.external-link target="_blank"} in [#2286](https://github.com/ag2ai/faststream/pull/2286){.external-link target="_blank"}
+* docs: doc fix by [@RenameMe1](https://github.com/RenameMe1){.external-link target="_blank"} in [#2288](https://github.com/ag2ai/faststream/pull/2288){.external-link target="_blank"}
+* docs: remove deprecated syntax from examples by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2234](https://github.com/ag2ai/faststream/pull/2234){.external-link target="_blank"}
+* docs: Improve grammar in `Lifespan: testing` by [@sobolevn](https://github.com/sobolevn){.external-link target="_blank"} in [#2298](https://github.com/ag2ai/faststream/pull/2298){.external-link target="_blank"}
+
+### New Contributors
+* [@mxnoob](https://github.com/mxnoob){.external-link target="_blank"} made their first contribution in [#2253](https://github.com/ag2ai/faststream/pull/2253){.external-link target="_blank"}
+* [@anywindblows](https://github.com/anywindblows){.external-link target="_blank"} made their first contribution in [#2238](https://github.com/ag2ai/faststream/pull/2238){.external-link target="_blank"}
+* @ilya-4real made their first contribution in [#2294](https://github.com/ag2ai/faststream/pull/2294){.external-link target="_blank"}
+
+**Full Changelog**: [#0.5.42...0.5.43](https://github.com/ag2ai/faststream/compare/0.5.42...0.5.43){.external-link target="_blank"}
+
 ## 0.5.42
 
 ### What's Changed

--- a/faststream/asgi/handlers.py
+++ b/faststream/asgi/handlers.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 from faststream.asyncapi.schema.utils import Tag
 
+
 class HttpHandler:
     def __init__(
         self,
@@ -91,7 +92,7 @@ def get(
 ) -> Union[Callable[["UserApp"], "ASGIApp"], "ASGIApp"]:
     def decorator(inner_func: "UserApp") -> "ASGIApp":
         return GetHandler(
-            inner_func, 
+            inner_func,
             include_in_schema=include_in_schema,
             description=description,
             tags=tags,

--- a/faststream/asgi/handlers.py
+++ b/faststream/asgi/handlers.py
@@ -5,6 +5,7 @@ from faststream.asgi.response import AsgiResponse
 if TYPE_CHECKING:
     from faststream.asgi.types import ASGIApp, Receive, Scope, Send, UserApp
 
+from faststream.asyncapi.schema.utils import Tag
 
 class HttpHandler:
     def __init__(
@@ -14,11 +15,15 @@ class HttpHandler:
         include_in_schema: bool = True,
         description: Optional[str] = None,
         methods: Optional[Sequence[str]] = None,
+        tags: list[Tag] = [],
+        unique_id: str | None = None,
     ):
         self.func = func
         self.methods = methods or ()
         self.include_in_schema = include_in_schema
         self.description = description or func.__doc__
+        self.tags: list[Tag] = tags
+        self.unique_id: str | None = unique_id
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
         if scope["method"] not in self.methods:
@@ -41,12 +46,16 @@ class GetHandler(HttpHandler):
         *,
         include_in_schema: bool = True,
         description: Optional[str] = None,
+        tags: list[Tag] = [],
+        unique_id: str | None = None,
     ):
         super().__init__(
             func,
             include_in_schema=include_in_schema,
             description=description,
             methods=("GET", "HEAD"),
+            tags=tags,
+            unique_id=unique_id,
         )
 
 
@@ -56,6 +65,8 @@ def get(
     *,
     include_in_schema: bool = True,
     description: Optional[str] = None,
+    tags: list[Tag] = [],
+    unique_id: str | None = None,
 ) -> "ASGIApp": ...
 
 
@@ -65,6 +76,8 @@ def get(
     *,
     include_in_schema: bool = True,
     description: Optional[str] = None,
+    tags: list[Tag] = [],
+    unique_id: str | None = None,
 ) -> Callable[["UserApp"], "ASGIApp"]: ...
 
 
@@ -73,10 +86,16 @@ def get(
     *,
     include_in_schema: bool = True,
     description: Optional[str] = None,
+    tags: list[Tag] = [],
+    unique_id: str | None = None,
 ) -> Union[Callable[["UserApp"], "ASGIApp"], "ASGIApp"]:
     def decorator(inner_func: "UserApp") -> "ASGIApp":
         return GetHandler(
-            inner_func, include_in_schema=include_in_schema, description=description
+            inner_func, 
+            include_in_schema=include_in_schema,
+            description=description,
+            tags=tags,
+            unique_id=unique_id,
         )
 
     if func is None:

--- a/faststream/asyncapi/generate.py
+++ b/faststream/asyncapi/generate.py
@@ -143,7 +143,7 @@ def get_broker_channels(
 
 def get_asgi_routes(
     app: "AsyncAPIApplication",
-    channels: Dict[str, Channel], 
+    channels: Dict[str, Channel],
 ) -> Dict[str, Channel]:
     """Get the ASGI routes for an application."""
     # We should import this here due
@@ -151,11 +151,10 @@ def get_asgi_routes(
     # so it looks like a circular import
     from faststream.asgi import AsgiFastStream
     from faststream.asgi.handlers import HttpHandler
-
+    from faststream.asyncapi.schema.bindings.main import OperationBinding
     from faststream.asyncapi.schema.channels import Channel
     from faststream.asyncapi.schema.operations import Operation
     from faststream.asyncapi.schema.utils import Tag
-    from faststream.asyncapi.schema.bindings.main import OperationBinding
 
     if not isinstance(app, AsgiFastStream):
         return channels

--- a/faststream/asyncapi/schema/operations.py
+++ b/faststream/asyncapi/schema/operations.py
@@ -35,7 +35,7 @@ class Operation(BaseModel):
 
     bindings: Optional[OperationBinding] = None
 
-    message: Union[Message, Reference]
+    message: Union[Message, Reference] = None
 
     security: Optional[Dict[str, List[str]]] = None
 

--- a/tests/asyncapi/basic.py
+++ b/tests/asyncapi/basic.py
@@ -1,7 +1,7 @@
 
 from faststream import FastStream
-from faststream.kafka import KafkaBroker
 from faststream.asgi import make_ping_asgi
+from faststream.kafka import KafkaBroker
 
 broker = KafkaBroker()
 app = FastStream(broker).as_asgi(

--- a/tests/asyncapi/basic.py
+++ b/tests/asyncapi/basic.py
@@ -1,0 +1,11 @@
+
+from faststream import FastStream
+from faststream.kafka import KafkaBroker
+from faststream.asgi import make_ping_asgi
+
+broker = KafkaBroker()
+app = FastStream(broker).as_asgi(
+    asgi_routes=[
+        ("/ping", make_ping_asgi(broker))
+    ]
+)

--- a/tests/asyncapi/test_asgi.py
+++ b/tests/asyncapi/test_asgi.py
@@ -2,6 +2,7 @@ from faststream import FastStream
 from faststream.asyncapi.generate import get_app_schema
 from faststream.kafka import KafkaBroker
 
+
 def test_asgi():
     schema = get_app_schema(FastStream(KafkaBroker())).to_jsonable()
 

--- a/tests/asyncapi/test_asgi.py
+++ b/tests/asyncapi/test_asgi.py
@@ -1,0 +1,29 @@
+from faststream import FastStream
+from faststream.asyncapi.generate import get_app_schema
+from faststream.kafka import KafkaBroker
+
+def test_asgi():
+    schema = get_app_schema(FastStream(KafkaBroker())).to_jsonable()
+
+    assert schema == {
+        "asyncapi": "2.6.0",
+        "defaultContentType": "application/json",
+        "info": {"description": "", "title": "FastStream", "version": "0.1.0"},
+        "servers": {
+            "development": {
+                "protocol": "kafka",
+                "protocolVersion": "auto",
+                "url": "localhost",
+            }
+        },
+        "channels": {
+            "ping": {
+                "servers": "- development",
+                "subscribe": {"bindings": {}, "tags": []},
+            }
+        },
+        "components": {
+            "messages": {},
+            "schemas": {}
+        },
+    }


### PR DESCRIPTION
# Description

Feature: AsyncAPI HTTP support #2091

Using AsgiFastStream object we can register some HTTP routes our application serve.
We should draw such routes in AsyncAPI specification as well. This feature should be togglable for sure in the basic include_in_schema=True/False way, but I am not sure about default value