### PR TITLE
Add AsyncAPI testing endpoint with real/test broker support

### DIFF
--- a/faststream/_internal/configs/specification.py
+++ b/faststream/_internal/configs/specification.py
@@ -5,6 +5,7 @@ from typing import Any
 @dataclass(kw_only=True)
 class SpecificationConfig:
     title_: str | None
+    operation_id_: str
     description_: str | None
 
     include_in_schema: bool = True

--- a/faststream/rabbit/broker/registrator.py
+++ b/faststream/rabbit/broker/registrator.py
@@ -59,6 +59,7 @@ class RabbitRegistrator(Registrator["IncomingMessage"]):
         no_reply: bool = False,
         # AsyncAPI information
         title: str | None = None,
+        operation_id: str,
         description: str | None = None,
         include_in_schema: bool = True,
     ) -> "RabbitSubscriber":
@@ -97,6 +98,7 @@ class RabbitRegistrator(Registrator["IncomingMessage"]):
             # specification args
             title_=title,
             description_=description,
+            operation_id_=operation_id,
             include_in_schema=include_in_schema,
         )
 
@@ -128,6 +130,7 @@ class RabbitRegistrator(Registrator["IncomingMessage"]):
         middlewares: Sequence["PublisherMiddleware"] = (),
         # AsyncAPI information
         title: str | None = None,
+        operation_id: str,
         description: str | None = None,
         schema: Any | None = None,
         include_in_schema: bool = True,
@@ -200,6 +203,7 @@ class RabbitRegistrator(Registrator["IncomingMessage"]):
             config=self.config,
             # specification args
             title_=title,
+            operation_id_=operation_id,
             description_=description,
             schema_=schema,
             include_in_schema=include_in_schema,

--- a/faststream/rabbit/publisher/factory.py
+++ b/faststream/rabbit/publisher/factory.py
@@ -26,6 +26,7 @@ def create_publisher(
     # Specification args
     schema_: Any | None,
     title_: str | None,
+    operation_id_: str,
     description_: str | None,
     include_in_schema: bool,
 ) -> RabbitPublisher:
