### PR TITLE
CI: use pre-commit-ci-lite instead of manual commit step during linters

### DIFF
--- a/.github/workflows/pr_autoupdate.yaml
+++ b/.github/workflows/pr_autoupdate.yaml
@@ -1,7 +1,7 @@
 name: Run linters
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -20,11 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          token: ${{ secrets.AUTOMERGE_TOKEN }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-          persist-credentials: false
 
       - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
         with:
@@ -56,10 +51,8 @@ jobs:
         with:
           extra_args: --hook-stage manual --all-files
 
-      - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
-        with:
-          commit_message: "chore: apply autofixes"
-          commit_user_name: faststream-actions[bot]
-          commit_user_email: faststream-actions[bot]@users.noreply.github.com
-          commit_author: faststream-actions[bot] <faststream-actions[bot]@users.noreply.github.com>
+      # the step must have either the default name or contain the text 'pre-commit-ci-lite'.
+      # the application uses this to find the right workflow.
+      - name: Run pre-commit-ci-lite
+        uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
+        if: always()

--- a/.github/workflows/pr_autoupdate.yaml
+++ b/.github/workflows/pr_autoupdate.yaml
@@ -45,6 +45,12 @@ jobs:
         with:
           just-version: 1.42.4
 
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        continue-on-error: true
+        with:
+          extra_args: --hook-stage manual --all-files
+
       # the step must have either the default name or contain the text 'pre-commit-ci-lite'.
       # the application uses this to find the right workflow.
       - name: Run pre-commit-ci-lite

--- a/.github/workflows/pr_autoupdate.yaml
+++ b/.github/workflows/pr_autoupdate.yaml
@@ -45,12 +45,6 @@ jobs:
         with:
           just-version: 1.42.4
 
-      - name: Run pre-commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        continue-on-error: true
-        with:
-          extra_args: --hook-stage manual --all-files
-
       # the step must have either the default name or contain the text 'pre-commit-ci-lite'.
       # the application uses this to find the right workflow.
       - name: Run pre-commit-ci-lite


### PR DESCRIPTION
# Description

Now `Run linters` workflow applies autofix commit using ready to go solution based on [pre-commit.ci](https://pre-commit.ci/)
Also now workflow triggered on `pull_request` event, it means more secured context of steps execution without access to base repository

Fixes #2410

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
