### PR TITLE
repair doc strings for request method

### DIFF
--- a/faststream/rabbit/testing.py
+++ b/faststream/rabbit/testing.py
@@ -244,7 +244,7 @@ class FakeProducer(AioPikaFastProducer):
         self,
         cmd: "RabbitPublishCommand",
     ) -> "PatchedMessage":
-        """Publish a message to a RabbitMQ queue or exchange."""
+        """Make a synchronous request to RabbitMQ."""
         incoming = build_message(
             message=cmd.body,
             exchange=cmd.exchange,


### PR DESCRIPTION
First, I adjusted the docstring to match the one of RabbitBroker. It makes things a bit less confusion.

Second, I was looking at the code to figure out if TestRabbitBroker could also set the "reply-to" property of the incoming message. Currently, when using with the fake broker, one gets when evaluating `Context('message')`:

```
RabbitMessage(raw_message=PatchedMessage:{'app_id': 'faststream-0.5.48',
...
 'reply_to': None,
```

whereas with the real broker, one gets

```
RabbitMessage(raw_message=IncomingMessage:{'app_id': 'faststream-0.5.48',
...
 'reply_to': 'amq.rabbitmq.reply-to.g1h2AA5yZXBseUA3NzI4NzE3MgAAUkkAAAAAaOPRjw==.ms5TOURI+Qs2Y1biv9El6w==',
```