### PR TITLE
fix: Reloader for docs serve

### DIFF
--- a/faststream/_internal/cli/supervisors/basereload.py
+++ b/faststream/_internal/cli/supervisors/basereload.py
@@ -66,7 +66,8 @@ class BaseReload:
         self._process.join()
 
     def start_process(self, worker_id: int | None = None) -> SpawnProcess:
-        self._args[1]["worker_id"] = worker_id
+        if isinstance(self._args[1], dict):
+            self._args[1]["worker_id"] = worker_id
         process = get_subprocess(target=self._target, args=self._args)
         process.start()
         return process


### PR DESCRIPTION
docs serve --reload crashes otherwise with

TypeError: 'str' object does not support item assignment on _args[1]['worker_id']

# Description

Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context.

Fixes #2542


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [ x ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ x ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ x ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ x ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
