### PR TITLE
refactor: parser codec protocols

### DIFF
--- a/faststream/_internal/parser.py
+++ b/faststream/_internal/parser.py
@@ -1,0 +1,49 @@
+from abc import abstractmethod
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from faststream._internal.basic_types import DecodedMessage
+    from faststream.message import StreamMessage
+
+MsgType = TypeVar("MsgType")
+
+
+class ParserProto(Protocol[MsgType]):
+    """Protocol for parsing raw messages into StreamMessage."""
+
+    @abstractmethod
+    async def parse_message(self, message: MsgType) -> "StreamMessage[MsgType]":
+        """Parse a raw message into a StreamMessage."""
+        ...
+
+
+class DecoderProto(Protocol):
+    """Protocol for decoding StreamMessage into DecodedMessage."""
+
+    @abstractmethod
+    async def decode_message(self, msg: "StreamMessage[Any]") -> "DecodedMessage":
+        """Decode a StreamMessage into a DecodedMessage."""
+        ...
+
+
+class BatchParserProto(Protocol[MsgType]):
+    """Protocol for parsing a batch of raw messages into StreamMessage."""
+
+    @abstractmethod
+    async def parse_batch(
+        self, messages: Sequence[MsgType]
+    ) -> "StreamMessage[Sequence[MsgType]]":
+        """Parse a batch of raw messages into a StreamMessage."""
+        ...
+
+
+class BatchDecoderProto(Protocol[MsgType]):
+    """Protocol for decoding a batch of StreamMessage into list of DecodedMessage."""
+
+    @abstractmethod
+    async def decode_batch(
+        self, msg: "StreamMessage[Sequence[MsgType]]"
+    ) -> list["DecodedMessage"]:
+        """Decode a batch of StreamMessage into a list of DecodedMessage."""
+        ...

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -51,9 +51,8 @@ def compile_path(
     return regex, original_path
 
 
-def match_path(pattern: "Pattern[str] | None", subject: str) -> "dict[str, Any]":
+def match_path(pattern: Pattern[str] | None, subject: str) -> dict[str, Any]:
     """Match subject against pattern and return named groups, or {} if no match."""
-    # Redis callers must check message.get("pattern") guard before calling this
     if pattern is not None and (match := pattern.match(subject)):
         return match.groupdict()
     return {}

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -1,6 +1,7 @@
 import re
 from collections.abc import Callable
 from re import Pattern
+from typing import Any
 
 from faststream.exceptions import SetupError
 
@@ -48,3 +49,11 @@ def compile_path(
 
     original_path += path[idx:]
     return regex, original_path
+
+
+def match_path(pattern: "Pattern[str] | None", subject: str) -> "dict[str, Any]":
+    """Match subject against pattern and return named groups, or {} if no match."""
+    # Redis callers must check message.get("pattern") guard before calling this
+    if pattern is not None and (match := pattern.match(subject)):
+        return match.groupdict()
+    return {}

--- a/faststream/confluent/parser.py
+++ b/faststream/confluent/parser.py
@@ -54,7 +54,7 @@ class AsyncConfluentParser:
             is_manual=self.is_manual,
         )
 
-    async def parse_message_batch(
+    async def parse_batch(
         self,
         message: tuple["Message", ...],
     ) -> KafkaMessage:
@@ -95,7 +95,7 @@ class AsyncConfluentParser:
         """Decodes a message."""
         return decode_message(msg)
 
-    async def decode_message_batch(
+    async def decode_batch(
         self,
         msg: "StreamMessage[tuple[Message, ...]]",
     ) -> "DecodedMessage":

--- a/faststream/confluent/subscriber/usecase.py
+++ b/faststream/confluent/subscriber/usecase.py
@@ -266,8 +266,8 @@ class BatchSubscriber(LogicSubscriber[tuple[Message, ...]]):
         max_records: int | None,
     ) -> None:
         self.parser = AsyncConfluentParser(is_manual=not config.ack_first)
-        config.decoder = self.parser.decode_message_batch
-        config.parser = self.parser.parse_message_batch
+        config.decoder = self.parser.decode_batch
+        config.parser = self.parser.parse_batch
         super().__init__(config, specification, calls)
 
         self.max_records = max_records

--- a/faststream/kafka/parser.py
+++ b/faststream/kafka/parser.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
+from faststream._internal.utils.path import match_path
 from faststream.kafka.message import (
     FAKE_CONSUMER,
     ConsumerProtocol,
@@ -7,7 +8,6 @@ from faststream.kafka.message import (
     KafkaRawMessage,
 )
 from faststream.message import decode_message
-from faststream._internal.utils.path import match_path
 
 if TYPE_CHECKING:
     from re import Pattern

--- a/faststream/kafka/parser.py
+++ b/faststream/kafka/parser.py
@@ -7,6 +7,7 @@ from faststream.kafka.message import (
     KafkaRawMessage,
 )
 from faststream.message import decode_message
+from faststream._internal.utils.path import match_path
 
 if TYPE_CHECKING:
     from re import Pattern
@@ -48,7 +49,7 @@ class AioKafkaParser:
             message_id=f"{message.offset}-{message.timestamp}",
             correlation_id=headers.get("correlation_id"),
             raw_message=message,
-            path=self.get_path(message.topic),
+            path=match_path(self.regex, message.topic),
             consumer=getattr(message, "consumer", self._consumer),
         )
 
@@ -59,14 +60,9 @@ class AioKafkaParser:
         """Decodes a message."""
         return decode_message(msg)
 
-    def get_path(self, topic: str) -> dict[str, str]:
-        if self.regex and (match := self.regex.match(topic)):
-            return match.groupdict()
-        return {}
-
 
 class AioKafkaBatchParser(AioKafkaParser):
-    async def parse_message(
+    async def parse_batch(
         self,
         message: tuple["ConsumerRecord", ...],
     ) -> "StreamMessage[tuple[ConsumerRecord, ...]]":
@@ -92,11 +88,11 @@ class AioKafkaBatchParser(AioKafkaParser):
             message_id=f"{first.offset}-{last.offset}-{first.timestamp}",
             correlation_id=headers.get("correlation_id"),
             raw_message=message,
-            path=self.get_path(first.topic),
+            path=match_path(self.regex, first.topic),
             consumer=self._consumer,
         )
 
-    async def decode_message(
+    async def decode_batch(
         self,
         msg: "StreamMessage[tuple[ConsumerRecord, ...]]",
     ) -> "DecodedMessage":

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -335,8 +335,8 @@ class BatchSubscriber(LogicSubscriber[tuple["ConsumerRecord", ...]]):
             msg_class=KafkaMessage if config.ack_first else KafkaAckableMessage,
             regex=reg,
         )
-        config.decoder = self.parser.decode_message
-        config.parser = self.parser.parse_message
+        config.decoder = self.parser.decode_batch
+        config.parser = self.parser.parse_batch
         super().__init__(config, specification, calls)
 
         self.batch_timeout_ms = batch_timeout_ms

--- a/faststream/nats/parser.py
+++ b/faststream/nats/parser.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from faststream._internal.utils.path import match_path
 from faststream.message import (
     StreamMessage,
     decode_message,
@@ -29,20 +30,7 @@ class NatsBaseParser:
         pattern: str,
     ) -> None:
         path_re, _ = compile_nats_wildcard(pattern)
-        self.__path_re = path_re
-
-    def get_path(
-        self,
-        subject: str,
-    ) -> dict[str, Any] | None:
-        path: dict[str, Any] | None = None
-
-        if (path_re := self.__path_re) is not None and (
-            match := path_re.match(subject)
-        ) is not None:
-            path = match.groupdict()
-
-        return path
+        self._path_re = path_re
 
     async def decode_message(
         self,
@@ -62,11 +50,8 @@ class NatsParser(NatsBaseParser):
     async def parse_message(
         self,
         message: "Msg",
-        *,
-        path: dict[str, Any] | None = None,
     ) -> "StreamMessage[Msg]":
-        if path is None:
-            path = self.get_path(message.subject)
+        path = match_path(self._path_re, message.subject)
 
         headers = message.header or {}
 
@@ -76,7 +61,7 @@ class NatsParser(NatsBaseParser):
         return NatsMessage(
             raw_message=message,
             body=message.data,
-            path=path or {},
+            path=path,
             reply_to=message.reply,
             headers=headers,
             content_type=headers.get("content-type", ""),
@@ -91,18 +76,15 @@ class JsParser(NatsBaseParser):
     async def parse_message(
         self,
         message: "Msg",
-        *,
-        path: dict[str, Any] | None = None,
     ) -> "StreamMessage[Msg]":
-        if path is None:
-            path = self.get_path(message.subject)
+        path = match_path(self._path_re, message.subject)
 
         headers = message.header or {}
 
         return NatsMessage(
             raw_message=message,
             body=message.data,
-            path=path or {},
+            path=path,
             reply_to=headers.get("reply_to", ""),  # differ from core
             headers=headers,
             content_type=headers.get("content-type"),
@@ -122,21 +104,21 @@ class BatchParser(JsParser):
         batch_headers: list[dict[str, str]] = []
 
         if message:
-            path = self.get_path(message[0].subject)
+            path = match_path(self._path_re, message[0].subject)
 
             for m in message:
                 batch_headers.append(m.headers or {})
                 body.append(m.data)
 
         else:
-            path = None
+            path = {}
 
         headers = next(iter(batch_headers), {})
 
         return NatsBatchMessage(
             raw_message=message,
             body=body,
-            path=path or {},
+            path=path,
             headers=headers,
             batch_headers=batch_headers,
         )
@@ -147,11 +129,8 @@ class BatchParser(JsParser):
     ) -> list["DecodedMessage"]:
         data: list[DecodedMessage] = []
 
-        path: dict[str, Any] | None = None
         for m in msg.raw_message:
-            one_msg = await self.parse_message(m, path=path)
-            path = one_msg.path
-
+            one_msg = await self.parse_message(m)
             data.append(decode_message(one_msg))
 
         return data
@@ -165,7 +144,7 @@ class KvParser(NatsBaseParser):
         return NatsKvMessage(
             raw_message=msg,
             body=msg.value,
-            path=self.get_path(msg.key) or {},
+            path=match_path(self._path_re, msg.key),
         )
 
 

--- a/faststream/rabbit/parser.py
+++ b/faststream/rabbit/parser.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 from aio_pika import Message
 from aio_pika.abc import DeliveryMode
 
+from faststream._internal.utils.path import match_path
 from faststream.message import (
     StreamMessage,
     decode_message,
@@ -34,12 +35,7 @@ class AioPikaParser:
         message: "IncomingMessage",
     ) -> StreamMessage["IncomingMessage"]:
         """Parses an incoming message and returns a RabbitMessage object."""
-        if (path_re := self.pattern) and (
-            match := path_re.match(message.routing_key or "")
-        ):
-            path = match.groupdict()
-        else:
-            path = {}
+        path = match_path(self.pattern, message.routing_key or "")
 
         return RabbitMessage(
             body=message.body,

--- a/faststream/redis/parser/parsers.py
+++ b/faststream/redis/parser/parsers.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, Protocol
 from faststream._internal._compat import dump_json, json_loads
 from faststream._internal.basic_types import DecodedMessage
 from faststream._internal.constants import EMPTY, ContentTypes
+from faststream._internal.utils.path import match_path
 from faststream.message import decode_message, gen_cor_id
 from faststream.redis.message import (
     RedisBatchListMessage,
@@ -55,7 +56,9 @@ class SimpleParser:
         return self.msg_class(
             raw_message=message,
             body=data,
-            path=self.get_path(message),
+            path=match_path(self.pattern, message["channel"])
+            if message.get("pattern")
+            else {},
             headers=headers,
             batch_headers=batch_headers,
             reply_to=headers.get("reply_to", ""),
@@ -69,16 +72,6 @@ class SimpleParser:
         message: Mapping[str, Any],
     ) -> tuple[bytes, dict[str, Any], list[dict[str, Any]]]:
         return (*self.config.message_format.parse(message["data"]), [])
-
-    def get_path(self, message: Mapping[str, Any]) -> dict[str, Any]:
-        if (
-            (path_re := self.pattern)
-            and message.get("pattern")
-            and (match := path_re.match(message["channel"]))
-        ):
-            return match.groupdict()
-
-        return {}
 
     async def decode_message(
         self,

--- a/faststream/redis/parser/parsers.py
+++ b/faststream/redis/parser/parsers.py
@@ -56,6 +56,8 @@ class SimpleParser:
         return self.msg_class(
             raw_message=message,
             body=data,
+            # Only pattern-subscribed messages have "pattern" set;
+            # guard here before calling match_path.
             path=match_path(self.pattern, message["channel"])
             if message.get("pattern")
             else {},


### PR DESCRIPTION
# Parser & Codec Interface Unification

First part of #2837 

## Motivation

Every broker in FastStream has its own parser class (`AioKafkaParser`, `AsyncConfluentParser`, `AioPikaParser`, `NatsParser`, `SimpleParser`, etc.), but none of them share a formal interface. They all implement `parse_message` and `decode_message` by convention — duck-typed, with no Protocol or ABC enforcing the contract. Batch parsing is worse: Kafka overrides `parse_message` with an incompatible signature, Confluent calls its methods `parse_message_batch`/`decode_message_batch`, and NATS uses `parse_batch`/`decode_batch`.

Path extraction (`get_path`) is scattered across four brokers with four different signatures — Kafka takes a `str`, NATS takes a `str` but returns `None` on miss, Redis takes the full message mapping, and Rabbit does it inline. This inconsistency blocks defining a common parser interface.

This PR eliminates these inconsistencies to lay the groundwork for user-defined custom parser and encoder classes in future PRs.

## What Changed

### 1. `match_path()` utility function

**File**: `faststream/_internal/utils/path.py`

A new function that consolidates the duplicated path-extraction logic that existed across four broker parsers. Every broker's `get_path` method was doing the same thing: `pattern.match(subject).groupdict()`. Now they all call `match_path()` instead.

#### How it works

`match_path` is the runtime complement to the existing `compile_path` function. While `compile_path` runs at subscriber setup time to convert a pattern string like `"logs.{level}"` into a compiled regex with named capture groups, `match_path` runs at message time to apply that regex against the actual routing key/topic/subject of an incoming message.

```python
def match_path(pattern: Pattern[str] | None, subject: str) -> dict[str, Any]:
```

**Parameters**:
- `pattern` — A compiled regex produced by `compile_path` (or `compile_nats_wildcard` for NATS). Can be `None` when the subscriber's topic has no path variables (e.g., a plain topic like `"orders"` rather than `"orders.{region}"`).
- `subject` — The routing key from the incoming message. This is `message.topic` for Kafka, `message.subject` for NATS, `message.routing_key` for RabbitMQ, or `message["channel"]` for Redis.

**Return value**: Always returns `dict[str, Any]`. On a successful match, returns the named groups from the regex (e.g., `{"level": "error"}` for subject `"logs.error"` against pattern `"logs.{level}"`). On no match or when `pattern` is `None`, returns an empty dict `{}`.

**Why it never returns `None`**: The previous NATS implementation returned `None` on miss, while Kafka and Redis returned `{}`. Standardizing on `{}` means callers never need `path or {}` guards — the result goes directly into `StreamMessage.path`.

**Redis-specific note**: Redis pub/sub is unique because only pattern-subscribed messages carry a `"pattern"` field in the message dict. The guard for this (`message.get("pattern")`) stays at the Redis call site — `match_path` itself remains broker-agnostic.

### 2. Protocol definitions

**File**: `faststream/_internal/parser.py` (new)

Four `typing.Protocol` interfaces that formalize the parser/decoder contract:

| Protocol | Method | Purpose |
|---|---|---|
| `ParserProto[MsgType]` | `parse_message(message: MsgType) → StreamMessage[MsgType]` | Convert raw broker message to StreamMessage |
| `DecoderProto` | `decode_message(msg: StreamMessage[Any]) → DecodedMessage` | Deserialize message body to Python object |
| `BatchParserProto[MsgType]` | `parse_batch(messages: Sequence[MsgType]) → StreamMessage[Sequence[MsgType]]` | Convert batch of raw messages to StreamMessage |
| `BatchDecoderProto[MsgType]` | `decode_batch(msg: StreamMessage[Sequence[MsgType]]) → list[DecodedMessage]` | Deserialize batch message bodies |

These follow the existing `ProducerProto` pattern — `typing.Protocol` with `@abstractmethod`, generic over message type where applicable. They are not `@runtime_checkable`; they exist for static type checking.

Parser and decoder are separate protocols because they're already consumed as independent callables at the subscriber wiring level (`config.parser = self.parser.parse_message`, `config.decoder = self.parser.decode_message`). This separation reflects the existing architecture.


## What Did NOT Change

- `ParserComposition` in `faststream/_internal/endpoint/utils.py` — the runtime wiring that wraps custom user parsers with defaults. Untouched.
- `CustomCallable` type alias — the public API for `broker.subscriber(parser=...)`. Untouched.
- Shared `decode_message()` utility in `faststream/message/utils.py` — the content-type based JSON/text decoder. Untouched.
- MQTT parser — no path support, no batch methods. Untouched.
- `_setup(consumer)` on Kafka/Confluent parsers — lifecycle wiring. Untouched.

## Future Direction

This PR is the foundation for enabling **user-defined custom parser and encoder classes**. Currently, users can only pass callables via `broker.subscriber(parser=...)`. The next PRs will:

1. **Accept `ParserProto`/`DecoderProto` instances** as custom parsers — not just callables. `ParserComposition` will be updated to detect whether the custom parser is a callable or a Protocol-conformant object and wire it accordingly.

2. **Standardize the encoder side** — `encode_message` currently only exists as a static method on `AioPikaParser`. Future work will define an `EncoderProto` and give each broker a formal encoding interface, enabling custom serialization strategies (e.g., Protobuf, Avro, MessagePack) via class-based encoders.

3. **Unify batch parsing further** — with consistent `parse_batch`/`decode_batch` naming across all brokers, a single `BatchParserProto`-conformant class can be swapped in regardless of the broker.

The key insight is that parsers and decoders are already consumed as independent callables at the wiring level. The Protocols formalize what's already happening, making it possible to type-check custom implementations and provide clear extension points without changing the runtime architecture.
