### PR TITLE
Modify sys.path on publish

### DIFF
--- a/faststream/_internal/cli/main.py
+++ b/faststream/_internal/cli/main.py
@@ -251,6 +251,7 @@ def _run_imported_app(
 def publish(
     ctx: typer.Context,
     app: str = APP_ARGUMENT,
+    app_dir: str = APP_DIR_OPTION,
     message: str = typer.Argument(
         ...,
         help="JSON Message string to publish.",
@@ -269,6 +270,9 @@ def publish(
     These are parsed and passed to the broker's publish method.
     """
     app, extra = parse_cli_args(app, *ctx.args)
+
+    if app_dir:  # pragma: no branch
+        sys.path.insert(0, app_dir)
 
     publish_extra: AnyDict = extra.copy()
     if "timeout" in publish_extra:


### PR DESCRIPTION
# Description

The publish CLI command didn't modify sys.path, causing it to fail when FastStream application files contained project-specific imports.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
