### PR TITLE
Add aiokafka error handling

### DIFF
--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -238,7 +238,7 @@ class LogicSubscriber(ABC, TasksMixin, SubscriberUsecase[MsgType]):
                 self._log(logging.ERROR, "There is no suitable compression library available. Please refer to the Kafka"
                                          " documentation for more information - "
                                          "https://aiokafka.readthedocs.io/en/stable/#installation")
-            except KafkaError as e:  # noqa: PERF203
+            except KafkaError as e:
                 self._log(logging.ERROR, "Kafka error occurred", exc_info=e)
                 if connected:
                     connected = False

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -233,10 +233,14 @@ class LogicSubscriber(ABC, TasksMixin, SubscriberUsecase[MsgType]):
             try:
                 msg = await self.get_msg(consumer)
 
-            except UnsupportedCodecError as e:
-                self._log(logging.ERROR, "There is no suitable compression library available. Please refer to the Kafka "
-                                         "documentation for more information - "
-                                         "https://aiokafka.readthedocs.io/en/stable/#installation", exc_info=e)
+            except UnsupportedCodecError as e:  # noqa: PERF203
+                self._log(
+                    logging.ERROR,
+                    "There is no suitable compression library available. Please refer to the Kafka "
+                    "documentation for more information - "
+                    "https://aiokafka.readthedocs.io/en/stable/#installation",
+                    exc_info=e,
+                )
                 await anyio.sleep(15)
 
             except KafkaError as e:

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -16,7 +16,7 @@ from typing import (
 
 import anyio
 from aiokafka import ConsumerRecord, TopicPartition
-from aiokafka.errors import ConsumerStoppedError, KafkaError
+from aiokafka.errors import ConsumerStoppedError, KafkaError, UnsupportedCodecError
 from typing_extensions import override
 
 from faststream.broker.publisher.fake import FakePublisher
@@ -234,6 +234,10 @@ class LogicSubscriber(ABC, TasksMixin, SubscriberUsecase[MsgType]):
                 msg = await self.get_msg(consumer)
 
             # pragma: no cover
+            except UnsupportedCodecError:
+                self._log(logging.ERROR, "There is no suitable compression library available. Please refer to the Kafka"
+                                         " documentation for more information - "
+                                         "https://aiokafka.readthedocs.io/en/stable/#installation")
             except KafkaError as e:  # noqa: PERF203
                 self._log(logging.ERROR, "Kafka error occurred", exc_info=e)
                 if connected:

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -233,11 +233,12 @@ class LogicSubscriber(ABC, TasksMixin, SubscriberUsecase[MsgType]):
             try:
                 msg = await self.get_msg(consumer)
 
-            # pragma: no cover
-            except UnsupportedCodecError:
-                self._log(logging.ERROR, "There is no suitable compression library available. Please refer to the Kafka"
-                                         " documentation for more information - "
-                                         "https://aiokafka.readthedocs.io/en/stable/#installation")
+            except UnsupportedCodecError as e:
+                self._log(logging.ERROR, "There is no suitable compression library available. Please refer to the Kafka "
+                                         "documentation for more information - "
+                                         "https://aiokafka.readthedocs.io/en/stable/#installation", exc_info=e)
+                await anyio.sleep(15)
+
             except KafkaError as e:
                 self._log(logging.ERROR, "Kafka error occurred", exc_info=e)
                 if connected:


### PR DESCRIPTION
# Description

Taking into account the already resolved Issue #2317, there is a need to gradually add new Aiokafka errors to the processing, removing them from the general 'exception KafkaError' and assigning them their own processing logic. To begin with, it is proposed to put the "UnsupportedCodecError" into a separate processing and refer to a specific part of the Aiokafka documentation to solve the problem.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
