### PR TITLE
configure supervisor to use default logging behaviour

### DIFF
--- a/tests/brokers/supervisor/conftest.py
+++ b/tests/brokers/supervisor/conftest.py
@@ -9,8 +9,10 @@ from faststream._internal.endpoint.subscriber.mixins import TasksMixin
 @pytest.fixture()
 def subscriber_with_task_mixin():
     mock = Mock(spec=TasksMixin)
+    mock._outer_config = Mock()
     mock.tasks = []
     mock.add_task = MethodType(TasksMixin.add_task, mock)
+
     return mock
 
 


### PR DESCRIPTION
# Description

a recent change introduced extra info logs directly using the logger object
rather than utilizing the underlying LoggingState ... this was perhaps done
voluntarily or may be an oversight.

https://github.com/ag2ai/faststream/pull/2408/files#diff-3bdf631deb6eb2f98857d14237f7442915bfcf8e509957718b6fd4bb20bcd399R48

i'm assuming the latter given that it seems to deviate from the norm in the repo.

for my part, i'm just trying to cut down on non-useful log lines such as : 
- 2025-09-25 18:35:49,560 INFO     - callback for Task-22 is being executed...

while retaining more useful ones such as application startup message

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
