### PR TITLE
Remove `on: workflow_dispatch: null`

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -1,7 +1,6 @@
 name: Publish to PyPi
 
 on:
-  workflow_dispatch: null
   release:
     types:
       - published


### PR DESCRIPTION
Is it really needed? We use just `on: released: [published]` in https://github.com/typeddjango/django-stubs/blob/master/.github/workflows/release.yml#L3-L5
