### PR TITLE
introduce stop method on broker and subscriber and deprecate close

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ pytest tests
 
 In your project, you'll find some *pytest marks*:
 
+* **confluent**
 * **slow**
 * **rabbit**
 * **kafka**

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ async def start_broker(app):
     await broker.start()
 
 async def stop_broker(app):
-    await broker.close()
+    await broker.stop()
 
 async def hello(request):
     return web.Response(text="Hello, world")

--- a/docs/docs/en/getting-started/integrations/django/index.md
+++ b/docs/docs/en/getting-started/integrations/django/index.md
@@ -127,7 +127,7 @@ async def broker_lifespan(app):
     try:
         yield
     finally:
-        await broker.close()
+        await broker.stop()
 
 application = Starlette(
     ...,
@@ -160,7 +160,7 @@ application = Starlette(
         try:
             yield
         finally:
-            await broker.close()
+            await broker.stop()
 
     application = Starlette(
         routes=(

--- a/docs/docs_src/integrations/http_frameworks_integrations/aiohttp.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/aiohttp.py
@@ -15,7 +15,7 @@ async def start_broker(app):
 
 
 async def stop_broker(app):
-    await broker.close()
+    await broker.stop()
 
 
 async def hello(request):

--- a/docs/docs_src/integrations/http_frameworks_integrations/blacksheep.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/blacksheep.py
@@ -19,7 +19,7 @@ async def start_broker(application: Application) -> None:
 
 @app.on_stop
 async def stop_broker(application: Application) -> None:
-    await broker.close()
+    await broker.stop()
 
 
 @app.route("/")

--- a/docs/docs_src/integrations/http_frameworks_integrations/falcon.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/falcon.py
@@ -28,7 +28,7 @@ class StreamMiddleware:
         await broker.start()
 
     async def process_shutdown(self, scope, event):
-        await broker.close()
+        await broker.stop()
 
 
 app = falcon.asgi.App()

--- a/docs/docs_src/integrations/http_frameworks_integrations/fastapi.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/fastapi.py
@@ -14,7 +14,7 @@ async def base_handler(body):
 async def lifespan(app: FastAPI):
     await broker.start()
     yield
-    await broker.close()
+    await broker.stop()
 
 app = FastAPI(lifespan=lifespan)
 

--- a/docs/docs_src/integrations/http_frameworks_integrations/litestar.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/litestar.py
@@ -14,5 +14,5 @@ async def index() -> str:
 app = Litestar(
     [index],
     on_startup=[broker.start],
-    on_shutdown=[broker.close],
+    on_shutdown=[broker.stop],
 )

--- a/docs/docs_src/integrations/http_frameworks_integrations/quart.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/quart.py
@@ -19,7 +19,7 @@ async def start_broker():
 
 @app.after_serving
 async def stop_broker():
-    await broker.close()
+    await broker.stop()
 
 
 @app.route("/")

--- a/docs/docs_src/integrations/http_frameworks_integrations/sanic.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/sanic.py
@@ -20,7 +20,7 @@ async def start_broker(app, loop):
 
 @app.after_server_stop
 async def stop_broker(app, loop):
-    await broker.close()
+    await broker.stop()
 
 
 @app.get("/")

--- a/docs/docs_src/integrations/http_frameworks_integrations/tornado.py
+++ b/docs/docs_src/integrations/http_frameworks_integrations/tornado.py
@@ -33,7 +33,7 @@ async def main():
     try:
         await asyncio.Event().wait()
     finally:
-        await broker.close()
+        await broker.stop()
 
 
 if __name__ == "__main__":

--- a/faststream/_internal/application.py
+++ b/faststream/_internal/application.py
@@ -185,7 +185,7 @@ class Application(ABC, AsyncAPIApplication):
             await func()
 
         if self.broker is not None:
-            await self.broker.close()
+            await self.broker.stop()
 
         for func in self._after_shutdown_calling:
             await func()

--- a/faststream/broker/core/usecase.py
+++ b/faststream/broker/core/usecase.py
@@ -339,7 +339,7 @@ class BrokerUsecase(
         self.running = False
 
         for h in self._subscribers.values():
-            await h.close()
+            await h.stop()
 
         if self._connection is not None:
             await self._close(exc_type, exc_val, exc_tb)

--- a/faststream/broker/core/usecase.py
+++ b/faststream/broker/core/usecase.py
@@ -215,7 +215,7 @@ class BrokerUsecase(
         exc_val: Optional[BaseException],
         exc_tb: Optional["TracebackType"],
     ) -> None:
-        await self.close(exc_type, exc_val, exc_tb)
+        await self.stop(exc_type, exc_val, exc_tb)
 
     @abstractmethod
     async def start(self) -> None:
@@ -309,6 +309,13 @@ class BrokerUsecase(
                     self._get_fmt(),
                 )
 
+    @deprecated(
+        "Deprecated in **FastStream 0.5.44**. "
+        "Please, use `stop` method instead. "
+        "Method `close` will be removed in **FastStream 0.7.0**.",
+        category=DeprecationWarning,
+        stacklevel=1,
+    )
     async def close(
         self,
         exc_type: Optional[Type[BaseException]] = None,
@@ -316,6 +323,19 @@ class BrokerUsecase(
         exc_tb: Optional["TracebackType"] = None,
     ) -> None:
         """Closes the object."""
+        return await self.stop(
+            exc_type=exc_type,
+            exc_val=exc_val,
+            exc_tb=exc_tb,
+        )
+
+    async def stop(
+        self,
+        exc_type: Optional[Type[BaseException]] = None,
+        exc_val: Optional[BaseException] = None,
+        exc_tb: Optional["TracebackType"] = None,
+    ) -> None:
+        """Stops subscribers and closes connection."""
         self.running = False
 
         for h in self._subscribers.values():

--- a/faststream/broker/fastapi/router.py
+++ b/faststream/broker/fastapi/router.py
@@ -335,7 +335,7 @@ class StreamRouter(
                         await h(app)
 
                 finally:
-                    await self.broker.close()
+                    await self.broker.stop()
 
         return start_broker_lifespan
 

--- a/faststream/broker/subscriber/mixins.py
+++ b/faststream/broker/subscriber/mixins.py
@@ -25,9 +25,9 @@ class TasksMixin(SubscriberUsecase[Any]):
     def add_task(self, coro: Coroutine[Any, Any, Any]) -> None:
         self.tasks.append(asyncio.create_task(coro))
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         """Clean up handler subscription, cancel consume task in graceful mode."""
-        await super().close()
+        await super().stop()
 
         for task in self.tasks:
             if not task.done():

--- a/faststream/broker/subscriber/proto.py
+++ b/faststream/broker/subscriber/proto.py
@@ -10,7 +10,7 @@ from typing import (
     Sequence,
 )
 
-from typing_extensions import Self, override
+from typing_extensions import Self, deprecated, override
 
 from faststream.asyncapi.proto import AsyncAPIProto
 from faststream.broker.proto import EndpointProto
@@ -86,8 +86,18 @@ class SubscriberProto(
     @abstractmethod
     async def start(self) -> None: ...
 
+    @deprecated(
+        "Deprecated in **FastStream 0.5.44**. "
+        "Please, use `stop` method instead. "
+        "Method `close` will be removed in **FastStream 0.7.0**.",
+        category=DeprecationWarning,
+        stacklevel=1,
+    )
+    async def close(self) -> None:
+        return await self.stop()
+
     @abstractmethod
-    async def close(self) -> None: ...
+    async def stop(self) -> None: ...
 
     @abstractmethod
     async def consume(self, msg: MsgType) -> Any: ...

--- a/faststream/broker/subscriber/usecase.py
+++ b/faststream/broker/subscriber/usecase.py
@@ -199,7 +199,7 @@ class SubscriberUsecase(
         self.running = True
 
     @abstractmethod
-    async def close(self) -> None:
+    async def stop(self) -> None:
         """Close the handler.
 
         Blocks event loop up to graceful_timeout seconds.
@@ -307,12 +307,12 @@ class SubscriberUsecase(
 
         except StopConsume:
             # Stop handler at StopConsume exception
-            await self.close()
+            await self.stop()
 
         except SystemExit:
             # Stop handler at `exit()` call
             try:
-                await self.close()
+                await self.stop()
             finally:
                 # Ensure that app.exit() is called on a shutdown request
                 # even if the consumer close operation threw an error.

--- a/faststream/confluent/subscriber/usecase.py
+++ b/faststream/confluent/subscriber/usecase.py
@@ -154,8 +154,8 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
         if self.calls:
             self.add_task(self._consume())
 
-    async def close(self) -> None:
-        await super().close()
+    async def stop(self) -> None:
+        await super().stop()
 
         if self.consumer is not None:
             await self.consumer.stop()

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -171,8 +171,8 @@ class LogicSubscriber(ABC, TasksMixin, SubscriberUsecase[MsgType]):
         if self.calls:
             self.add_task(self._run_consume_loop(self.consumer))
 
-    async def close(self) -> None:
-        await super().close()
+    async def stop(self) -> None:
+        await super().stop()
 
         if self.consumer is not None:
             await self.consumer.stop()
@@ -617,7 +617,7 @@ class ConcurrentBetweenPartitionsSubscriber(DefaultSubscriber):
             for consumer in self.consumer_subgroup:
                 self.add_task(self._run_consume_loop(consumer))
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         if self.consumer_subgroup:
             async with anyio.create_task_group() as tg:
                 for consumer in self.consumer_subgroup:
@@ -625,7 +625,7 @@ class ConcurrentBetweenPartitionsSubscriber(DefaultSubscriber):
 
             self.consumer_subgroup = []
 
-        await super().close()
+        await super().stop()
 
     async def get_msg(self, consumer: "AIOKafkaConsumer") -> "KafkaRawMessage":
         assert consumer, "You should setup subscriber at first."  # nosec B101

--- a/faststream/nats/subscriber/usecase.py
+++ b/faststream/nats/subscriber/usecase.py
@@ -167,9 +167,9 @@ class LogicSubscriber(Generic[ConnectionType, MsgType], SubscriberUsecase[MsgTyp
         if self.calls:
             await self._create_subscription(connection=self._connection)
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         """Clean up handler subscription, cancel consume task in graceful mode."""
-        await super().close()
+        await super().stop()
 
         if self.subscription is not None:
             await self.subscription.unsubscribe()

--- a/faststream/rabbit/subscriber/usecase.py
+++ b/faststream/rabbit/subscriber/usecase.py
@@ -175,8 +175,8 @@ class LogicSubscriber(
 
         await super().start()
 
-    async def close(self) -> None:
-        await super().close()
+    async def stop(self) -> None:
+        await super().stop()
 
         if self._queue_obj is not None:
             if self._consumer_tag is not None:  # pragma: no branch

--- a/faststream/redis/subscriber/usecase.py
+++ b/faststream/redis/subscriber/usecase.py
@@ -200,8 +200,8 @@ class LogicSubscriber(SubscriberUsecase[UnifyRedisDict]):
     async def _get_msgs(self, *args: Any) -> None:
         raise NotImplementedError()
 
-    async def close(self) -> None:
-        await super().close()
+    async def stop(self) -> None:
+        await super().stop()
 
         if self.task is not None and not self.task.done():
             self.task.cancel()
@@ -283,13 +283,13 @@ class ChannelSubscriber(LogicSubscriber):
 
         await super().start(psub)
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         if self.subscription is not None:
             await self.subscription.unsubscribe()
             await self.subscription.aclose()  # type: ignore[attr-defined]
             self.subscription = None
 
-        await super().close()
+        await super().stop()
 
     @override
     async def get_one(  # type: ignore[override]

--- a/faststream/testing/broker.py
+++ b/faststream/testing/broker.py
@@ -117,7 +117,7 @@ class TestBroker(Generic[Broker]):
             "ping",
             return_value=True,
         ), mock.patch.object(
-            broker,   # TODO: remove it in 0.7
+            broker,  # TODO: remove it in 0.7
             "close",  # patch stop to save compatibility
         ):
             yield

--- a/faststream/testing/broker.py
+++ b/faststream/testing/broker.py
@@ -103,7 +103,7 @@ class TestBroker(Generic[Broker]):
             wraps=partial(self._fake_connect, broker),
         ), mock.patch.object(
             broker,
-            "close",
+            "stop",
         ), mock.patch.object(
             broker,
             "_connection",
@@ -116,6 +116,9 @@ class TestBroker(Generic[Broker]):
             broker,
             "ping",
             return_value=True,
+        ), mock.patch.object(
+            broker,   # TODO: remove it in 0.7
+            "close",  # patch stop to save compatibility
         ):
             yield
 

--- a/tests/brokers/base/connection.py
+++ b/tests/brokers/base/connection.py
@@ -19,7 +19,7 @@ class BrokerConnectionTestcase:
     async def test_close_before_start(self, async_mock):
         br = self.broker()
         assert br._connection is None
-        await br.close()
+        await br.stop()
         br._connection = async_mock
         await br._close()
         assert not br.running
@@ -30,7 +30,7 @@ class BrokerConnectionTestcase:
         broker = self.broker(**kwargs)
         await broker.connect()
         assert await self.ping(broker)
-        await broker.close()
+        await broker.stop()
 
     @pytest.mark.asyncio
     async def test_connection_by_url(self, settings):
@@ -38,7 +38,7 @@ class BrokerConnectionTestcase:
         broker = self.broker()
         await broker.connect(**kwargs)
         assert await self.ping(broker)
-        await broker.close()
+        await broker.stop()
 
     @pytest.mark.asyncio
     async def test_connect_by_url_priority(self, settings):
@@ -46,7 +46,7 @@ class BrokerConnectionTestcase:
         broker = self.broker("wrong_url")
         await broker.connect(**kwargs)
         assert await self.ping(broker)
-        await broker.close()
+        await broker.stop()
 
     @pytest.mark.asyncio
     async def test_ping_timeout(self, settings):
@@ -54,4 +54,4 @@ class BrokerConnectionTestcase:
         broker = self.broker("wrong_url")
         await broker.connect(**kwargs)
         assert not await broker.ping(timeout=1e-24)
-        await broker.close()
+        await broker.stop()

--- a/tests/brokers/base/consume.py
+++ b/tests/brokers/base/consume.py
@@ -269,7 +269,7 @@ class BrokerConsumeTestcase(BaseTestcaseConfig):
             with anyio.move_on_after(self.timeout):
                 await event.wait()
 
-            await sub.close()
+            await sub.stop()
 
         assert event.is_set()
 

--- a/tests/brokers/base/testclient.py
+++ b/tests/brokers/base/testclient.py
@@ -126,11 +126,13 @@ class BrokerTestclientTestcase(
             assert isinstance(br.start, Mock)
             assert isinstance(br._connect, Mock)
             assert isinstance(br.close, Mock)
+            assert isinstance(br.stop, Mock)
             assert isinstance(br._producer, fake_producer_class)
 
         assert not isinstance(br.start, Mock)
         assert not isinstance(br._connect, Mock)
         assert not isinstance(br.close, Mock)
+        assert not isinstance(br.stop, Mock)
         assert br._connection is not None
         assert not isinstance(br._producer, fake_producer_class)
 
@@ -142,6 +144,7 @@ class BrokerTestclientTestcase(
             assert not isinstance(br.start, Mock)
             assert not isinstance(br._connect, Mock)
             assert not isinstance(br.close, Mock)
+            assert not isinstance(br.stop, Mock)
             assert br._connection is not None
             assert br._producer is not None
 

--- a/tests/brokers/kafka/test_consume.py
+++ b/tests/brokers/kafka/test_consume.py
@@ -404,7 +404,7 @@ class TestConsume(BrokerRealConsumeTestcase):
             await asyncio.sleep(1)
             assert inputs == {"hello1", "hello2", "hello3", "hello4", "hello5"}
 
-            await broker.close()
+            await broker.stop()
 
     @pytest.mark.asyncio
     @pytest.mark.slow
@@ -457,7 +457,7 @@ class TestConsume(BrokerRealConsumeTestcase):
                 )
                 assert mock.mock.call_count == 2
 
-            await broker.close()
+            await broker.stop()
 
     @pytest.mark.asyncio
     @pytest.mark.slow
@@ -500,7 +500,7 @@ class TestConsume(BrokerRealConsumeTestcase):
         with patch.object(consume_broker, "logger", Mock(handlers=[])) as mock:
             async with self.patch_broker(consume_broker) as broker:
                 await broker.start()
-                await broker.close()
+                await broker.stop()
             if warning:
                 assert (
                     len(
@@ -608,7 +608,7 @@ class TestConsume(BrokerRealConsumeTestcase):
 
         async with self.patch_broker(consume_broker) as broker:
             await broker.start()
-            await broker.close()
+            await broker.stop()
 
         assert called_assigned is True
         assert called_revoked is True
@@ -643,7 +643,7 @@ class TestConsume(BrokerRealConsumeTestcase):
 
         async with self.patch_broker(consume_broker) as broker:
             await broker.start()
-            await broker.close()
+            await broker.stop()
 
         assert called_assigned is True
         assert called_revoked is True

--- a/tests/brokers/rabbit/test_connect.py
+++ b/tests/brokers/rabbit/test_connect.py
@@ -25,7 +25,7 @@ class TestConnection(BrokerConnectionTestcase):
             ),
         )
         assert await broker.connect()
-        await broker.close()
+        await broker.stop()
 
     @pytest.mark.asyncio
     async def test_connect_handover_config_to_connect(self, settings):
@@ -38,10 +38,10 @@ class TestConnection(BrokerConnectionTestcase):
                 password=settings.password,
             ),
         )
-        await broker.close()
+        await broker.stop()
 
     @pytest.mark.asyncio
     async def test_connect_handover_config_to_connect_override_init(self, settings):
         broker = self.broker("fake-url")  # will be ignored
         assert await broker.connect(url=settings.url)
-        await broker.close()
+        await broker.stop()

--- a/tests/brokers/redis/test_connect.py
+++ b/tests/brokers/redis/test_connect.py
@@ -32,11 +32,11 @@ class TestConnection(BrokerConnectionTestcase):
             port=settings.port,
         )
         assert await self.ping(broker)
-        await broker.close()
+        await broker.stop()
 
     @pytest.mark.asyncio
     async def test_connect_merge_args_and_kwargs_native(self, settings):
         broker = self.broker("fake-url")  # will be ignored
         await broker.connect(url=settings.url)
         assert await self.ping(broker)
-        await broker.close()
+        await broker.stop()

--- a/tests/brokers/redis/test_fastapi.py
+++ b/tests/brokers/redis/test_fastapi.py
@@ -50,7 +50,7 @@ class TestRouter(FastAPITestcase):
             port=settings.port,
         )
         await broker._connection.ping()
-        await broker.close()
+        await broker.stop()
 
     async def test_batch_real(
         self,

--- a/tests/cli/rabbit/test_app.py
+++ b/tests/cli/rabbit/test_app.py
@@ -201,7 +201,7 @@ async def test_shutdown_lifespan_after_broker_stopped(
         await async_mock.before()
         assert not async_mock.broker_stop.called
 
-    with patch.object(app.broker, "close", async_mock.broker_stop):
+    with patch.object(app.broker, "stop", async_mock.broker_stop):
         await app.stop()
 
     async_mock.broker_stop.assert_called_once()
@@ -214,7 +214,7 @@ async def test_running(async_mock, app: FastStream):
     app.exit()
 
     with patch.object(app.broker, "start", async_mock.broker_run), patch.object(
-        app.broker, "close", async_mock.broker_stopped
+        app.broker, "stop", async_mock.broker_stopped
     ):
         await app.run()
 
@@ -246,7 +246,7 @@ async def test_running_lifespan_contextmanager(async_mock, mock: Mock, app: Fast
     app.exit()
 
     with patch.object(app.broker, "start", async_mock.broker_run), patch.object(
-        app.broker, "close", async_mock.broker_stopped
+        app.broker, "stop", async_mock.broker_stopped
     ):
         await app.run(run_extra_options={"env": "test"})
 
@@ -323,7 +323,7 @@ async def test_lifespan_contextmanager(async_mock: AsyncMock, app: FastStream):
     app = FastStream(app.broker, lifespan=lifespan)
 
     with patch.object(app.broker, "start", async_mock.broker_run), patch.object(
-        app.broker, "close", async_mock.broker_stopped
+        app.broker, "stop", async_mock.broker_stopped
     ):
         async with TestApp(app, {"env": "test"}):
             pass
@@ -344,7 +344,7 @@ def test_sync_lifespan_contextmanager(async_mock: AsyncMock, app: FastStream):
     app = FastStream(app.broker, lifespan=lifespan)
 
     with patch.object(app.broker, "start", async_mock.broker_run), patch.object(
-        app.broker, "close", async_mock.broker_stopped
+        app.broker, "stop", async_mock.broker_stopped
     ), TestApp(app, {"env": "test"}):
         pass
 
@@ -358,7 +358,7 @@ def test_sync_lifespan_contextmanager(async_mock: AsyncMock, app: FastStream):
 @pytest.mark.skipif(IS_WINDOWS, reason="does not run on windows")
 async def test_stop_with_sigint(async_mock, app: FastStream):
     with patch.object(app.broker, "start", async_mock.broker_run_sigint), patch.object(
-        app.broker, "close", async_mock.broker_stopped_sigint
+        app.broker, "stop", async_mock.broker_stopped_sigint
     ):
         async with anyio.create_task_group() as tg:
             tg.start_soon(app.run)
@@ -372,7 +372,7 @@ async def test_stop_with_sigint(async_mock, app: FastStream):
 @pytest.mark.skipif(IS_WINDOWS, reason="does not run on windows")
 async def test_stop_with_sigterm(async_mock, app: FastStream):
     with patch.object(app.broker, "start", async_mock.broker_run_sigterm), patch.object(
-        app.broker, "close", async_mock.broker_stopped_sigterm
+        app.broker, "stop", async_mock.broker_stopped_sigterm
     ):
         async with anyio.create_task_group() as tg:
             tg.start_soon(app.run)
@@ -397,7 +397,7 @@ async def test_run_asgi(async_mock: AsyncMock, app: FastStream):
     assert asgi_app.routes == asgi_routes
 
     with patch.object(app.broker, "start", async_mock.broker_run), patch.object(
-        app.broker, "close", async_mock.broker_stopped
+        app.broker, "stop", async_mock.broker_stopped
     ):
         async with anyio.create_task_group() as tg:
             tg.start_soon(app.run)


### PR DESCRIPTION
# Description

Why there's `close` after `start`, when `stop` fits better?

I updated broker and subscriber to use `stop` instead of `close`. The `close` method is marked as deprecated and to be removed in 0.7.0.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] A new method and deprecation of an old one

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes **do generate** new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
