### PR TITLE
fix: Change f-string in logs

### DIFF
--- a/faststream/kafka/helpers/rebalance_listener.py
+++ b/faststream/kafka/helpers/rebalance_listener.py
@@ -68,7 +68,7 @@ class _LoggingListener(ConsumerRebalanceListener):  # type: ignore[misc]
         self.logger.log(
             logging.INFO,
             f"Consumer {self.consumer._coordinator.member_id} assigned to partitions: "
-            f"{assigned}",
+            f"({', '.join(str(tp) for tp in assigned)})",
             extra=self.log_extra,
         )
 


### PR DESCRIPTION
# Description

My project includes loguru, which intercepts logs for their centralized processing. But in the place where I made changes, a lot is inserted without preliminary processing, which causes a KeyError in loguru. The error is not critical and does not crash the application, but purely visually I do not want to see an error message when starting the application

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
