### PR TITLE
dont replace hyphen in cli values

### DIFF
--- a/faststream/_internal/cli/utils/parser.py
+++ b/faststream/_internal/cli/utils/parser.py
@@ -36,7 +36,7 @@ def parse_cli_args(*args: str) -> tuple[str, dict[str, "SettingField"]]:
         if ":" in item and not is_bind_arg(item):
             app = item
 
-        elif "-" in item:
+        elif item.startswith("-"):
             if k:
                 k = k.strip().lstrip("-").replace("-", "_")
 

--- a/tests/cli/utils/test_parser.py
+++ b/tests/cli/utils/test_parser.py
@@ -79,3 +79,19 @@ def test_bind_arg(args: str):
 )
 def test_not_bind_arg(args: str):
     assert is_bind_arg(args) is False
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_extra"),
+    (
+        pytest.param(["--key", "value"], {"key": "value"}),
+        pytest.param(["--key", "va-lue"], {"key": "va-lue"}),
+        pytest.param(["--key", "--value"], {"key": True, "value": True}),
+        pytest.param(["--key", "-value"], {"key": True, "value": True}),
+        pytest.param(["-key", "--value"], {"key": True, "value": True}),
+        pytest.param(["--ke-y", "value"], {"ke_y": "value"}),
+    )
+)
+def test_parse_extra_args(args, expected_extra):
+    _, extra = parse_cli_args(*args)
+    assert extra == expected_extra

--- a/tests/mypy/rabbit.py
+++ b/tests/mypy/rabbit.py
@@ -1,7 +1,5 @@
 from collections.abc import Awaitable, Callable
 
-from faststream.rabbit.publisher.usecase import RabbitPublisher
-from faststream.rabbit.subscriber.usecase import RabbitSubscriber
 import prometheus_client
 from aio_pika import IncomingMessage
 from aiormq.abc import ConfirmationFrameType
@@ -12,6 +10,8 @@ from faststream.rabbit import RabbitBroker, RabbitMessage, RabbitRoute, RabbitRo
 from faststream.rabbit.fastapi import RabbitRouter as FastAPIRouter
 from faststream.rabbit.opentelemetry import RabbitTelemetryMiddleware
 from faststream.rabbit.prometheus import RabbitPrometheusMiddleware
+from faststream.rabbit.publisher.usecase import RabbitPublisher
+from faststream.rabbit.subscriber.usecase import RabbitSubscriber
 
 
 def sync_decoder(msg: RabbitMessage) -> DecodedMessage:


### PR DESCRIPTION
# Description

When pass extra values to cli, faststream replaced hyphens to undescore.

```
faststream publish simple:app '{"name": "John"}' --subject 'my-topic'
faststream publish simple:app '{"name": "John"}' --subject='my-topic'
# extra args {'subject': True, 'my_topic': True}
```

Expected extra args is `{"subject": "my-topic"}`

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
