### PR TITLE
fix overlapping patterns

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,5 +1,5 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.5.45"
+__version__ = "0.5.46"
 
 SERVICE_NAME = f"faststream-{__version__}"

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -237,8 +237,8 @@ def is_covered(subject: str, pattern: str) -> bool:
     return len(subject_parts) == len(pattern_parts)
 
 
-def filter_overlapped_subjects(subjects: list[str]) -> list[str]:
-    filtered_subjects: Final[list[str]] = []
+def filter_overlapped_subjects(subjects: List[str]) -> List[str]:
+    filtered_subjects: Final[List[str]] = []
     for subject in subjects:
         need_to_add = True
         for filtered_subject_position in range(len(filtered_subjects)):

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -223,17 +223,12 @@ def is_covered(subject: str, pattern: str) -> bool:
     subject_parts: Final = subject.split(".")
     pattern_parts: Final = pattern.split(".")
 
-    if len(subject_parts) < len(pattern_parts):
-        return False
-
     for i, pattern_part in enumerate(pattern_parts):
-        if pattern_part == "*" and subject_parts[i] != ">":
+        if pattern_part == "*":
+            if subject_parts[i] == ">":
+                return False
             continue
-        if (
-            pattern_part == ">"
-            and (subject_parts[i] != "*" or len(subject_parts) > len(pattern_parts))
-            and i == len(pattern_parts) - 1
-        ):
+        if pattern_part == ">" and i == len(pattern_parts) - 1:
             return True
         if subject_parts[i] != pattern_part:
             return False

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -227,9 +227,13 @@ def is_covered(subject: str, pattern: str) -> bool:
         return False
 
     for i, pattern_part in enumerate(pattern_parts):
-        if pattern_part == "*":
+        if pattern_part == "*" and subject_parts[i] != ">":
             continue
-        if pattern_part == ">" and i == len(pattern_parts) - 1:
+        if (
+            pattern_part == ">"
+            and (subject_parts[i] != "*" or len(subject_parts) > len(pattern_parts))
+            and i == len(pattern_parts) - 1
+        ):
             return True
         if subject_parts[i] != pattern_part:
             return False

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -674,7 +674,11 @@ class NatsBroker(
                     await self.stream.update_stream(
                         config=stream.config,
                         subjects=tuple(
-                            set(old_config.subjects or ()).union(stream.subjects)
+                            set(old_config.subjects or ()).union(
+                                subject for subject in stream.subjects if (
+                                    "*" not in subject and ">" not in subject
+                                )
+                            )
                         ),
                     )
 

--- a/faststream/nats/subscriber/asyncapi.py
+++ b/faststream/nats/subscriber/asyncapi.py
@@ -29,7 +29,7 @@ class AsyncAPISubscriber(LogicSubscriber[Any, Any]):
     """A class to represent a NATS handler."""
 
     def get_name(self) -> str:
-        return f"{self.subject}:{self.call_name}"
+        return f"{self.clear_subject}:{self.call_name}"
 
     def get_schema(self) -> Dict[str, Channel]:
         payloads = self.get_payloads()

--- a/tests/brokers/nats/test_overlaping_subjects.py
+++ b/tests/brokers/nats/test_overlaping_subjects.py
@@ -1,3 +1,5 @@
+from typing import List, Set
+
 import pytest
 
 from faststream.nats.broker.broker import filter_overlapped_subjects
@@ -30,5 +32,5 @@ from faststream.nats.broker.broker import filter_overlapped_subjects
         (["a.*.*", "a.*.*.*", "a.b.c", "a.b.c.d"], {"a.*.*", "a.*.*.*"}),
     ],
 )
-def test_filter_overlapped_subjects(subjects: list[str], expected: set[str]) -> None:
+def test_filter_overlapped_subjects(subjects: List[str], expected: Set[str]) -> None:
     assert set(filter_overlapped_subjects(subjects)) == expected

--- a/tests/brokers/nats/test_overlaping_subjects.py
+++ b/tests/brokers/nats/test_overlaping_subjects.py
@@ -1,0 +1,25 @@
+import pytest
+
+@pytest.mark.parametrize(
+    ("subjects", "expected"),
+    [
+        (["a"], {"a"}),
+        (["a", "a"], {"a"}),
+        (["a.b", "a.b"], {"a.b"}),
+        (["a", "b"], {"a", "b"}),
+        (["a.b", "b.b"], {"a.b", "b.b"}),
+        (["a.b", "a.*"], {"a.*"}),
+        (["a.b.c", "a.*.c"], {"a.*.c"}),
+        (["*.b.c", "a.>", "a.b.c"], {"*.b.c", "a.>"}),  # <- this case will raise subject "a.>" overlaps with "*.b.c"
+        (["a.b", "a.*", "a.b.c"], {"a.*", "a.b.c"}),  # but I don't know what to do with it
+        (["a.b", "a.>", "a.b.c"], {"a.>"}),
+        (["a.*", "a.>"], {"a.>", "a.*"}),
+        (["a.*", "a.>", "a.b"], {"a.>", "a.*"}),
+        (["a.*.*", "a.>"], {"a.>"}),
+        (["a.*.*", "a.*.*.*", "a.b.c", "a.b.c.d", "a.>"], {"a.>"}),
+        (["a.>", "a.*.*", "a.*.*.*", "a.b.c", "a.b.c.d"], {"a.>"}),
+        (["a.*.*", "a.*.*.*", "a.b.c", "a.b.c.d"], {"a.*.*", "a.*.*.*"}),
+    ],
+)
+def test_filter_overlapped_subjects(subjects: list[str], expected: set[str]) -> None:
+    assert set(filter_overlapped_subjects(subjects)) == expected

