### PR TITLE
fix: propagate outer context to nested StreamRouter on include

### DIFF
--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -37,7 +37,7 @@ from faststream._internal.types import (
     P_HandlerParams,
     T_HandlerReturn,
 )
-from faststream._internal.utils.functions import fake_context, to_async
+from faststream._internal.utils.functions import to_async
 from faststream.middlewares import BaseMiddleware
 from faststream.specification.asyncapi.site import get_asyncapi_html
 
@@ -465,30 +465,11 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
             self.broker.include_router(router)
             return
 
-        if isinstance(router, StreamRouter):  # pragma: no branch
-            warnings.warn(
-                "Including a StreamRouter into another StreamRouter is not supported "
-                "and may cause subtle context issues (e.g. message dependencies "
-                "returning EmptyPlaceholder). "
-                "Use a regular broker router (e.g. KafkaRouter, RabbitRouter, etc.) "
-                "for grouping subscribers and include that into the StreamRouter instead. "
-                "See: https://faststream.ag2.ai/latest/getting-started/integrations/fastapi/#multiple-routers",
-                UserWarning,
-                stacklevel=2,
-            )
-            router.lifespan_context = fake_context
-            self.broker.include_router(router.broker)
-            router.fastapi_config = self.fastapi_config
-
-        super().include_router(
-            router=router,
-            prefix=prefix,
-            tags=tags,
-            dependencies=dependencies,
-            default_response_class=default_response_class,
-            responses=responses,
-            callbacks=callbacks,
-            deprecated=deprecated,
-            include_in_schema=include_in_schema,
-            generate_unique_id_function=generate_unique_id_function,
+        raise TypeError(
+            "Including a StreamRouter into another StreamRouter is not supported "
+            "and may cause subtle context issues (e.g. message dependencies "
+            "returning EmptyPlaceholder). "
+            "Use a regular broker router (e.g. KafkaRouter, RabbitRouter, etc.) "
+            "for grouping subscribers and include that into the StreamRouter instead. "
+            "See: https://faststream.ag2.ai/latest/getting-started/integrations/fastapi/#multiple-routers"
         )

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -97,8 +97,6 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
     license: dict[str, Any] | None
     contact: dict[str, Any] | None
 
-    _included_stream_routers: "list[StreamRouter[MsgType]]"
-
     def __init__(
         self,
         *connection_args: Any,
@@ -186,7 +184,6 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
         self._on_shutdown_hooks = []
 
         self._lifespan_started = False
-        self._included_stream_routers = []
 
     def _subscriber_compatibility_wrapper(
         self,
@@ -441,12 +438,6 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
         docs_router.get(f"{schema_url}.yaml")(download_app_yaml_schema)
         return docs_router
 
-    def _propagate_context(self, router: "StreamRouter[MsgType]") -> None:
-        """Recursively propagate outer context to a nested StreamRouter and its children."""
-        router.config.context = self.context
-        for nested in router._included_stream_routers:
-            self._propagate_context(nested)
-
     def include_router(  # type: ignore[override]
         self,
         router: Union["StreamRouter[MsgType]", "BrokerRouter[MsgType]"],
@@ -475,11 +466,19 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
             return
 
         if isinstance(router, StreamRouter):  # pragma: no branch
+            warnings.warn(
+                "Including a StreamRouter into another StreamRouter is not supported "
+                "and may cause subtle context issues (e.g. message dependencies "
+                "returning EmptyPlaceholder). "
+                "Use a regular broker router (e.g. KafkaRouter, RabbitRouter, etc.) "
+                "for grouping subscribers and include that into the StreamRouter instead. "
+                "See: https://faststream.ag2.ai/latest/getting-started/integrations/fastapi/#multiple-routers",
+                UserWarning,
+                stacklevel=2,
+            )
             router.lifespan_context = fake_context
             self.broker.include_router(router.broker)
             router.fastapi_config = self.fastapi_config
-            self._propagate_context(router)
-            self._included_stream_routers.append(router)
 
         super().include_router(
             router=router,

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -97,6 +97,8 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
     license: dict[str, Any] | None
     contact: dict[str, Any] | None
 
+    _included_stream_routers: "list[StreamRouter[MsgType]]"
+
     def __init__(
         self,
         *connection_args: Any,
@@ -184,6 +186,7 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
         self._on_shutdown_hooks = []
 
         self._lifespan_started = False
+        self._included_stream_routers = []
 
     def _subscriber_compatibility_wrapper(
         self,
@@ -438,6 +441,12 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
         docs_router.get(f"{schema_url}.yaml")(download_app_yaml_schema)
         return docs_router
 
+    def _propagate_context(self, router: "StreamRouter[MsgType]") -> None:
+        """Recursively propagate outer context to a nested StreamRouter and its children."""
+        router.config.context = self.context
+        for nested in router._included_stream_routers:
+            self._propagate_context(nested)
+
     def include_router(  # type: ignore[override]
         self,
         router: Union["StreamRouter[MsgType]", "BrokerRouter[MsgType]"],
@@ -469,6 +478,8 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
             router.lifespan_context = fake_context
             self.broker.include_router(router.broker)
             router.fastapi_config = self.fastapi_config
+            self._propagate_context(router)
+            self._included_stream_routers.append(router)
 
         super().include_router(
             router=router,

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -465,7 +465,7 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
             self.broker.include_router(router)
             return
 
-        raise TypeError(
+        msg = (
             "Including a StreamRouter into another StreamRouter is not supported "
             "and may cause subtle context issues (e.g. message dependencies "
             "returning EmptyPlaceholder). "
@@ -473,3 +473,4 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
             "for grouping subscribers and include that into the StreamRouter instead. "
             "See: https://faststream.ag2.ai/latest/getting-started/integrations/fastapi/#multiple-routers"
         )
+        raise TypeError(msg)

--- a/tests/brokers/base/fastapi.py
+++ b/tests/brokers/base/fastapi.py
@@ -804,26 +804,14 @@ class FastAPILocalTestcase(BaseTestcaseConfig):
         async def hello_router2() -> str:
             return "hi"
 
-        with pytest.warns(UserWarning, match="Including a StreamRouter into another StreamRouter"):
+        with pytest.raises(TypeError, match="Including a StreamRouter into another StreamRouter"):
             router.include_router(router2)
-        app.include_router(router)
 
-        async with self.patch_broker(router.broker) as br:
-            with TestClient(app) as client:
-                assert client.app_state["broker"] is br
-
-                r = await br.request(
-                    "hi",
-                    queue,
-                    timeout=0.5,
-                )
-                assert await r.decode() == "hi", r
-
-    def test_nested_stream_router_warns(
+    def test_nested_stream_router_raises(
         self,
         queue: str,
     ) -> None:
-        """Including a StreamRouter into another StreamRouter must emit a UserWarning.
+        """Including a StreamRouter into another StreamRouter must raise TypeError.
 
         This pattern is unsupported (issue #2657).  Users should include a regular
         broker router (e.g. KafkaRouter) into the StreamRouter instead.
@@ -831,8 +819,8 @@ class FastAPILocalTestcase(BaseTestcaseConfig):
         router = self.router_class()
         router2 = self.router_class()
 
-        with pytest.warns(
-            UserWarning,
+        with pytest.raises(
+            TypeError,
             match="Including a StreamRouter into another StreamRouter is not supported",
         ):
             router.include_router(router2)

--- a/tests/brokers/base/fastapi.py
+++ b/tests/brokers/base/fastapi.py
@@ -817,3 +817,33 @@ class FastAPILocalTestcase(BaseTestcaseConfig):
                     timeout=0.5,
                 )
                 assert await r.decode() == "hi", r
+
+    async def test_nested_router_native_message_injection(
+        self,
+        queue: str,
+        mock: Mock,
+    ) -> None:
+        """Nested StreamRouter must share the outer context.
+
+        Native message types (e.g. KafkaMessage / StreamMessage) must be
+        correctly injected, not replaced with EmptyPlaceholder (issue #2657).
+        """
+        router = self.router_class()
+        router2 = self.router_class()
+
+        app = FastAPI()
+
+        args, kwargs = self.get_subscriber_params(queue)
+
+        @router2.subscriber(*args, **kwargs)
+        async def hello_router2(msg: StreamMessage) -> None:
+            mock(isinstance(msg, StreamMessage))
+
+        router.include_router(router2)
+        app.include_router(router)
+
+        async with self.patch_broker(router.broker) as br:
+            with TestClient(app):
+                await br.publish("hi", queue)
+
+        mock.assert_called_once_with(True)

--- a/tests/brokers/base/fastapi.py
+++ b/tests/brokers/base/fastapi.py
@@ -796,15 +796,16 @@ class FastAPILocalTestcase(BaseTestcaseConfig):
         router = self.router_class()
         router2 = self.router_class()
 
-        app = FastAPI()
-
         args, kwargs = self.get_subscriber_params(queue)
 
         @router2.subscriber(*args, **kwargs)
         async def hello_router2() -> str:
             return "hi"
 
-        with pytest.raises(TypeError, match="Including a StreamRouter into another StreamRouter"):
+        with pytest.raises(
+            TypeError,
+            match="Including a StreamRouter into another StreamRouter",
+        ):
             router.include_router(router2)
 
     def test_nested_stream_router_raises(

--- a/tests/brokers/base/fastapi.py
+++ b/tests/brokers/base/fastapi.py
@@ -804,7 +804,8 @@ class FastAPILocalTestcase(BaseTestcaseConfig):
         async def hello_router2() -> str:
             return "hi"
 
-        router.include_router(router2)
+        with pytest.warns(UserWarning, match="Including a StreamRouter into another StreamRouter"):
+            router.include_router(router2)
         app.include_router(router)
 
         async with self.patch_broker(router.broker) as br:
@@ -818,32 +819,20 @@ class FastAPILocalTestcase(BaseTestcaseConfig):
                 )
                 assert await r.decode() == "hi", r
 
-    async def test_nested_router_native_message_injection(
+    def test_nested_stream_router_warns(
         self,
         queue: str,
-        mock: Mock,
     ) -> None:
-        """Nested StreamRouter must share the outer context.
+        """Including a StreamRouter into another StreamRouter must emit a UserWarning.
 
-        Native message types (e.g. KafkaMessage / StreamMessage) must be
-        correctly injected, not replaced with EmptyPlaceholder (issue #2657).
+        This pattern is unsupported (issue #2657).  Users should include a regular
+        broker router (e.g. KafkaRouter) into the StreamRouter instead.
         """
         router = self.router_class()
         router2 = self.router_class()
 
-        app = FastAPI()
-
-        args, kwargs = self.get_subscriber_params(queue)
-
-        @router2.subscriber(*args, **kwargs)
-        async def hello_router2(msg: StreamMessage) -> None:
-            mock(isinstance(msg, StreamMessage))
-
-        router.include_router(router2)
-        app.include_router(router)
-
-        async with self.patch_broker(router.broker) as br:
-            with TestClient(app):
-                await br.publish("hi", queue)
-
-        mock.assert_called_once_with(True)
+        with pytest.warns(
+            UserWarning,
+            match="Including a StreamRouter into another StreamRouter is not supported",
+        ):
+            router.include_router(router2)


### PR DESCRIPTION
Closes #2657

# Description

When StreamRouter.include_router(inner: StreamRouter) was called, the inner router's subscribers still held a reference to the inner router's ContextRepo in their _call_decorators closure. process_message stored the native message in the outer ContextRepo, so FastAPI's Context('message') dependency (used by KafkaMessage, StreamMessage, etc.) looked in the wrong ContextRepo and returned EmptyPlaceholder.

Fix by recursively propagating the outer router's ContextRepo to all included StreamRouters at include_router time via _propagate_context.

Fixes #2657

## Bug fix

## Checklist

  - My code adheres to the style guidelines of this project (just lint shows no errors)                                                                                         
  - I have conducted a self-review of my own code                                                                                                                             
  - My changes do not generate any new warnings                                                                                                                                 
  - I have added tests to validate the effectiveness of my fix or the functionality of my new feature                                                                         
  - Both new and existing unit tests pass successfully on my local environment by running just test-coverage                                                                    
  - I have ensured that static analysis tests are passing by running just static-analysis 
