### PR TITLE
add try/finally to ensure we exit on close error

### DIFF
--- a/faststream/broker/subscriber/usecase.py
+++ b/faststream/broker/subscriber/usecase.py
@@ -311,10 +311,13 @@ class SubscriberUsecase(
 
         except SystemExit:
             # Stop handler at `exit()` call
-            await self.close()
-
-            if app := context.get("app"):
-                app.exit()
+            try:
+                await self.close()
+            finally:
+                # Ensure that app.exit() is called on a shutdown request
+                # even if the consumer close operation threw an error.
+                if app := context.get("app"):
+                    app.exit()
 
         except Exception:  # nosec B110
             # All other exceptions were logged by CriticalLogMiddleware


### PR DESCRIPTION
# Description

When closing the consumer during a `consume` operation the consumer may throw an exception
which is neither handled not reported.

This is especially problematic when this is as a result of a `SystemExit` exception where
we are expecting the application to shutdown. Currently, when this situation occurs, the application
ends up in an inconsistent state where the consumer may be shutdown and no longer consuming,
yet the application remains up.

As an initial patch for this, we call the `app.exit()` within a `try/finally` block. 

In my situation, the underlying root cause was a CancelledError thrown deep within aiokafka:
https://github.com/aio-libs/aiokafka/issues/647

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
