### PR TITLE
fix(asyncapi): promote nested pydantic  to components/schemas

### DIFF
--- a/faststream/specification/asyncapi/v2_6_0/generate.py
+++ b/faststream/specification/asyncapi/v2_6_0/generate.py
@@ -229,6 +229,12 @@ def _resolve_msg_payloads(
     if isinstance(one_of, dict):
         for p_title, p in one_of.items():
             formatted_payload_title = clear_key(p_title)
+            # Promote nested Pydantic $defs from each payload into components/schemas
+            # so that referenced nested models are available globally.
+            if isinstance(p, dict) and DEF_KEY in p:
+                defs = p.pop(DEF_KEY) or {}
+                for def_name, def_schema in defs.items():
+                    payloads[clear_key(def_name)] = def_schema
             payloads.update(p.pop(DEF_KEY, {}))
             if formatted_payload_title not in payloads:
                 payloads[formatted_payload_title] = p

--- a/faststream/specification/asyncapi/v3_0_0/generate.py
+++ b/faststream/specification/asyncapi/v3_0_0/generate.py
@@ -275,6 +275,12 @@ def _resolve_msg_payloads(
         one_of_list = []
         processed_payloads: dict[str, dict[str, Any]] = {}
         for name, payload in one_of.items():
+            # Promote nested Pydantic $defs from each payload into components/schemas
+            # so that referenced nested models are available globally.
+            if isinstance(payload, dict) and DEF_KEY in payload:
+                defs = payload.pop(DEF_KEY) or {}
+                for def_name, def_schema in defs.items():
+                    payloads[clear_key(def_name)] = def_schema
             processed_payloads[clear_key(name)] = payload
             one_of_list.append(Reference(**{"$ref": f"#/components/schemas/{name}"}))
 

--- a/tests/asyncapi/base/v2_6_0/arguments.py
+++ b/tests/asyncapi/base/v2_6_0/arguments.py
@@ -420,6 +420,81 @@ class FastAPICompatible(AsyncAPI260Factory):
             },
         }
 
+    def test_nested_models_in_union_should_be_in_schemas(self) -> None:
+        """Test that nested Pydantic models in union types are promoted to components/schemas.
+
+        Fixes issue #2443: Nested Pydantic models are not included in AsyncAPI
+        components/schemas (inplaced instead).
+        """
+        class Email(pydantic.BaseModel):
+            addr: str
+
+        class User(pydantic.BaseModel):
+            name: str = ""
+            id: int
+            email: Email
+
+        class Other(pydantic.BaseModel):
+            id: int
+
+        broker = self.broker_class()
+
+        @broker.subscriber("test")
+        async def handle(body: User | Other) -> None: ...
+
+        schema = self.get_spec(broker).to_jsonable()
+
+        payload = schema["components"]["schemas"]
+
+        # Check that nested Email model is promoted to components/schemas
+        assert "Email" in payload
+        assert payload["Email"] == {
+            "title": "Email",
+            "type": "object",
+            "properties": {"addr": {"title": "Addr", "type": "string"}},
+            "required": ["addr"],
+        }
+
+    def test_nested_models_in_publisher_union_should_be_in_schemas(self) -> None:
+        """Test that nested Pydantic models in publisher union types are promoted to components/schemas.
+
+        Fixes issue #2443: Nested Pydantic models are not included in AsyncAPI
+        components/schemas (inplaced instead).
+        """
+        class Email(pydantic.BaseModel):
+            addr: str
+
+        class User(pydantic.BaseModel):
+            name: str = ""
+            id: int
+            email: Email
+
+        class Other(pydantic.BaseModel):
+            id: int
+
+        broker = self.broker_class()
+
+        publisher = broker.publisher("test")
+
+        @publisher
+        def handle0(msg) -> User: ...
+
+        @publisher
+        def handle1(msg) -> Other: ...
+
+        schema = self.get_spec(broker).to_jsonable()
+
+        payload = schema["components"]["schemas"]
+
+        # Check that nested Email model is promoted to components/schemas
+        assert "Email" in payload
+        assert payload["Email"] == {
+            "title": "Email",
+            "type": "object",
+            "properties": {"addr": {"title": "Addr", "type": "string"}},
+            "required": ["addr"],
+        }
+
     def test_pydantic_model_with_example(self) -> None:
         class User(pydantic.BaseModel):
             name: str = ""

--- a/tests/asyncapi/base/v3_0_0/publisher.py
+++ b/tests/asyncapi/base/v3_0_0/publisher.py
@@ -121,31 +121,3 @@ class PublisherTestcase(AsyncAPI300Factory):
         schema = self.get_spec(broker).to_jsonable()
 
         assert schema["channels"] == {}, schema["channels"]
-
-    def test_nested_models_in_one_of_should_be_in_schemas(self) -> None:
-        class Email(pydantic.BaseModel):
-            email: str
-
-        class User(pydantic.BaseModel):
-            email: Email
-            name: str = ""
-            id: int
-
-        broker = self.broker_class()
-
-        publisher = broker.publisher("test")
-
-        @publisher
-        def handle0(msg) -> User: ...
-
-        class Other(pydantic.BaseModel):
-            id: int
-
-        @publisher
-        def handle1(msg) -> Other: ...
-
-        schema = self.get_spec(broker).to_jsonable()
-
-        payload = schema["components"]["schemas"]
-
-        assert "Email" in payload

--- a/tests/asyncapi/base/v3_0_0/publisher.py
+++ b/tests/asyncapi/base/v3_0_0/publisher.py
@@ -121,3 +121,31 @@ class PublisherTestcase(AsyncAPI300Factory):
         schema = self.get_spec(broker).to_jsonable()
 
         assert schema["channels"] == {}, schema["channels"]
+
+    def test_nested_models_in_one_of_should_be_in_schemas(self) -> None:
+        class Email(pydantic.BaseModel):
+            email: str
+
+        class User(pydantic.BaseModel):
+            email: Email
+            name: str = ""
+            id: int
+
+        broker = self.broker_class()
+
+        publisher = broker.publisher("test")
+
+        @publisher
+        def handle0(msg) -> User: ...
+
+        class Other(pydantic.BaseModel):
+            id: int
+
+        @publisher
+        def handle1(msg) -> Other: ...
+
+        schema = self.get_spec(broker).to_jsonable()
+
+        payload = schema["components"]["schemas"]
+
+        assert "Email" in payload


### PR DESCRIPTION
# Description

Promote nested Pydantic model definitions from message payloads (including oneOf cases) into components/schemas and replace inline schemas with $ref references. This resolves incorrect “inplace” embedding of nested models in generated AsyncAPI 3.0 documents.

Not sure if it is a good implementation, however tests are passing

Fixes #2443


## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
