### PR TITLE
fix: add injection extra options in lifespan

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,5 +1,5 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.5.43"
+__version__ = "0.5.44"
 
 SERVICE_NAME = f"faststream-{__version__}"

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -183,7 +183,9 @@ class AsgiFastStream(Application):
 
     @asynccontextmanager
     async def start_lifespan_context(self) -> AsyncIterator[None]:
-        async with anyio.create_task_group() as tg, self.lifespan_context():
+        async with anyio.create_task_group() as tg, self.lifespan_context(
+            **self._run_extra_options
+        ):
             tg.start_soon(self._startup, self._log_level, self._run_extra_options)
 
             try:


### PR DESCRIPTION
# Description

Fix bug, when extra options was ignored for ASGI Application

```python
from faststream import FastStream
from faststream.nats import NatsBroker
from contextlib import asynccontextmanager


broker = NatsBroker()


@asynccontextmanager
async def lifespan(test: int, port: int):
    print(port)  # 5000
    print(test)  # 3
    yield


app = FastStream(broker, lifespan=lifespan).as_asgi(
    asyncapi_path="/docs",
)
```

```bash
faststream run main:app --test 3 --port 5000
```

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