@@ -49,6 +50,7 @@ def create_publisher(
             exchange=exchange,
             # specification options
             schema_=schema_,
+            operation_id_=operation_id_,
             title_=title_,
             description_=description_,
             include_in_schema=include_in_schema,

--- a/faststream/rabbit/subscriber/factory.py
+++ b/faststream/rabbit/subscriber/factory.py
@@ -37,6 +37,7 @@ def create_subscriber(
     config: "RabbitBrokerConfig",
     # Specification args
     title_: str | None,
+    operation_id_: str,
     description_: str | None,
     include_in_schema: bool,
 ) -> RabbitSubscriber:
@@ -60,6 +61,7 @@ def create_subscriber(
         _outer_config=config,
         specification_config=RabbitSubscriberSpecificationConfig(
             title_=title_,
+            operation_id_=operation_id_,
             description_=description_,
             include_in_schema=include_in_schema,
             queue=queue,

--- a/faststream/rabbit/subscriber/specification.py
+++ b/faststream/rabbit/subscriber/specification.py
@@ -36,7 +36,6 @@ class RabbitSubscriberSpecification(SubscriberSpecification[RabbitBrokerConfig, 
         queue_binding = amqp.Queue.from_queue(queue)
 
         channel_name = self.name
-
         return {
             channel_name: SubscriberSpec(
                 description=self.description,
@@ -57,6 +56,7 @@ class RabbitSubscriberSpecification(SubscriberSpecification[RabbitBrokerConfig, 
                         title=f"{channel_name}:Message",
                         payload=resolve_payloads(payloads),
                     ),
+                    operationId=self.config.operation_id_,
                 ),
                 bindings=ChannelBinding(
                     amqp=amqp.ChannelBinding(

--- a/faststream/specification/asyncapi/v2_6_0/generate.py
+++ b/faststream/specification/asyncapi/v2_6_0/generate.py
@@ -149,7 +149,6 @@ def get_broker_channels(
 ) -> dict[str, Channel]:
     """Get the broker channels for an application."""
     channels = {}
-
     for s in filter(lambda s: s.specification.include_in_schema, broker.subscribers):
         for key, sub in s.schema().items():
             if key in channels:
@@ -158,7 +157,6 @@ def get_broker_channels(
                     RuntimeWarning,
                     stacklevel=1,
                 )
-
             channels[key] = Channel.from_sub(sub)
 
     for p in filter(lambda p: p.specification.include_in_schema, broker.publishers):

--- a/faststream/specification/asyncapi/v2_6_0/schema/operations.py
+++ b/faststream/specification/asyncapi/v2_6_0/schema/operations.py
@@ -53,7 +53,7 @@ class Operation(BaseModel):
         return cls(
             message=Message.from_spec(operation.message),
             bindings=OperationBinding.from_sub(operation.bindings),
-            operationId=None,
+            operationId=operation.operationId,
             summary=None,
             description=None,
             tags=None,
@@ -65,7 +65,7 @@ class Operation(BaseModel):
         return cls(
             message=Message.from_spec(operation.message),
             bindings=OperationBinding.from_pub(operation.bindings),
-            operationId=None,
+            operationId=operation.operationId,
             summary=None,
             description=None,
             tags=None,

--- a/faststream/specification/schema/operation/model.py
+++ b/faststream/specification/schema/operation/model.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from dataclasses import dataclass
 
 from faststream.specification.schema.bindings import OperationBinding
@@ -6,5 +7,6 @@ from faststream.specification.schema.message import Message
 
 @dataclass
 class Operation:
+    operationId: str
     message: Message
     bindings: OperationBinding | None


### PR DESCRIPTION
# Description

This PR introduces a new demo FastAPI endpoint `/asyncapi/try/{operation_id}/{operation_type}` for testing AsyncAPI operations (2.6.0) by its `operation_id` with the following features with minor changes to FastStream:

1. Dual-mode operation:
  -   Test mode (uses TestRabbitBroker)
  -   Real broker mode

2. Operation type handling

Resolves #2222


## Type of change
- [ ] New feature (a non-breaking change that adds functionality)

## Demo

```python
from typing import Any, Dict, Optional

from fastapi import FastAPI, HTTPException, status
from fastapi.middleware.cors import CORSMiddleware
from faststream import FastStream
from faststream.specification.asyncapi.v2_6_0.generate import get_app_schema
from faststream.specification.asyncapi.v2_6_0.schema.operations import Operation
from faststream.specification.asyncapi.v2_6_0.schema import ApplicationSchema
from faststream.rabbit import RabbitBroker, TestRabbitBroker
from pydantic import BaseModel, Field


class BrokerRequest(BaseModel):
    message: Dict[str, Any]
    options: Dict[str, Any] = Field(default_factory=Dict)

class PublishResponse(BaseModel):
    status: str
    queue: str
    operation_id: str


def find_operation(
    schema: ApplicationSchema, operation_id: str, operation_type: str
) -> Optional[Operation]:
    for channel in schema.channels.values():
        try:
            operation = getattr(channel, operation_type)
            if operation.operationId == operation_id:
                return operation
        except AttributeError:
            return None
    return None

async def publish_message(
    operation: Operation,
    message: Dict[str, Any],
    broker: RabbitBroker,
    test_mode: bool = False
) -> PublishResponse:
    if not operation.bindings or not operation.bindings.amqp:
        raise ValueError("AMQP binding not configured")

    queue = operation.bindings.amqp.cc or ""
    if not queue:
        raise ValueError("Queue name not specified")

    publish_params = {
        "message": message,
        "queue": queue,
        "mandatory": bool(operation.bindings.amqp.mandatory),
        "priority": operation.bindings.amqp.priority or 0,
    }

    try:
        if test_mode:
            async with TestRabbitBroker(broker) as br:
                await br.publish(**publish_params)
        else:
            await broker.publish(**publish_params)
        
        return PublishResponse(
            status="success",
            queue=queue,
            operation_id=operation.operationId
        )
    except Exception as e:
        raise RuntimeError(f"Publish failed: {str(e)}")

broker = RabbitBroker()
fs_app = FastStream(broker)
app = FastAPI(title="AsyncAPI Test Endpoint")

app.add_middleware(
    CORSMiddleware,
    allow_origins=["http://localhost:3000"],
    allow_credentials=True,
    allow_methods=["POST"],
    allow_headers=["*"],
)

@broker.subscriber("test_1", operation_id="receive_light_measurement")
async def handle_light(msg: Dict[str, Any]) -> Dict[str, Any]:
    return {"status": "processed", "data": msg}

@broker.subscriber("test_2", operation_id="turn_on")
async def handle_turn_on(msg: Dict[str, Any]) -> Dict[str, Any]:
    return {"status": "processed", "data": msg}

@app.post(
    "/asyncapi/try/{operation_id}/{operation_type}",
    response_model=PublishResponse,
    status_code=status.HTTP_200_OK
)
async def test_operation(
    operation_id: str,
    operation_type: str,
    request: BrokerRequest
):
    ASYNCAPI_OPERATION_MAPPING = {
        'publish': 'subscribe',
        'subscribe': 'publish'
    }

    if operation_type not in ASYNCAPI_OPERATION_MAPPING:
        raise HTTPException(
            status_code=status.HTTP_400_BAD_REQUEST,
            detail=f"Invalid operation type. Allowed: {list(ASYNCAPI_OPERATION_MAPPING.keys())}"
        )

    schema = get_app_schema(broker, "test", "0.0.0", "2.6.0", "test schema", None, None, None, None, [{
            "name": "test",
            "description": "test",
            "external_docs": {
                "url": "http://example.com",
            }
    }], None)

    operation = find_operation(schema, operation_id, ASYNCAPI_OPERATION_MAPPING[operation_type])
    
    if not operation:
        raise HTTPException(
            status_code=status.HTTP_404_NOT_FOUND,
            detail="Operation not found"
        )

    try:
        return await publish_message(
            operation=operation,
            message=request.message,
            broker=broker,
            test_mode=not request.options.get("sendToRealBroker", False)
        )
    except ValueError as e:
        raise HTTPException(
            status_code=status.HTTP_400_BAD_REQUEST,
            detail=str(e)
        )
    except RuntimeError as e:
        raise HTTPException(
            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
            detail=str(e)
        )
```

## Improvements to discuss
- Add to FastStream core functions `find_operation` and `publish_message` to hide from users asyncapi schema details 