--- a/tests/brokers/nats/test_overlaping_subjects.py
+++ b/tests/brokers/nats/test_overlaping_subjects.py
@@ -15,7 +15,7 @@ TEST_CASES: Final = {
     "overlapping_wildcards_and_specific": (
         ["*.b.c", "a.>", "a.b.c"],
         {"a.>", "*.b.c"},
-    ),  # <- this case will raise subject "a.>" overlaps with "*.b.c" but I don't know what to do with it
+    ),
     "nested_wildcard_and_specific": (["a.b", "a.*", "a.b.c"], {"a.b.c", "a.*"}),
     "wildcard_overlaps_specific": (["a.b", "a.>", "a.b.c"], {"a.>"}),
     "wildcard_overlaps_wildcard": (["a.*", "a.>"], {"a.>"}),
@@ -23,12 +23,14 @@ TEST_CASES: Final = {
     "wildcard_overlaps_wildcard_and_specific": (["a.*", "a.>", "a.b"], {"a.>"}),
     "specific_wildcard_overlaps_wildcard": (["a.b", "a.*", "a.>"], {"a.>"}),
     "deep_wildcard_overlaps_wildcard": (["a.*.*", "a.>"], {"a.>"}),
-    "deep_wildcards_and_wildcard": (
-        ["a.*.*", "a.*.*.*", "a.b.c", "a.b.c.d", "a.>"],
-        {"a.>"},
-    ),
     "wildcard_overlaps_deep_wildcards": (
-        ["a.>", "a.*.*", "a.*.*.*", "a.b.c", "a.b.c.d"],
+        [
+            "a.*.*",
+            "a.*.*.*",
+            "a.b.c",
+            "a.>",
+            "a.b.c.d",
+        ],
         {"a.>"},
     ),
     "deep_wildcards": (["a.*.*", "a.*.*.*", "a.b.c", "a.b.c.d"], {"a.*.*.*", "a.*.*"}),

--- a/tests/brokers/nats/test_overlaping_subjects.py
+++ b/tests/brokers/nats/test_overlaping_subjects.py
@@ -16,11 +16,11 @@ from faststream.nats.broker.broker import filter_overlapped_subjects
         (
             ["*.b.c", "a.>", "a.b.c"],
             {"*.b.c", "a.>"},
-        ),  # <- this case will raise subject "a.>" overlaps with "*.b.c"
+        ),  # <- this case will raise subject "a.>" overlaps with "*.b.c" but I don't know what to do with it
         (
             ["a.b", "a.*", "a.b.c"],
             {"a.*", "a.b.c"},
-        ),  # but I don't know what to do with it
+        ),
         (["a.b", "a.>", "a.b.c"], {"a.>"}),
         (["a.*", "a.>"], {"a.>", "a.*"}),
         (["a.*", "a.>", "a.b"], {"a.>", "a.*"}),

--- a/tests/brokers/nats/test_overlaping_subjects.py
+++ b/tests/brokers/nats/test_overlaping_subjects.py
@@ -1,5 +1,8 @@
 import pytest
 
+from faststream.nats.broker.broker import filter_overlapped_subjects
+
+
 @pytest.mark.parametrize(
     ("subjects", "expected"),
     [
@@ -10,8 +13,14 @@ import pytest
         (["a.b", "b.b"], {"a.b", "b.b"}),
         (["a.b", "a.*"], {"a.*"}),
         (["a.b.c", "a.*.c"], {"a.*.c"}),
-        (["*.b.c", "a.>", "a.b.c"], {"*.b.c", "a.>"}),  # <- this case will raise subject "a.>" overlaps with "*.b.c"
-        (["a.b", "a.*", "a.b.c"], {"a.*", "a.b.c"}),  # but I don't know what to do with it
+        (
+            ["*.b.c", "a.>", "a.b.c"],
+            {"*.b.c", "a.>"},
+        ),  # <- this case will raise subject "a.>" overlaps with "*.b.c"
+        (
+            ["a.b", "a.*", "a.b.c"],
+            {"a.*", "a.b.c"},
+        ),  # but I don't know what to do with it
         (["a.b", "a.>", "a.b.c"], {"a.>"}),
         (["a.*", "a.>"], {"a.>", "a.*"}),
         (["a.*", "a.>", "a.b"], {"a.>", "a.*"}),


### PR DESCRIPTION
# Description

Want to fix the issue of overlapping of patterned subject `a.*.*` with existing subject `a.a.a`

```python
broker: typing.Final = NatsBroker(
    name="123",
    logger=LOGGER,
    **nats_config,
)
@broker.subscriber(
    "a.b.c",
    description="Consumes changes of individuals",
    durable="1",
    stream="123",
    pull_sub=True,
    no_reply=True,
    retry=True,
)
def tst1(msg):
    print(f"tst1: {msg}")

@broker.subscriber(
    "a.>",
    description="Consumes changes of individuals",
    durable="2",
    stream="123",
    pull_sub=True,
    no_reply=True,
    retry=True,
)
def tst2(msg):
    print(f"tst2: {msg}")

application: typing.Final = FastStream(broker)

```
Error: `nats.js.errors.ServerError: nats: ServerError: code=500 err_code=10052 description='subject "a.b.c" overlaps with "a.>"'`
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
