### PR TITLE
feat: codec wiring unification

### DIFF
--- a/faststream/_internal/configs/broker.py
+++ b/faststream/_internal/configs/broker.py
@@ -12,6 +12,7 @@ from faststream._internal.producer import ProducerProto, ProducerUnset
 if TYPE_CHECKING:
     from fast_depends.dependencies import Dependant
 
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import BrokerMiddleware, CustomCallable
     from faststream.middlewares import AckPolicy
 
@@ -24,6 +25,7 @@ class BrokerConfig:
     broker_middlewares: Sequence["BrokerMiddleware[Any]"] = ()
     broker_parser: Optional["CustomCallable"] = None
     broker_decoder: Optional["CustomCallable"] = None
+    broker_codec: Optional["CodecProto"] = None
 
     producer: "ProducerProto[Any]" = field(default_factory=ProducerUnset)
     logger: "LoggerState" = field(default_factory=LoggerState)
@@ -123,6 +125,13 @@ class ConfigComposition(Generic[BrokerConfigType]):
         for c in self.configs:
             if c.broker_decoder:
                 return c.broker_decoder
+        return None
+
+    @property
+    def broker_codec(self) -> Optional["CodecProto"]:
+        for c in self.configs:
+            if c.broker_codec:
+                return c.broker_codec
         return None
 
     @property

--- a/faststream/_internal/configs/broker.py
+++ b/faststream/_internal/configs/broker.py
@@ -64,7 +64,7 @@ BrokerConfigType = TypeVar313(
 ConfigType = Union["ConfigComposition[Any]", "BrokerConfigType", BrokerConfig]
 
 
-class ConfigComposition(Generic[BrokerConfigType]):
+class ConfigComposition(Generic[BrokerConfigType]):  # noqa: PLR0904
     def __init__(self, config: BrokerConfigType) -> None:
         self.configs: tuple[ConfigType, ...] = (config,)
 

--- a/faststream/_internal/endpoint/subscriber/usecase.py
+++ b/faststream/_internal/endpoint/subscriber/usecase.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from faststream._internal.configs import SubscriberUsecaseConfig
     from faststream._internal.endpoint.call_wrapper import HandlerCallWrapper
     from faststream._internal.endpoint.publisher import PublisherProto
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         AsyncFilter,
         BrokerMiddleware,
@@ -58,6 +59,7 @@ class _CallOptions(NamedTuple):
     parser: Optional["CustomCallable"]
     decoder: Optional["CustomCallable"]
     dependencies: Iterable["Dependant"]
+    codec: Optional["CodecProto"] = None
 
 
 class SubscriberUsecase(Endpoint, Generic[MsgType]):
@@ -90,6 +92,7 @@ class SubscriberUsecase(Endpoint, Generic[MsgType]):
             parser=None,
             decoder=None,
             dependencies=(),
+            codec=None,
         )
 
         self._call_decorators: tuple[Decorator, ...] = ()
@@ -193,11 +196,13 @@ class SubscriberUsecase(Endpoint, Generic[MsgType]):
         parser_: Optional["CustomCallable"],
         decoder_: Optional["CustomCallable"],
         dependencies_: Iterable["Dependant"],
+        codec_: Optional["CodecProto"] = None,
     ) -> Self:
         self._call_options = _CallOptions(
             parser=parser_,
             decoder=decoder_,
             dependencies=dependencies_,
+            codec=codec_,
         )
         return self
 

--- a/faststream/_internal/endpoint/subscriber/usecase.py
+++ b/faststream/_internal/endpoint/subscriber/usecase.py
@@ -147,12 +147,23 @@ class SubscriberUsecase(Endpoint, Generic[MsgType]):
         else:
             async_parser = self._parser
 
-        if decoder := (
+        # Codec takes priority over legacy decoder.
+        # Having both is an error — it's ambiguous which takes effect.
+        codec = self._call_options.codec or self._outer_config.broker_codec
+        decoder = (
             item_decoder
             or self._call_options.decoder
             or self._outer_config.broker_decoder
-        ):
-            async_decoder: AsyncCallable = ParserComposition(decoder, self._decoder)
+        )
+
+        if codec and decoder:
+            msg = "Cannot use both 'codec' and 'decoder' — 'codec' replaces 'decoder'."
+            raise ValueError(msg)
+
+        if codec:
+            async_decoder: AsyncCallable = codec.decode
+        elif decoder:
+            async_decoder = ParserComposition(decoder, self._decoder)
         else:
             async_decoder = self._decoder
 

--- a/faststream/_internal/parser.py
+++ b/faststream/_internal/parser.py
@@ -2,8 +2,12 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
+from faststream.message.utils import decode_message, encode_message
+
 if TYPE_CHECKING:
-    from faststream._internal.basic_types import DecodedMessage
+    from fast_depends.library.serializer import SerializerProto
+
+    from faststream._internal.basic_types import DecodedMessage, SendableMessage
     from faststream.message import StreamMessage
 
 MsgType = TypeVar("MsgType")
@@ -47,3 +51,35 @@ class BatchDecoderProto(Protocol[MsgType]):
     ) -> list["DecodedMessage"]:
         """Decode a batch of StreamMessage into a list of DecodedMessage."""
         ...
+
+
+class CodecProto(Protocol):
+    """Protocol for encoding and decoding message bodies."""
+
+    @abstractmethod
+    async def decode(self, msg: "StreamMessage[Any]") -> "DecodedMessage":
+        """Decode a StreamMessage body into a Python object."""
+        ...
+
+    @abstractmethod
+    async def encode(
+        self,
+        msg: "SendableMessage",
+        serializer: "SerializerProto | None" = None,
+    ) -> tuple[bytes, str | None]:
+        """Encode a Python object into bytes and content_type."""
+        ...
+
+
+class DefaultCodec:
+    """Default codec that delegates to the shared encode_message/decode_message functions."""
+
+    async def decode(self, msg: "StreamMessage[Any]") -> "DecodedMessage":
+        return decode_message(msg)
+
+    async def encode(
+        self,
+        msg: "SendableMessage",
+        serializer: "SerializerProto | None" = None,
+    ) -> tuple[bytes, str | None]:
+        return encode_message(msg, serializer)

--- a/faststream/confluent/__init__.py
+++ b/faststream/confluent/__init__.py
@@ -3,11 +3,9 @@ from typing import TYPE_CHECKING
 from faststream._internal.testing.app import TestApp
 
 if TYPE_CHECKING:
-    from confluent_kafka import Message as ConfluentMessage
-
     from faststream._internal.parser import ParserProto
 
-    ConfluentParserType = ParserProto["ConfluentMessage"]
+    ConfluentParserType = ParserProto["Message"]  # type: ignore[name-defined]
 
 try:
     from .annotations import KafkaMessage

--- a/faststream/confluent/__init__.py
+++ b/faststream/confluent/__init__.py
@@ -1,4 +1,13 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.testing.app import TestApp
+
+if TYPE_CHECKING:
+    from confluent_kafka import Message as ConfluentMessage
+
+    from faststream._internal.parser import ParserProto
+
+    ConfluentParserType = ParserProto["ConfluentMessage"]
 
 try:
     from .annotations import KafkaMessage
@@ -16,6 +25,7 @@ except ImportError as e:
     raise ImportError(INSTALL_FASTSTREAM_CONFLUENT) from e
 
 __all__ = (
+    "ConfluentParserType",
     "KafkaBroker",
     "KafkaMessage",
     "KafkaPublishCommand",

--- a/faststream/confluent/broker/broker.py
+++ b/faststream/confluent/broker/broker.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
         LoggerProto,
         SendableMessage,
     )
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -97,6 +98,7 @@ class KafkaBroker(
         graceful_timeout: float | None = 15.0,
         ack_policy: AckPolicy = EMPTY,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         parser: Optional["CustomCallable"] = None,
         dependencies: Iterable["Dependant"] = (),
         middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
@@ -200,10 +202,11 @@ class KafkaBroker(
                 explicitly set by the user it will be chosen.
             transactional_id: Transactional ID for the producer.
             transaction_timeout_ms: Transaction timeout in milliseconds.
-            graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-            ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
-            decoder: Custom decoder object.
-            parser: Custom parser object.
+             graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
+             ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
+             decoder: Custom decoder object.
+             codec: Custom codec object.
+             parser: Custom parser object.
             dependencies: Dependencies to apply to all broker subscribers.
             middlewares: Middlewares to apply to all broker publishers/subscribers.
             routers: Routers to apply to broker.
@@ -272,6 +275,7 @@ class KafkaBroker(
                 ),
                 # both args,
                 broker_decoder=decoder,
+                broker_codec=codec,
                 broker_parser=parser,
                 broker_middlewares=middlewares,
                 logger=make_kafka_logger_state(

--- a/faststream/confluent/broker/broker.py
+++ b/faststream/confluent/broker/broker.py
@@ -193,23 +193,23 @@ class KafkaBroker(
                 may want to reduce the number of requests even under moderate load.
                 This setting accomplishes this by adding a small amount of
                 artificial delay; that is, if first request is processed faster,
-                than `linger_ms`, producer will wait ``linger_ms - process_time``.
-            enable_idempotence: When set to `True`, the producer will
-                ensure that exactly one copy of each message is written in the
-                stream. If `False`, producer retries due to broker failures,
-                etc., may write duplicates of the retried message in the stream.
-                Note that enabling idempotence acks to set to ``all``. If it is not
-                explicitly set by the user it will be chosen.
-            transactional_id: Transactional ID for the producer.
-            transaction_timeout_ms: Transaction timeout in milliseconds.
+                 than `linger_ms`, producer will wait ``linger_ms - process_time``.
+             enable_idempotence: When set to `True`, the producer will
+                 ensure that exactly one copy of each message is written in the
+                 stream. If `False`, producer retries due to broker failures,
+                 etc., may write duplicates of the retried message in the stream.
+                 Note that enabling idempotence acks to set to ``all``. If it is not
+                 explicitly set by the user it will be chosen.
+             transactional_id: Transactional ID for the producer.
+             transaction_timeout_ms: Transaction timeout in milliseconds.
              graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
              ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
              decoder: Custom decoder object.
              codec: Custom codec object.
              parser: Custom parser object.
-            dependencies: Dependencies to apply to all broker subscribers.
-            middlewares: Middlewares to apply to all broker publishers/subscribers.
-            routers: Routers to apply to broker.
+             dependencies: Dependencies to apply to all broker subscribers.
+             middlewares: Middlewares to apply to all broker publishers/subscribers.
+             routers: Routers to apply to broker.
             security: Security options to connect broker and generate AsyncAPI server security information.
             specification_url: AsyncAPI hardcoded server addresses. Use `servers` if not specified.
             protocol: AsyncAPI server protocol.

--- a/faststream/confluent/broker/broker.py
+++ b/faststream/confluent/broker/broker.py
@@ -193,23 +193,23 @@ class KafkaBroker(
                 may want to reduce the number of requests even under moderate load.
                 This setting accomplishes this by adding a small amount of
                 artificial delay; that is, if first request is processed faster,
-                 than `linger_ms`, producer will wait ``linger_ms - process_time``.
-             enable_idempotence: When set to `True`, the producer will
-                 ensure that exactly one copy of each message is written in the
-                 stream. If `False`, producer retries due to broker failures,
-                 etc., may write duplicates of the retried message in the stream.
-                 Note that enabling idempotence acks to set to ``all``. If it is not
-                 explicitly set by the user it will be chosen.
-             transactional_id: Transactional ID for the producer.
-             transaction_timeout_ms: Transaction timeout in milliseconds.
-             graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-             ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
-             decoder: Custom decoder object.
-             codec: Custom codec object.
-             parser: Custom parser object.
-             dependencies: Dependencies to apply to all broker subscribers.
-             middlewares: Middlewares to apply to all broker publishers/subscribers.
-             routers: Routers to apply to broker.
+                than `linger_ms`, producer will wait ``linger_ms - process_time``.
+            enable_idempotence: When set to `True`, the producer will
+                ensure that exactly one copy of each message is written in the
+                stream. If `False`, producer retries due to broker failures,
+                etc., may write duplicates of the retried message in the stream.
+                Note that enabling idempotence acks to set to ``all``. If it is not
+                explicitly set by the user it will be chosen.
+            transactional_id: Transactional ID for the producer.
+            transaction_timeout_ms: Transaction timeout in milliseconds.
+            graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
+            ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
+            decoder: Custom decoder object.
+            codec: Custom codec object.
+            parser: Custom parser object.
+            dependencies: Dependencies to apply to all broker subscribers.
+            middlewares: Middlewares to apply to all broker publishers/subscribers.
+            routers: Routers to apply to broker.
             security: Security options to connect broker and generate AsyncAPI server security information.
             specification_url: AsyncAPI hardcoded server addresses. Use `servers` if not specified.
             protocol: AsyncAPI server protocol.

--- a/faststream/confluent/broker/registrator.py
+++ b/faststream/confluent/broker/registrator.py
@@ -356,43 +356,43 @@ class KafkaRegistrator(
                 should be set no higher than 1/3 of that value. It can be
                 adjusted even lower to control the expected time for normal
                 rebalances.
-             isolation_level: Controls how to read messages written
-                 transactionally.
+            isolation_level: Controls how to read messages written
+                transactionally.
 
                  * `read_committed`, batch consumer will only return
-                 transactional messages which have been committed.
+                transactional messages which have been committed.
 
                  * `read_uncommitted` (the default), batch consumer will
-                 return all messages, even transactional messages which have been
-                 aborted.
+                return all messages, even transactional messages which have been
+                aborted.
 
-                 Non-transactional messages will be returned unconditionally in
-                 either mode.
+                Non-transactional messages will be returned unconditionally in
+                either mode.
 
-                 Messages will always be returned in offset order. Hence, in
+                Messages will always be returned in offset order. Hence, in
                  `read_committed` mode, batch consumer will only return
-                 messages up to the last stable offset (ALSO), which is the one less
-                 than the offset of the first open transaction. In particular any
-                 messages appearing after messages belonging to ongoing transactions
-                 will be withheld until the relevant transaction has been completed.
-                 As a result, `read_committed` consumers will not be able to read up
-                 to the high watermark when there are in flight transactions.
-                 Further, when in `read_committed` the seek_to_end method will
-                 return the ALSO. See method docs below.
-             batch: Whether to consume messages in batches or not.
-             max_records: Number of messages to consume as one batch.
-             on_assign: Callback called when partitions are assigned to the consumer
-                 during a rebalance. Receives ``(consumer, partitions)`` arguments.
-             on_revoke: Callback called when partitions are revoked from the consumer
-                 during a rebalance. Receives ``(consumer, partitions)`` arguments.
-             on_lost: Callback called when partitions are lost (e.g., due to session
-                 timeout). Receives ``(consumer, partitions)`` arguments.
-             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-             parser: Parser to map original **Message** object to FastStream one.
-             decoder: Function to decode FastStream msg bytes body to python objects.
-             codec: Custom codec object.
-             middlewares: Subscriber middlewares to wrap incoming message processing.
-             no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
+                messages up to the last stable offset (ALSO), which is the one less
+                than the offset of the first open transaction. In particular any
+                messages appearing after messages belonging to ongoing transactions
+                will be withheld until the relevant transaction has been completed.
+                As a result, `read_committed` consumers will not be able to read up
+                to the high watermark when there are in flight transactions.
+                Further, when in `read_committed` the seek_to_end method will
+                return the ALSO. See method docs below.
+            batch: Whether to consume messages in batches or not.
+            max_records: Number of messages to consume as one batch.
+            on_assign: Callback called when partitions are assigned to the consumer
+                during a rebalance. Receives ``(consumer, partitions)`` arguments.
+            on_revoke: Callback called when partitions are revoked from the consumer
+                during a rebalance. Receives ``(consumer, partitions)`` arguments.
+            on_lost: Callback called when partitions are lost (e.g., due to session
+                timeout). Receives ``(consumer, partitions)`` arguments.
+            dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+            parser: Parser to map original **Message** object to FastStream one.
+            decoder: Function to decode FastStream msg bytes body to python objects.
+            codec: Custom codec object.
+            middlewares: Subscriber middlewares to wrap incoming message processing.
+            no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
             ack_policy: Acknowledgement policy for the subscriber.
             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
             title: Specification subscriber object title.

--- a/faststream/confluent/broker/registrator.py
+++ b/faststream/confluent/broker/registrator.py
@@ -23,6 +23,7 @@ from faststream.middlewares import AckPolicy
 if TYPE_CHECKING:
     from fast_depends.dependencies import Dependant
 
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -78,6 +79,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -121,6 +123,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -164,6 +167,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -207,6 +211,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: int | None = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -254,6 +259,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         # Specification args
@@ -448,6 +454,7 @@ class KafkaRegistrator(
         return subscriber.add_call(
             parser_=parser or self._parser,
             decoder_=decoder or self._decoder,
+            codec_=codec,
             dependencies_=dependencies,
         )
 

--- a/faststream/confluent/broker/registrator.py
+++ b/faststream/confluent/broker/registrator.py
@@ -356,42 +356,43 @@ class KafkaRegistrator(
                 should be set no higher than 1/3 of that value. It can be
                 adjusted even lower to control the expected time for normal
                 rebalances.
-            isolation_level: Controls how to read messages written
-                transactionally.
+             isolation_level: Controls how to read messages written
+                 transactionally.
 
-                * `read_committed`, batch consumer will only return
-                transactional messages which have been committed.
+                 * `read_committed`, batch consumer will only return
+                 transactional messages which have been committed.
 
-                * `read_uncommitted` (the default), batch consumer will
-                return all messages, even transactional messages which have been
-                aborted.
+                 * `read_uncommitted` (the default), batch consumer will
+                 return all messages, even transactional messages which have been
+                 aborted.
 
-                Non-transactional messages will be returned unconditionally in
-                either mode.
+                 Non-transactional messages will be returned unconditionally in
+                 either mode.
 
-                Messages will always be returned in offset order. Hence, in
-                `read_committed` mode, batch consumer will only return
-                messages up to the last stable offset (ALSO), which is the one less
-                than the offset of the first open transaction. In particular any
-                messages appearing after messages belonging to ongoing transactions
-                will be withheld until the relevant transaction has been completed.
-                As a result, `read_committed` consumers will not be able to read up
-                to the high watermark when there are in flight transactions.
-                Further, when in `read_committed` the seek_to_end method will
-                return the ALSO. See method docs below.
-            batch: Whether to consume messages in batches or not.
-            max_records: Number of messages to consume as one batch.
-            on_assign: Callback called when partitions are assigned to the consumer
-                during a rebalance. Receives ``(consumer, partitions)`` arguments.
-            on_revoke: Callback called when partitions are revoked from the consumer
-                during a rebalance. Receives ``(consumer, partitions)`` arguments.
-            on_lost: Callback called when partitions are lost (e.g., due to session
-                timeout). Receives ``(consumer, partitions)`` arguments.
-            dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-            parser: Parser to map original **Message** object to FastStream one.
-            decoder: Function to decode FastStream msg bytes body to python objects.
-            middlewares: Subscriber middlewares to wrap incoming message processing.
-            no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
+                 Messages will always be returned in offset order. Hence, in
+                 `read_committed` mode, batch consumer will only return
+                 messages up to the last stable offset (ALSO), which is the one less
+                 than the offset of the first open transaction. In particular any
+                 messages appearing after messages belonging to ongoing transactions
+                 will be withheld until the relevant transaction has been completed.
+                 As a result, `read_committed` consumers will not be able to read up
+                 to the high watermark when there are in flight transactions.
+                 Further, when in `read_committed` the seek_to_end method will
+                 return the ALSO. See method docs below.
+             batch: Whether to consume messages in batches or not.
+             max_records: Number of messages to consume as one batch.
+             on_assign: Callback called when partitions are assigned to the consumer
+                 during a rebalance. Receives ``(consumer, partitions)`` arguments.
+             on_revoke: Callback called when partitions are revoked from the consumer
+                 during a rebalance. Receives ``(consumer, partitions)`` arguments.
+             on_lost: Callback called when partitions are lost (e.g., due to session
+                 timeout). Receives ``(consumer, partitions)`` arguments.
+             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+             parser: Parser to map original **Message** object to FastStream one.
+             decoder: Function to decode FastStream msg bytes body to python objects.
+             codec: Custom codec object.
+             middlewares: Subscriber middlewares to wrap incoming message processing.
+             no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
             ack_policy: Acknowledgement policy for the subscriber.
             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
             title: Specification subscriber object title.

--- a/faststream/kafka/__init__.py
+++ b/faststream/kafka/__init__.py
@@ -1,4 +1,13 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.testing.app import TestApp
+
+if TYPE_CHECKING:
+    from aiokafka import ConsumerRecord
+
+    from faststream._internal.parser import ParserProto
+
+    KafkaParserType = ParserProto["ConsumerRecord"]
 
 try:
     from aiokafka import ConsumerRecord, TopicPartition
@@ -21,6 +30,7 @@ __all__ = (
     "ConsumerRecord",
     "KafkaBroker",
     "KafkaMessage",
+    "KafkaParserType",
     "KafkaPublishCommand",
     "KafkaPublishMessage",
     "KafkaPublisher",

--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -314,16 +314,16 @@ class KafkaBroker(
                 Transaction timeout in milliseconds.
             graceful_timeout (Optional[float]):
                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-             ack_policy (AckPolicy):
-                 Default acknowledgement policy for all subscribers. Individual subscribers can override.
-                 If not set, each broker type uses its built-in default.
-             decoder (Optional[CustomCallable]):
-                 Custom decoder object.
-             codec (Optional[CodecProto]):
-                 Custom codec object.
-             parser (Optional[CustomCallable]):
-                 Custom parser object.
-             dependencies (Iterable[Dependant]):
+            ack_policy (AckPolicy):
+                Default acknowledgement policy for all subscribers. Individual subscribers can override.
+                If not set, each broker type uses its built-in default.
+            decoder (Optional[CustomCallable]):
+                Custom decoder object.
+            codec (Optional[CodecProto]):
+                Custom codec object.
+            parser (Optional[CustomCallable]):
+                Custom parser object.
+            dependencies (Iterable[Dependant]):
                 Dependencies to apply to all broker subscribers.
             middlewares (Sequence[BrokerMiddlewarep[Any, Any]]):
                 Middlewares to apply to all broker publishers/subscribers.

--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -314,14 +314,16 @@ class KafkaBroker(
                 Transaction timeout in milliseconds.
             graceful_timeout (Optional[float]):
                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-            ack_policy (AckPolicy):
-                Default acknowledgement policy for all subscribers. Individual subscribers can override.
-                If not set, each broker type uses its built-in default.
-            decoder (Optional[CustomCallable]):
-                Custom decoder object.
-            parser (Optional[CustomCallable]):
-                Custom parser object.
-            dependencies (Iterable[Dependant]):
+             ack_policy (AckPolicy):
+                 Default acknowledgement policy for all subscribers. Individual subscribers can override.
+                 If not set, each broker type uses its built-in default.
+             decoder (Optional[CustomCallable]):
+                 Custom decoder object.
+             codec (Optional[CodecProto]):
+                 Custom codec object.
+             parser (Optional[CustomCallable]):
+                 Custom parser object.
+             dependencies (Iterable[Dependant]):
                 Dependencies to apply to all broker subscribers.
             middlewares (Sequence[BrokerMiddlewarep[Any, Any]]):
                 Middlewares to apply to all broker publishers/subscribers.

--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         LoggerProto,
         SendableMessage,
     )
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -215,6 +216,7 @@ class KafkaBroker(
         graceful_timeout: float | None = 15.0,
         ack_policy: AckPolicy = EMPTY,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         parser: Optional["CustomCallable"] = None,
         dependencies: Iterable["Dependant"] = (),
         middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
@@ -418,6 +420,7 @@ class KafkaBroker(
                 ),
                 # both args,
                 broker_decoder=decoder,
+                broker_codec=codec,
                 broker_parser=parser,
                 broker_middlewares=middlewares,
                 logger=make_kafka_logger_state(

--- a/faststream/kafka/broker/registrator.py
+++ b/faststream/kafka/broker/registrator.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from aiokafka.coordinator.assignors.abstract import AbstractPartitionAssignor
     from fast_depends.dependencies import Dependant
 
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -90,6 +91,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -138,6 +140,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -186,6 +189,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -234,6 +238,7 @@ class KafkaRegistrator(
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
@@ -276,20 +281,21 @@ class KafkaRegistrator(
         max_records: int | None = None,
         listener: Optional["ConsumerRebalanceListener"] = None,
         pattern: str | None = None,
-        partitions: Collection["TopicPartition"] = (),
-        # broker args
-        persistent: bool = True,
-        dependencies: Iterable["Dependant"] = (),
-        parser: Optional["CustomCallable"] = None,
-        decoder: Optional["CustomCallable"] = None,
-        max_workers: int | None = None,
-        ack_policy: AckPolicy = EMPTY,
-        no_reply: bool = False,
-        # Specification args
-        title: str | None = None,
-        description: str | None = None,
-        include_in_schema: bool = True,
-    ) -> Union[
+         partitions: Collection["TopicPartition"] = (),
+         # broker args
+         persistent: bool = True,
+         dependencies: Iterable["Dependant"] = (),
+         parser: Optional["CustomCallable"] = None,
+         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
+         max_workers: int | None = None,
+         ack_policy: AckPolicy = EMPTY,
+         no_reply: bool = False,
+         # Specification args
+         title: str | None = None,
+         description: str | None = None,
+         include_in_schema: bool = True,
+     ) -> Union[
         "DefaultSubscriber",
         "BatchSubscriber",
         "ConcurrentDefaultSubscriber",
@@ -330,218 +336,219 @@ class KafkaRegistrator(
         listener: Optional["ConsumerRebalanceListener"] = None,
         pattern: str | None = None,
         partitions: Collection["TopicPartition"] = (),
-        # broker args
-        persistent: bool = True,
-        dependencies: Iterable["Dependant"] = (),
-        parser: Optional["CustomCallable"] = None,
-        decoder: Optional["CustomCallable"] = None,
-        max_workers: int | None = None,
-        ack_policy: AckPolicy = EMPTY,
-        no_reply: bool = False,
-        # Specification args
-        title: str | None = None,
-        description: str | None = None,
-        include_in_schema: bool = True,
-    ) -> Union[
-        "DefaultSubscriber",
-        "BatchSubscriber",
-        "ConcurrentDefaultSubscriber",
-        "ConcurrentBetweenPartitionsSubscriber",
-    ]:
-        """Create a subscriber for Kafka topics.
+         # broker args
+         persistent: bool = True,
+         dependencies: Iterable["Dependant"] = (),
+         parser: Optional["CustomCallable"] = None,
+         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
+         max_workers: int | None = None,
+         ack_policy: AckPolicy = EMPTY,
+         no_reply: bool = False,
+         # Specification args
+         title: str | None = None,
+         description: str | None = None,
+         include_in_schema: bool = True,
+     ) -> Union[
+         "DefaultSubscriber",
+         "BatchSubscriber",
+         "ConcurrentDefaultSubscriber",
+         "ConcurrentBetweenPartitionsSubscriber",
+      ]:
+         """Create a subscriber for Kafka topics.
 
-        Args:
-            *topics: Kafka topics to consume messages from.
-            batch: Whether to consume messages in batches or not.
-            group_id:
-                Name of the consumer group to join for dynamic
-                partition assignment (if enabled), and to use for fetching and
-                committing offsets. If `None`, auto-partition assignment (via
-                group coordinator) and offset commits are disabled.
-            group_instance_id:
-                Name of the group instance ID used for static
-                membership (KIP-345). If set, the consumer is treated as a
-                static member, which means it does not join/leave the group
-                on each restart, avoiding unnecessary rebalances.
-            key_deserializer:
-                Any callable that takes a raw message `bytes`
-                key and returns a deserialized one.
-            value_deserializer:
-                Any callable that takes a raw message `bytes`
-                value and returns a deserialized value.
-            fetch_max_bytes:
-                The maximum amount of data the server should
-                return for a fetch request. This is not an absolute maximum, if
-                the first message in the first non-empty partition of the fetch
-                is larger than this value, the message will still be returned
-                to ensure that the consumer can make progress. NOTE: consumer
-                performs fetches to multiple brokers in parallel so memory
-                usage will depend on the number of brokers containing
-                partitions for the topic.
-            fetch_min_bytes:
-                Minimum amount of data the server should
-                return for a fetch request, otherwise wait up to
-                `fetch_max_wait_ms` for more data to accumulate.
-            fetch_max_wait_ms:
-                The maximum amount of time in milliseconds
-                the server will block before answering the fetch request if
-                there isn't sufficient data to immediately satisfy the
-                requirement given by `fetch_min_bytes`.
-            max_partition_fetch_bytes:
-                The maximum amount of data
-                per-partition the server will return. The maximum total memory
-                used for a request ``= #partitions * max_partition_fetch_bytes``.
-                This size must be at least as large as the maximum message size
-                the server allows or else it is possible for the producer to
-                send messages larger than the consumer can fetch. If that
-                happens, the consumer can get stuck trying to fetch a large
-                message on a certain partition.
-            auto_offset_reset:
-                A policy for resetting offsets on `OffsetOutOfRangeError` errors:
+         Args:
+             *topics: Kafka topics to consume messages from.
+             batch: Whether to consume messages in batches or not.
+             group_id:
+                 Name of the consumer group to join for dynamic
+                 partition assignment (if enabled), and to use for fetching and
+                 committing offsets. If `None`, auto-partition assignment (via
+                 group coordinator) and offset commits are disabled.
+             group_instance_id:
+                 Name of the group instance ID used for static
+                 membership (KIP-345). If set, the consumer is treated as a
+                 static member, which means it does not join/leave the group
+                 on each restart, avoiding unnecessary rebalances.
+             key_deserializer:
+                 Any callable that takes a raw message `bytes`
+                 key and returns a deserialized one.
+             value_deserializer:
+                 Any callable that takes a raw message `bytes`
+                 value and returns a deserialized value.
+             fetch_max_bytes:
+                 The maximum amount of data the server should
+                 return for a fetch request. This is not an absolute maximum, if
+                 the first message in the first non-empty partition of the fetch
+                 is larger than this value, the message will still be returned
+                 to ensure that the consumer can make progress. NOTE: consumer
+                 performs fetches to multiple brokers in parallel so memory
+                 usage will depend on the number of brokers containing
+                 partitions for the topic.
+             fetch_min_bytes:
+                 Minimum amount of data the server should
+                 return for a fetch request, otherwise wait up to
+                 `fetch_max_wait_ms` for more data to accumulate.
+             fetch_max_wait_ms:
+                 The maximum amount of time in milliseconds
+                 the server will block before answering the fetch request if
+                 there isn't sufficient data to immediately satisfy the
+                 requirement given by `fetch_min_bytes`.
+             max_partition_fetch_bytes:
+                 The maximum amount of data
+                 per-partition the server will return. The maximum total memory
+                 used for a request ``= #partitions * max_partition_fetch_bytes``.
+                 This size must be at least as large as the maximum message size
+                 the server allows or else it is possible for the producer to
+                 send messages larger than the consumer can fetch. If that
+                 happens, the consumer can get stuck trying to fetch a large
+                 message on a certain partition.
+             auto_offset_reset:
+                 A policy for resetting offsets on `OffsetOutOfRangeError` errors:
 
-                * `earliest` will move to the oldest available message
-                * `latest` will move to the most recent
-                * `none` will raise an exception so you can handle this case
-            auto_commit:
-                If `True` the consumer's offset will be
-                periodically committed in the background.
+                 * `earliest` will move to the oldest available message
+                 * `latest` will move to the most recent
+                 * `none` will raise an exception so you can handle this case
+             auto_commit:
+                 If `True` the consumer's offset will be
+                 periodically committed in the background.
 
-            auto_commit_interval_ms:
-                Milliseconds between automatic
-                offset commits, if `auto_commit` is `True`.
-            check_crcs:
-                Automatically check the CRC32 of the records
-                consumed. This ensures no on-the-wire or on-disk corruption to
-                the messages occurred. This check adds some overhead, so it may
-                be disabled in cases seeking extreme performance.
-            partition_assignment_strategy:
-                List of objects to use to
-                distribute partition ownership amongst consumer instances when
-                group management is used. This preference is implicit in the order
-                of the strategies in the list. When assignment strategy changes:
-                to support a change to the assignment strategy, new versions must
-                enable support both for the old assignment strategy and the new
-                one. The coordinator will choose the old assignment strategy until
-                all members have been updated. Then it will choose the new
-                strategy.
-            max_poll_interval_ms:
-                Maximum allowed time between calls to
-                consume messages in batches. If this interval
-                is exceeded the consumer is considered failed and the group will
-                rebalance in order to reassign the partitions to another consumer
-                group member. If API methods block waiting for messages, that time
-                does not count against this timeout.
-            rebalance_timeout_ms:
-                The maximum time server will wait for this
-                consumer to rejoin the group in a case of rebalance. In Java client
-                this behaviour is bound to `max.poll.interval.ms` configuration,
-                but as ``aiokafka`` will rejoin the group in the background, we
-                decouple this setting to allow finer tuning by users that use
-                `ConsumerRebalanceListener` to delay rebalacing. Defaults
-                to ``session_timeout_ms``
-            session_timeout_ms:
-                Client group session and failure detection
-                timeout. The consumer sends periodic heartbeats
-                (`heartbeat.interval.ms`) to indicate its liveness to the broker.
-                If no hearts are received by the broker for a group member within
-                the session timeout, the broker will remove the consumer from the
-                group and trigger a rebalance. The allowed range is configured with
-                the **broker** configuration properties
-                `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
-            heartbeat_interval_ms:
-                The expected time in milliseconds
-                between heartbeats to the consumer coordinator when using
-                Kafka's group management feature. Heartbeats are used to ensure
-                that the consumer's session stays active and to facilitate
-                rebalancing when new consumers join or leave the group. The
-                value must be set lower than `session_timeout_ms`, but typically
-                should be set no higher than 1/3 of that value. It can be
-                adjusted even lower to control the expected time for normal
-                rebalances.
-            consumer_timeout_ms:
-                Maximum wait timeout for background fetching
-                routine. Mostly defines how fast the system will see rebalance and
-                request new data for new partitions.
-            max_poll_records:
-                The maximum number of records returned in a
-                single call by batch consumer. Has no limit by default.
-            exclude_internal_topics:
-                Whether records from internal topics
-                (such as offsets) should be exposed to the consumer. If set to True
-                the only way to receive records from an internal topic is
-                subscribing to it.
-            isolation_level:
-                Controls how to read messages written
-                transactionally.
+             auto_commit_interval_ms:
+                 Milliseconds between automatic
+                 offset commits, if `auto_commit` is `True`.
+             check_crcs:
+                 Automatically check the CRC32 of the records
+                 consumed. This ensures no on-the-wire or on-disk corruption to
+                 the messages occurred. This check adds some overhead, so it may
+                 be disabled in cases seeking extreme performance.
+             partition_assignment_strategy:
+                 List of objects to use to
+                 distribute partition ownership amongst consumer instances when
+                 group management is used. This preference is implicit in the order
+                 of the strategies in the list. When assignment strategy changes:
+                 to support a change to the assignment strategy, new versions must
+                 enable support both for the old assignment strategy and the new
+                 one. The coordinator will choose the old assignment strategy until
+                 all members have been updated. Then it will choose the new
+                 strategy.
+             max_poll_interval_ms:
+                 Maximum allowed time between calls to
+                 consume messages in batches. If this interval
+                 is exceeded the consumer is considered failed and the group will
+                 rebalance in order to reassign the partitions to another consumer
+                 group member. If API methods block waiting for messages, that time
+                 does not count against this timeout.
+             rebalance_timeout_ms:
+                 The maximum time server will wait for this
+                 consumer to rejoin the group in a case of rebalance. In Java client
+                 this behaviour is bound to `max.poll.interval.ms` configuration,
+                 but as ``aiokafka`` will rejoin the group in the background, we
+                 decouple this setting to allow finer tuning by users that use
+                 `ConsumerRebalanceListener` to delay rebalacing. Defaults
+                 to ``session_timeout_ms``
+             session_timeout_ms:
+                 Client group session and failure detection
+                 timeout. The consumer sends periodic heartbeats
+                 (`heartbeat.interval.ms`) to indicate its liveness to the broker.
+                 If no hearts are received by the broker for a group member within
+                 the session timeout, the broker will remove the consumer from the
+                 group and trigger a rebalance. The allowed range is configured with
+                 the **broker** configuration properties
+                 `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
+             heartbeat_interval_ms:
+                 The expected time in milliseconds
+                 between heartbeats to the consumer coordinator when using
+                 Kafka's group management feature. Heartbeats are used to ensure
+                 that the consumer's session stays active and to facilitate
+                 rebalancing when new consumers join or leave the group. The
+                 value must be set lower than `session_timeout_ms`, but typically
+                 should be set no higher than 1/3 of that value. It can be
+                 adjusted even lower to control the expected time for normal
+                 rebalances.
+             consumer_timeout_ms:
+                 Maximum wait timeout for background fetching
+                 routine. Mostly defines how fast the system will see rebalance and
+                 request new data for new partitions.
+             max_poll_records:
+                 The maximum number of records returned in a
+                 single call by batch consumer. Has no limit by default.
+             exclude_internal_topics:
+                 Whether records from internal topics
+                 (such as offsets) should be exposed to the consumer. If set to True
+                 the only way to receive records from an internal topic is
+                 subscribing to it.
+             isolation_level:
+                 Controls how to read messages written
+                 transactionally.
 
-                * `read_committed`, batch consumer will only return
-                transactional messages which have been committed.
+                 * `read_committed`, batch consumer will only return
+                 transactional messages which have been committed.
 
-                * `read_uncommitted` (the default), batch consumer will
-                return all messages, even transactional messages which have been
-                aborted.
+                 * `read_uncommitted` (the default), batch consumer will
+                 return all messages, even transactional messages which have been
+                 aborted.
 
-                Non-transactional messages will be returned unconditionally in
-                either mode.
+                 Non-transactional messages will be returned unconditionally in
+                 either mode.
 
-                Messages will always be returned in offset order. Hence, in
-                `read_committed` mode, batch consumer will only return
-                messages up to the last stable offset (ALSO), which is the one less
-                than the offset of the first open transaction. In particular any
-                messages appearing after messages belonging to ongoing transactions
-                will be withheld until the relevant transaction has been completed.
-                As a result, `read_committed` consumers will not be able to read up
-                to the high watermark when there are in flight transactions.
-                Further, when in `read_committed` the seek_to_end method will
-                return the ALSO. See method docs below.
-            batch_timeout_ms:
-                Milliseconds spent waiting if
-                data is not available in the buffer. If 0, returns immediately
-                with any records that are available currently in the buffer,
-                else returns empty.
-            max_records: Number of messages to consume as one batch.
-            listener:
-                Optionally include listener
-                callback, which will be called before and after each rebalance
-                operation.
-                As part of group management, the consumer will keep track of
-                the list of consumers that belong to a particular group and
-                will trigger a rebalance operation if one of the following
-                events trigger:
+                 Messages will always be returned in offset order. Hence, in
+                 `read_committed` mode, batch consumer will only return
+                 messages up to the last stable offset (ALSO), which is the one less
+                 than the offset of the first open transaction. In particular any
+                 messages appearing after messages belonging to ongoing transactions
+                 will be withheld until the relevant transaction has been completed.
+                 As a result, `read_committed` consumers will not be able to read up
+                 to the high watermark when there are in flight transactions.
+                 Further, when in `read_committed` the seek_to_end method will
+                 return the ALSO. See method docs below.
+             batch_timeout_ms:
+                 Milliseconds spent waiting if
+                 data is not available in the buffer. If 0, returns immediately
+                 with any records that are available currently in the buffer,
+                 else returns empty.
+             max_records: Number of messages to consume as one batch.
+             listener:
+                 Optionally include listener
+                 callback, which will be called before and after each rebalance
+                 operation.
+                 As part of group management, the consumer will keep track of
+                 the list of consumers that belong to a particular group and
+                 will trigger a rebalance operation if one of the following
+                 events trigger:
 
-                * Number of partitions change for any of the subscribed topics
-                * Topic is created or deleted
-                * An existing member of the consumer group dies
-                * A new member is added to the consumer group
+                 * Number of partitions change for any of the subscribed topics
+                 * Topic is created or deleted
+                 * An existing member of the consumer group dies
+                 * A new member is added to the consumer group
 
-                When any of these events are triggered, the provided listener
-                will be invoked first to indicate that the consumer's
-                assignment has been revoked, and then again when the new
-                assignment has been received. Note that this listener will
-                immediately override any listener set in a previous call
-                to subscribe. It is guaranteed, however, that the partitions
-                revoked/assigned
-                through this interface are from topics subscribed in this call.
-            pattern:
-                Pattern to match available topics. You must provide either topics or pattern, but not both.
-            partitions:  An explicit partitions list to assign.
-                You can't use 'topics' and 'partitions' in the same time.
-            dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-            parser: Parser to map original **ConsumerRecord** object to FastStream one.
-            decoder: Function to decode FastStream msg bytes body to python objects.
-            middlewares: Subscriber middlewares to wrap incoming message processing.
-            max_workers: Number of workers to process messages concurrently.
-            no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
-            ack_policy: Acknowledgement policy for the subscriber.
-            no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
-            title: Specification subscriber object title.
-            description: Specification subscriber object description. " "Uses decorated docstring as default.
-            include_in_schema: Whetever to include operation in Specification schema or not.
-            persistent: Whether to make the subscriber persistent or not.
-        """
-        workers = max_workers or 1
+                 When any of these events are triggered, the provided listener
+                 will be invoked first to indicate that the consumer's
+                 assignment has been revoked, and then again when the new
+                 assignment has been received. Note that this listener will
+                 immediately override any listener set in a previous call
+                 to subscribe. It is guaranteed, however, that the partitions
+                 revoked/assigned
+                 through this interface are from topics subscribed in this call.
+             pattern:
+                 Pattern to match available topics. You must provide either topics or pattern, but not both.
+             partitions:  An explicit partitions list to assign.
+                 You can't use 'topics' and 'partitions' in the same time.
+             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+             parser: Parser to map original **ConsumerRecord** object to FastStream one.
+             decoder: Function to decode FastStream msg bytes body to python objects.
+             middlewares: Subscriber middlewares to wrap incoming message processing.
+             max_workers: Number of workers to process messages concurrently.
+             no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
+             ack_policy: Acknowledgement policy for the subscriber.
+             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
+             title: Specification subscriber object title.
+             description: Specification subscriber object description. " "Uses decorated docstring as default.
+             include_in_schema: Whetever to include operation in Specification schema or not.
+             persistent: Whether to make the subscriber persistent or not.
+         """
+         workers = max_workers or 1
 
-        subscriber = create_subscriber(
+         subscriber = create_subscriber(
             *topics,
             batch=batch,
             max_workers=workers,
@@ -579,24 +586,25 @@ class KafkaRegistrator(
             title_=title,
             description_=description,
             include_in_schema=include_in_schema,
-        )
+         )
 
-        super().subscriber(subscriber, persistent=persistent)
+         super().subscriber(subscriber, persistent=persistent)
 
-        subscriber.add_call(
-            parser_=parser,
-            decoder_=decoder,
-            dependencies_=dependencies,
-        )
+         subscriber.add_call(
+             parser_=parser,
+             decoder_=decoder,
+             codec_=codec,
+             dependencies_=dependencies,
+         )
 
-        if batch:
-            return cast("BatchSubscriber", subscriber)
+         if batch:
+             return cast("BatchSubscriber", subscriber)
 
-        if workers > 1:
+         if workers > 1:
             if subscriber.ack_policy is AckPolicy.ACK_FIRST:
                 return cast("ConcurrentDefaultSubscriber", subscriber)
             return cast("ConcurrentBetweenPartitionsSubscriber", subscriber)
-        return cast("DefaultSubscriber", subscriber)
+         return cast("DefaultSubscriber", subscriber)
 
     @overload  # type: ignore[override]
     def publisher(

--- a/faststream/kafka/broker/registrator.py
+++ b/faststream/kafka/broker/registrator.py
@@ -531,14 +531,14 @@ class KafkaRegistrator(
                 through this interface are from topics subscribed in this call.
             pattern:
                 Pattern to match available topics. You must provide either topics or pattern, but not both.
-             partitions:  An explicit partitions list to assign.
-                 You can't use 'topics' and 'partitions' in the same time.
-             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-             parser: Parser to map original **ConsumerRecord** object to FastStream one.
-             decoder: Function to decode FastStream msg bytes body to python objects.
-             codec: Custom codec object.
-             middlewares: Subscriber middlewares to wrap incoming message processing.
-             max_workers: Number of workers to process messages concurrently.
+            partitions:  An explicit partitions list to assign.
+                You can't use 'topics' and 'partitions' in the same time.
+            dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+            parser: Parser to map original **ConsumerRecord** object to FastStream one.
+            decoder: Function to decode FastStream msg bytes body to python objects.
+            codec: Custom codec object.
+            middlewares: Subscriber middlewares to wrap incoming message processing.
+            max_workers: Number of workers to process messages concurrently.
             no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
             ack_policy: Acknowledgement policy for the subscriber.
             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.

--- a/faststream/kafka/broker/registrator.py
+++ b/faststream/kafka/broker/registrator.py
@@ -281,21 +281,21 @@ class KafkaRegistrator(
         max_records: int | None = None,
         listener: Optional["ConsumerRebalanceListener"] = None,
         pattern: str | None = None,
-         partitions: Collection["TopicPartition"] = (),
-         # broker args
-         persistent: bool = True,
-         dependencies: Iterable["Dependant"] = (),
-         parser: Optional["CustomCallable"] = None,
-         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
-         max_workers: int | None = None,
-         ack_policy: AckPolicy = EMPTY,
-         no_reply: bool = False,
-         # Specification args
-         title: str | None = None,
-         description: str | None = None,
-         include_in_schema: bool = True,
-     ) -> Union[
+        partitions: Collection["TopicPartition"] = (),
+        # broker args
+        persistent: bool = True,
+        dependencies: Iterable["Dependant"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
+        max_workers: int | None = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        # Specification args
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+    ) -> Union[
         "DefaultSubscriber",
         "BatchSubscriber",
         "ConcurrentDefaultSubscriber",
@@ -336,219 +336,220 @@ class KafkaRegistrator(
         listener: Optional["ConsumerRebalanceListener"] = None,
         pattern: str | None = None,
         partitions: Collection["TopicPartition"] = (),
-         # broker args
-         persistent: bool = True,
-         dependencies: Iterable["Dependant"] = (),
-         parser: Optional["CustomCallable"] = None,
-         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
-         max_workers: int | None = None,
-         ack_policy: AckPolicy = EMPTY,
-         no_reply: bool = False,
-         # Specification args
-         title: str | None = None,
-         description: str | None = None,
-         include_in_schema: bool = True,
-     ) -> Union[
-         "DefaultSubscriber",
-         "BatchSubscriber",
-         "ConcurrentDefaultSubscriber",
-         "ConcurrentBetweenPartitionsSubscriber",
-      ]:
-         """Create a subscriber for Kafka topics.
+        # broker args
+        persistent: bool = True,
+        dependencies: Iterable["Dependant"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
+        max_workers: int | None = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        # Specification args
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+    ) -> Union[
+        "DefaultSubscriber",
+        "BatchSubscriber",
+        "ConcurrentDefaultSubscriber",
+        "ConcurrentBetweenPartitionsSubscriber",
+    ]:
+        """Create a subscriber for Kafka topics.
 
-         Args:
-             *topics: Kafka topics to consume messages from.
-             batch: Whether to consume messages in batches or not.
-             group_id:
-                 Name of the consumer group to join for dynamic
-                 partition assignment (if enabled), and to use for fetching and
-                 committing offsets. If `None`, auto-partition assignment (via
-                 group coordinator) and offset commits are disabled.
-             group_instance_id:
-                 Name of the group instance ID used for static
-                 membership (KIP-345). If set, the consumer is treated as a
-                 static member, which means it does not join/leave the group
-                 on each restart, avoiding unnecessary rebalances.
-             key_deserializer:
-                 Any callable that takes a raw message `bytes`
-                 key and returns a deserialized one.
-             value_deserializer:
-                 Any callable that takes a raw message `bytes`
-                 value and returns a deserialized value.
-             fetch_max_bytes:
-                 The maximum amount of data the server should
-                 return for a fetch request. This is not an absolute maximum, if
-                 the first message in the first non-empty partition of the fetch
-                 is larger than this value, the message will still be returned
-                 to ensure that the consumer can make progress. NOTE: consumer
-                 performs fetches to multiple brokers in parallel so memory
-                 usage will depend on the number of brokers containing
-                 partitions for the topic.
-             fetch_min_bytes:
-                 Minimum amount of data the server should
-                 return for a fetch request, otherwise wait up to
-                 `fetch_max_wait_ms` for more data to accumulate.
-             fetch_max_wait_ms:
-                 The maximum amount of time in milliseconds
-                 the server will block before answering the fetch request if
-                 there isn't sufficient data to immediately satisfy the
-                 requirement given by `fetch_min_bytes`.
-             max_partition_fetch_bytes:
-                 The maximum amount of data
-                 per-partition the server will return. The maximum total memory
-                 used for a request ``= #partitions * max_partition_fetch_bytes``.
-                 This size must be at least as large as the maximum message size
-                 the server allows or else it is possible for the producer to
-                 send messages larger than the consumer can fetch. If that
-                 happens, the consumer can get stuck trying to fetch a large
-                 message on a certain partition.
-             auto_offset_reset:
-                 A policy for resetting offsets on `OffsetOutOfRangeError` errors:
+        Args:
+            *topics: Kafka topics to consume messages from.
+            batch: Whether to consume messages in batches or not.
+            group_id:
+                Name of the consumer group to join for dynamic
+                partition assignment (if enabled), and to use for fetching and
+                committing offsets. If `None`, auto-partition assignment (via
+                group coordinator) and offset commits are disabled.
+            group_instance_id:
+                Name of the group instance ID used for static
+                membership (KIP-345). If set, the consumer is treated as a
+                static member, which means it does not join/leave the group
+                on each restart, avoiding unnecessary rebalances.
+            key_deserializer:
+                Any callable that takes a raw message `bytes`
+                key and returns a deserialized one.
+            value_deserializer:
+                Any callable that takes a raw message `bytes`
+                value and returns a deserialized value.
+            fetch_max_bytes:
+                The maximum amount of data the server should
+                return for a fetch request. This is not an absolute maximum, if
+                the first message in the first non-empty partition of the fetch
+                is larger than this value, the message will still be returned
+                to ensure that the consumer can make progress. NOTE: consumer
+                performs fetches to multiple brokers in parallel so memory
+                usage will depend on the number of brokers containing
+                partitions for the topic.
+            fetch_min_bytes:
+                Minimum amount of data the server should
+                return for a fetch request, otherwise wait up to
+                `fetch_max_wait_ms` for more data to accumulate.
+            fetch_max_wait_ms:
+                The maximum amount of time in milliseconds
+                the server will block before answering the fetch request if
+                there isn't sufficient data to immediately satisfy the
+                requirement given by `fetch_min_bytes`.
+            max_partition_fetch_bytes:
+                The maximum amount of data
+                per-partition the server will return. The maximum total memory
+                used for a request ``= #partitions * max_partition_fetch_bytes``.
+                This size must be at least as large as the maximum message size
+                the server allows or else it is possible for the producer to
+                send messages larger than the consumer can fetch. If that
+                happens, the consumer can get stuck trying to fetch a large
+                message on a certain partition.
+            auto_offset_reset:
+                A policy for resetting offsets on `OffsetOutOfRangeError` errors:
 
-                 * `earliest` will move to the oldest available message
-                 * `latest` will move to the most recent
-                 * `none` will raise an exception so you can handle this case
-             auto_commit:
-                 If `True` the consumer's offset will be
-                 periodically committed in the background.
+                * `earliest` will move to the oldest available message
+                * `latest` will move to the most recent
+                * `none` will raise an exception so you can handle this case
+            auto_commit:
+                If `True` the consumer's offset will be
+                periodically committed in the background.
 
-             auto_commit_interval_ms:
-                 Milliseconds between automatic
-                 offset commits, if `auto_commit` is `True`.
-             check_crcs:
-                 Automatically check the CRC32 of the records
-                 consumed. This ensures no on-the-wire or on-disk corruption to
-                 the messages occurred. This check adds some overhead, so it may
-                 be disabled in cases seeking extreme performance.
-             partition_assignment_strategy:
-                 List of objects to use to
-                 distribute partition ownership amongst consumer instances when
-                 group management is used. This preference is implicit in the order
-                 of the strategies in the list. When assignment strategy changes:
-                 to support a change to the assignment strategy, new versions must
-                 enable support both for the old assignment strategy and the new
-                 one. The coordinator will choose the old assignment strategy until
-                 all members have been updated. Then it will choose the new
-                 strategy.
-             max_poll_interval_ms:
-                 Maximum allowed time between calls to
-                 consume messages in batches. If this interval
-                 is exceeded the consumer is considered failed and the group will
-                 rebalance in order to reassign the partitions to another consumer
-                 group member. If API methods block waiting for messages, that time
-                 does not count against this timeout.
-             rebalance_timeout_ms:
-                 The maximum time server will wait for this
-                 consumer to rejoin the group in a case of rebalance. In Java client
-                 this behaviour is bound to `max.poll.interval.ms` configuration,
-                 but as ``aiokafka`` will rejoin the group in the background, we
-                 decouple this setting to allow finer tuning by users that use
-                 `ConsumerRebalanceListener` to delay rebalacing. Defaults
-                 to ``session_timeout_ms``
-             session_timeout_ms:
-                 Client group session and failure detection
-                 timeout. The consumer sends periodic heartbeats
-                 (`heartbeat.interval.ms`) to indicate its liveness to the broker.
-                 If no hearts are received by the broker for a group member within
-                 the session timeout, the broker will remove the consumer from the
-                 group and trigger a rebalance. The allowed range is configured with
-                 the **broker** configuration properties
-                 `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
-             heartbeat_interval_ms:
-                 The expected time in milliseconds
-                 between heartbeats to the consumer coordinator when using
-                 Kafka's group management feature. Heartbeats are used to ensure
-                 that the consumer's session stays active and to facilitate
-                 rebalancing when new consumers join or leave the group. The
-                 value must be set lower than `session_timeout_ms`, but typically
-                 should be set no higher than 1/3 of that value. It can be
-                 adjusted even lower to control the expected time for normal
-                 rebalances.
-             consumer_timeout_ms:
-                 Maximum wait timeout for background fetching
-                 routine. Mostly defines how fast the system will see rebalance and
-                 request new data for new partitions.
-             max_poll_records:
-                 The maximum number of records returned in a
-                 single call by batch consumer. Has no limit by default.
-             exclude_internal_topics:
-                 Whether records from internal topics
-                 (such as offsets) should be exposed to the consumer. If set to True
-                 the only way to receive records from an internal topic is
-                 subscribing to it.
-             isolation_level:
-                 Controls how to read messages written
-                 transactionally.
+            auto_commit_interval_ms:
+                Milliseconds between automatic
+                offset commits, if `auto_commit` is `True`.
+            check_crcs:
+                Automatically check the CRC32 of the records
+                consumed. This ensures no on-the-wire or on-disk corruption to
+                the messages occurred. This check adds some overhead, so it may
+                be disabled in cases seeking extreme performance.
+            partition_assignment_strategy:
+                List of objects to use to
+                distribute partition ownership amongst consumer instances when
+                group management is used. This preference is implicit in the order
+                of the strategies in the list. When assignment strategy changes:
+                to support a change to the assignment strategy, new versions must
+                enable support both for the old assignment strategy and the new
+                one. The coordinator will choose the old assignment strategy until
+                all members have been updated. Then it will choose the new
+                strategy.
+            max_poll_interval_ms:
+                Maximum allowed time between calls to
+                consume messages in batches. If this interval
+                is exceeded the consumer is considered failed and the group will
+                rebalance in order to reassign the partitions to another consumer
+                group member. If API methods block waiting for messages, that time
+                does not count against this timeout.
+            rebalance_timeout_ms:
+                The maximum time server will wait for this
+                consumer to rejoin the group in a case of rebalance. In Java client
+                this behaviour is bound to `max.poll.interval.ms` configuration,
+                but as ``aiokafka`` will rejoin the group in the background, we
+                decouple this setting to allow finer tuning by users that use
+                `ConsumerRebalanceListener` to delay rebalacing. Defaults
+                to ``session_timeout_ms``
+            session_timeout_ms:
+                Client group session and failure detection
+                timeout. The consumer sends periodic heartbeats
+                (`heartbeat.interval.ms`) to indicate its liveness to the broker.
+                If no hearts are received by the broker for a group member within
+                the session timeout, the broker will remove the consumer from the
+                group and trigger a rebalance. The allowed range is configured with
+                the **broker** configuration properties
+                `group.min.session.timeout.ms` and `group.max.session.timeout.ms`.
+            heartbeat_interval_ms:
+                The expected time in milliseconds
+                between heartbeats to the consumer coordinator when using
+                Kafka's group management feature. Heartbeats are used to ensure
+                that the consumer's session stays active and to facilitate
+                rebalancing when new consumers join or leave the group. The
+                value must be set lower than `session_timeout_ms`, but typically
+                should be set no higher than 1/3 of that value. It can be
+                adjusted even lower to control the expected time for normal
+                rebalances.
+            consumer_timeout_ms:
+                Maximum wait timeout for background fetching
+                routine. Mostly defines how fast the system will see rebalance and
+                request new data for new partitions.
+            max_poll_records:
+                The maximum number of records returned in a
+                single call by batch consumer. Has no limit by default.
+            exclude_internal_topics:
+                Whether records from internal topics
+                (such as offsets) should be exposed to the consumer. If set to True
+                the only way to receive records from an internal topic is
+                subscribing to it.
+            isolation_level:
+                Controls how to read messages written
+                transactionally.
 
-                 * `read_committed`, batch consumer will only return
-                 transactional messages which have been committed.
+                * `read_committed`, batch consumer will only return
+                transactional messages which have been committed.
 
-                 * `read_uncommitted` (the default), batch consumer will
-                 return all messages, even transactional messages which have been
-                 aborted.
+                * `read_uncommitted` (the default), batch consumer will
+                return all messages, even transactional messages which have been
+                aborted.
 
-                 Non-transactional messages will be returned unconditionally in
-                 either mode.
+                Non-transactional messages will be returned unconditionally in
+                either mode.
 
-                 Messages will always be returned in offset order. Hence, in
-                 `read_committed` mode, batch consumer will only return
-                 messages up to the last stable offset (ALSO), which is the one less
-                 than the offset of the first open transaction. In particular any
-                 messages appearing after messages belonging to ongoing transactions
-                 will be withheld until the relevant transaction has been completed.
-                 As a result, `read_committed` consumers will not be able to read up
-                 to the high watermark when there are in flight transactions.
-                 Further, when in `read_committed` the seek_to_end method will
-                 return the ALSO. See method docs below.
-             batch_timeout_ms:
-                 Milliseconds spent waiting if
-                 data is not available in the buffer. If 0, returns immediately
-                 with any records that are available currently in the buffer,
-                 else returns empty.
-             max_records: Number of messages to consume as one batch.
-             listener:
-                 Optionally include listener
-                 callback, which will be called before and after each rebalance
-                 operation.
-                 As part of group management, the consumer will keep track of
-                 the list of consumers that belong to a particular group and
-                 will trigger a rebalance operation if one of the following
-                 events trigger:
+                Messages will always be returned in offset order. Hence, in
+                `read_committed` mode, batch consumer will only return
+                messages up to the last stable offset (ALSO), which is the one less
+                than the offset of the first open transaction. In particular any
+                messages appearing after messages belonging to ongoing transactions
+                will be withheld until the relevant transaction has been completed.
+                As a result, `read_committed` consumers will not be able to read up
+                to the high watermark when there are in flight transactions.
+                Further, when in `read_committed` the seek_to_end method will
+                return the ALSO. See method docs below.
+            batch_timeout_ms:
+                Milliseconds spent waiting if
+                data is not available in the buffer. If 0, returns immediately
+                with any records that are available currently in the buffer,
+                else returns empty.
+            max_records: Number of messages to consume as one batch.
+            listener:
+                Optionally include listener
+                callback, which will be called before and after each rebalance
+                operation.
+                As part of group management, the consumer will keep track of
+                the list of consumers that belong to a particular group and
+                will trigger a rebalance operation if one of the following
+                events trigger:
 
-                 * Number of partitions change for any of the subscribed topics
-                 * Topic is created or deleted
-                 * An existing member of the consumer group dies
-                 * A new member is added to the consumer group
+                * Number of partitions change for any of the subscribed topics
+                * Topic is created or deleted
+                * An existing member of the consumer group dies
+                * A new member is added to the consumer group
 
-                 When any of these events are triggered, the provided listener
-                 will be invoked first to indicate that the consumer's
-                 assignment has been revoked, and then again when the new
-                 assignment has been received. Note that this listener will
-                 immediately override any listener set in a previous call
-                 to subscribe. It is guaranteed, however, that the partitions
-                 revoked/assigned
-                 through this interface are from topics subscribed in this call.
-             pattern:
-                 Pattern to match available topics. You must provide either topics or pattern, but not both.
+                When any of these events are triggered, the provided listener
+                will be invoked first to indicate that the consumer's
+                assignment has been revoked, and then again when the new
+                assignment has been received. Note that this listener will
+                immediately override any listener set in a previous call
+                to subscribe. It is guaranteed, however, that the partitions
+                revoked/assigned
+                through this interface are from topics subscribed in this call.
+            pattern:
+                Pattern to match available topics. You must provide either topics or pattern, but not both.
              partitions:  An explicit partitions list to assign.
                  You can't use 'topics' and 'partitions' in the same time.
              dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
              parser: Parser to map original **ConsumerRecord** object to FastStream one.
              decoder: Function to decode FastStream msg bytes body to python objects.
+             codec: Custom codec object.
              middlewares: Subscriber middlewares to wrap incoming message processing.
              max_workers: Number of workers to process messages concurrently.
-             no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
-             ack_policy: Acknowledgement policy for the subscriber.
-             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
-             title: Specification subscriber object title.
-             description: Specification subscriber object description. " "Uses decorated docstring as default.
-             include_in_schema: Whetever to include operation in Specification schema or not.
-             persistent: Whether to make the subscriber persistent or not.
-         """
-         workers = max_workers or 1
+            no_ack: Whether to disable **FastStream** auto acknowledgement logic or not.
+            ack_policy: Acknowledgement policy for the subscriber.
+            no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
+            title: Specification subscriber object title.
+            description: Specification subscriber object description. " "Uses decorated docstring as default.
+            include_in_schema: Whetever to include operation in Specification schema or not.
+            persistent: Whether to make the subscriber persistent or not.
+        """
+        workers = max_workers or 1
 
-         subscriber = create_subscriber(
+        subscriber = create_subscriber(
             *topics,
             batch=batch,
             max_workers=workers,
@@ -586,25 +587,25 @@ class KafkaRegistrator(
             title_=title,
             description_=description,
             include_in_schema=include_in_schema,
-         )
+        )
 
-         super().subscriber(subscriber, persistent=persistent)
+        super().subscriber(subscriber, persistent=persistent)
 
-         subscriber.add_call(
-             parser_=parser,
-             decoder_=decoder,
-             codec_=codec,
-             dependencies_=dependencies,
-         )
+        subscriber.add_call(
+            parser_=parser,
+            decoder_=decoder,
+            codec_=codec,
+            dependencies_=dependencies,
+        )
 
-         if batch:
-             return cast("BatchSubscriber", subscriber)
+        if batch:
+            return cast("BatchSubscriber", subscriber)
 
-         if workers > 1:
+        if workers > 1:
             if subscriber.ack_policy is AckPolicy.ACK_FIRST:
                 return cast("ConcurrentDefaultSubscriber", subscriber)
             return cast("ConcurrentBetweenPartitionsSubscriber", subscriber)
-         return cast("DefaultSubscriber", subscriber)
+        return cast("DefaultSubscriber", subscriber)
 
     @overload  # type: ignore[override]
     def publisher(

--- a/faststream/mqtt/broker/broker.py
+++ b/faststream/mqtt/broker/broker.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import LoggerProto, SendableMessage
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import BrokerMiddleware, CustomCallable
     from faststream.mqtt.message import MQTTMessage
     from faststream.security import BaseSecurity
@@ -65,6 +66,7 @@ class MQTTBroker(
         graceful_timeout: float | None = 15.0,
         decoder: Optional["CustomCallable"] = None,
         parser: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         dependencies: Iterable["Dependant"] = (),
         middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
         routers: Iterable[MQTTRegistrator] = (),
@@ -120,6 +122,7 @@ class MQTTBroker(
                 broker_middlewares=middlewares,
                 broker_parser=parser,
                 broker_decoder=decoder,
+                broker_codec=codec,
                 logger=make_mqtt_logger_state(
                     logger=logger,
                     log_level=log_level,

--- a/faststream/mqtt/broker/registrator.py
+++ b/faststream/mqtt/broker/registrator.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     import zmqtt  # noqa: F401
     from fast_depends.dependencies import Dependant
 
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -42,6 +43,7 @@ class MQTTRegistrator(Registrator["zmqtt.Message", MQTTBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         max_workers: int = 1,
         persistent: bool = True,
         # AsyncAPI information
@@ -86,6 +88,7 @@ class MQTTRegistrator(Registrator["zmqtt.Message", MQTTBrokerConfig]):
         return subscriber.add_call(
             parser_=parser or self._parser,
             decoder_=decoder or self._decoder,
+            codec_=codec,
             dependencies_=dependencies,
         )
 

--- a/faststream/mqtt/broker/registrator.py
+++ b/faststream/mqtt/broker/registrator.py
@@ -57,15 +57,16 @@ class MQTTRegistrator(Registrator["zmqtt.Message", MQTTBrokerConfig]):
             topic: MQTT topic filter. Wildcards ``+`` (single level) and
                 ``#`` (multi-level) are supported.
             qos: QoS level for the subscription (0, 1, or 2).
-            shared: Optional shared subscription group name. When set,
-                subscribes as ``$share/<group>/<topic>``.
-            ack_policy: Acknowledgement policy for message processing.
-            no_reply: Whether to disable FastStream RPC / reply-to responses.
-            dependencies: Dependencies list to apply to the subscriber.
-            parser: Custom parser to map raw messages to FastStream ones.
-            decoder: Function to decode FastStream message bytes to Python objects.
-            max_workers: Number of workers to process messages concurrently.
-            persistent: Whether to retain the subscriber across broker restarts.
+             shared: Optional shared subscription group name. When set,
+                 subscribes as ``$share/<group>/<topic>``.
+             ack_policy: Acknowledgement policy for message processing.
+             no_reply: Whether to disable FastStream RPC / reply-to responses.
+             dependencies: Dependencies list to apply to the subscriber.
+             parser: Custom parser to map raw messages to FastStream ones.
+             decoder: Function to decode FastStream message bytes to Python objects.
+             codec: Custom codec object.
+             max_workers: Number of workers to process messages concurrently.
+             persistent: Whether to retain the subscriber across broker restarts.
             title: AsyncAPI subscriber object title.
             description: AsyncAPI subscriber object description.
             include_in_schema: Whether to include operation in AsyncAPI schema.

--- a/faststream/mqtt/broker/registrator.py
+++ b/faststream/mqtt/broker/registrator.py
@@ -57,16 +57,16 @@ class MQTTRegistrator(Registrator["zmqtt.Message", MQTTBrokerConfig]):
             topic: MQTT topic filter. Wildcards ``+`` (single level) and
                 ``#`` (multi-level) are supported.
             qos: QoS level for the subscription (0, 1, or 2).
-             shared: Optional shared subscription group name. When set,
-                 subscribes as ``$share/<group>/<topic>``.
-             ack_policy: Acknowledgement policy for message processing.
-             no_reply: Whether to disable FastStream RPC / reply-to responses.
-             dependencies: Dependencies list to apply to the subscriber.
-             parser: Custom parser to map raw messages to FastStream ones.
-             decoder: Function to decode FastStream message bytes to Python objects.
-             codec: Custom codec object.
-             max_workers: Number of workers to process messages concurrently.
-             persistent: Whether to retain the subscriber across broker restarts.
+            shared: Optional shared subscription group name. When set,
+                subscribes as ``$share/<group>/<topic>``.
+            ack_policy: Acknowledgement policy for message processing.
+            no_reply: Whether to disable FastStream RPC / reply-to responses.
+            dependencies: Dependencies list to apply to the subscriber.
+            parser: Custom parser to map raw messages to FastStream ones.
+            decoder: Function to decode FastStream message bytes to Python objects.
+            codec: Custom codec object.
+            max_workers: Number of workers to process messages concurrently.
+            persistent: Whether to retain the subscriber across broker restarts.
             title: AsyncAPI subscriber object title.
             description: AsyncAPI subscriber object description.
             include_in_schema: Whether to include operation in AsyncAPI schema.

--- a/faststream/nats/__init__.py
+++ b/faststream/nats/__init__.py
@@ -3,11 +3,9 @@ from typing import TYPE_CHECKING
 from faststream._internal.testing.app import TestApp
 
 if TYPE_CHECKING:
-    from nats.aio.msg import Msg
-
     from faststream._internal.parser import ParserProto
 
-    NatsParserType = ParserProto["Msg"]
+    NatsParserType = ParserProto["Msg"]  # type: ignore[name-defined]
 
 try:
     from nats.js.api import (

--- a/faststream/nats/__init__.py
+++ b/faststream/nats/__init__.py
@@ -1,4 +1,13 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.testing.app import TestApp
+
+if TYPE_CHECKING:
+    from nats.aio.msg import Msg
+
+    from faststream._internal.parser import ParserProto
+
+    NatsParserType = ParserProto["Msg"]
 
 try:
     from nats.js.api import (
@@ -41,6 +50,7 @@ __all__ = (
     "KvWatch",
     "NatsBroker",
     "NatsMessage",
+    "NatsParserType",
     "NatsPublishCommand",
     "NatsPublisher",
     "NatsResponse",

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -80,64 +80,64 @@ if TYPE_CHECKING:
         """NatsBroker.connect() method type hints.
 
         Args:
-        error_cb:
-        Callback to report errors.
-        disconnected_cb: \
-         Callback to report disconnection from NATS.
-        closed_cb:
-        Callback to report when client stops reconnection to NATS.
-        discovered_server_cb:
-        A callback to report when a new server joins the cluster.
-        reconnected_cb:
-        Callback to report success reconnection.
-        name:
-        Label the connection with name (shown in NATS monitoring
-        pedantic:
-        Turn on NATS server pedantic mode that performs extra checks on the protocol.
-        https://docs.nats.io/using-nats/developer/connecting/misc#turn-on-pedantic-mode
-        verbose:
-        Verbose mode produce more feedback about code execution.
-        allow_reconnect:
-        Whether recover connection automatically or not.
-        connect_timeout:
-        Timeout in seconds to establish connection with NATS server.
-        reconnect_time_wait:
-        Time in seconds to wait for reestablish connection to NATS server
-        max_reconnect_attempts:
-        Maximum attempts number to reconnect to NATS server.
-        ping_interval:
-        Interval in seconds to ping.
-        max_outstanding_pings:
-        Maximum number of failed pings
-        dont_randomize:
-        Boolean indicating should client randomly shuffle servers list for reconnection randomness.
-        flusher_queue_size:
-        Max count of commands awaiting to be flushed to the socket
-        no_echo:
-        Boolean indicating should commands be echoed.
-        tls_hostname:
-        Hostname for TLS.
-        token:
-        Auth token for NATS auth.
-        drain_timeout:
-        Timeout in seconds to drain subscriptions.
-        signature_cb:
-        A callback used to sign a nonce from the server while authenticating with nkeys.
-        The user should sign the nonce and return the base64 encoded signature.
-        user_jwt_cb:
-        A callback used to fetch and return the account signed JWT for this user.
-        user_credentials:
-        A user credentials file or tuple of files.
-        nkeys_seed:
-        Path-like object containing nkeys seed that will be used.
-        nkeys_seed_str:
-        Nkeys seed to be used.
-        inbox_prefix:
-        Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
-        pending_size:
-        Max size of the pending buffer for publishing commands.
-        flush_timeout:
-        Max duration to wait for a forced flush to occur
+            error_cb:
+                Callback to report errors.
+            disconnected_cb: \
+                Callback to report disconnection from NATS.
+            closed_cb:
+                Callback to report when client stops reconnection to NATS.
+            discovered_server_cb:
+                A callback to report when a new server joins the cluster.
+            reconnected_cb:
+                Callback to report success reconnection.
+            name:
+                Label the connection with name (shown in NATS monitoring
+            pedantic:
+                Turn on NATS server pedantic mode that performs extra checks on the protocol.
+                https://docs.nats.io/using-nats/developer/connecting/misc#turn-on-pedantic-mode
+            verbose:
+                Verbose mode produce more feedback about code execution.
+            allow_reconnect:
+                Whether recover connection automatically or not.
+            connect_timeout:
+                Timeout in seconds to establish connection with NATS server.
+            reconnect_time_wait:
+                Time in seconds to wait for reestablish connection to NATS server
+            max_reconnect_attempts:
+                Maximum attempts number to reconnect to NATS server.
+            ping_interval:
+                Interval in seconds to ping.
+            max_outstanding_pings:
+                Maximum number of failed pings
+            dont_randomize:
+                Boolean indicating should client randomly shuffle servers list for reconnection randomness.
+            flusher_queue_size:
+                Max count of commands awaiting to be flushed to the socket
+            no_echo:
+                Boolean indicating should commands be echoed.
+            tls_hostname:
+                Hostname for TLS.
+            token:
+                Auth token for NATS auth.
+            drain_timeout:
+                Timeout in seconds to drain subscriptions.
+            signature_cb:
+                A callback used to sign a nonce from the server while authenticating with nkeys.
+                The user should sign the nonce and return the base64 encoded signature.
+            user_jwt_cb:
+                A callback used to fetch and return the account signed JWT for this user.
+            user_credentials:
+                A user credentials file or tuple of files.
+            nkeys_seed:
+                Path-like object containing nkeys seed that will be used.
+            nkeys_seed_str:
+                Nkeys seed to be used.
+            inbox_prefix:
+                Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
+            pending_size:
+                Max size of the pending buffer for publishing commands.
+            flush_timeout:
+                Max duration to wait for a forced flush to occur
         """
 
         error_cb: "ErrorCallback" | None
@@ -296,7 +296,7 @@ class NatsBroker(
             flush_timeout:
                 Max duration to wait for a forced flush to occur
             js_options:
-                JetStream options to pass to the connection.
+                JetStream initialization options.
             graceful_timeout:
                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
             ack_policy:
@@ -310,9 +310,9 @@ class NatsBroker(
             dependencies:
                 Dependencies to apply to all broker subscribers.
             middlewares:
-                Middlewares to apply to all broker publishers/subscribers.
+                "Middlewares to apply to all broker publishers/subscribers.
             routers:
-                Routers to apply to broker.
+                "Routers to apply to broker.
             security:
                 Security options to connect broker and generate AsyncAPI server security information.
             specification_url:

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -50,124 +50,124 @@ from .logging import make_nats_logger_state
 from .registrator import NatsRegistrator
 
 if TYPE_CHECKING:
-     from types import TracebackType
+    from types import TracebackType
 
-     from fast_depends.dependencies import Dependant
-     from fast_depends.library.serializer import SerializerProto
-     from nats.aio.client import (
-     Callback,
-     Credentials,
-     ErrorCallback,
-     JWTCallback,
-     SignatureCallback,
-     )
-     from nats.js.api import Placement, RePublish, StorageType
-     from nats.js.kv import KeyValue
-     from nats.js.object_store import ObjectStore
-     from typing_extensions import TypedDict
+    from fast_depends.dependencies import Dependant
+    from fast_depends.library.serializer import SerializerProto
+    from nats.aio.client import (
+        Callback,
+        Credentials,
+        ErrorCallback,
+        JWTCallback,
+        SignatureCallback,
+    )
+    from nats.js.api import Placement, RePublish, StorageType
+    from nats.js.kv import KeyValue
+    from nats.js.object_store import ObjectStore
+    from typing_extensions import TypedDict
 
-     from faststream._internal.basic_types import LoggerProto, SendableMessage
-     from faststream._internal.parser import CodecProto
-     from faststream._internal.types import BrokerMiddleware, CustomCallable
-     from faststream.nats.configs.broker import JsInitOptions
-     from faststream.nats.helpers import KVBucketDeclarer, OSBucketDeclarer
-     from faststream.nats.message import NatsMessage
-     from faststream.nats.schemas import PubAck, Schedule
-     from faststream.security import BaseSecurity
-     from faststream.specification.schema.extra import Tag, TagDict
+    from faststream._internal.basic_types import LoggerProto, SendableMessage
+    from faststream._internal.parser import CodecProto
+    from faststream._internal.types import BrokerMiddleware, CustomCallable
+    from faststream.nats.configs.broker import JsInitOptions
+    from faststream.nats.helpers import KVBucketDeclarer, OSBucketDeclarer
+    from faststream.nats.message import NatsMessage
+    from faststream.nats.schemas import PubAck, Schedule
+    from faststream.security import BaseSecurity
+    from faststream.specification.schema.extra import Tag, TagDict
 
-     class NatsInitKwargs(TypedDict, total=False):
-         """NatsBroker.connect() method type hints.
+    class NatsInitKwargs(TypedDict, total=False):
+        """NatsBroker.connect() method type hints.
 
-         Args:
-         error_cb:
-         Callback to report errors.
-         disconnected_cb: \
+        Args:
+        error_cb:
+        Callback to report errors.
+        disconnected_cb: \
          Callback to report disconnection from NATS.
-         closed_cb:
-         Callback to report when client stops reconnection to NATS.
-         discovered_server_cb:
-         A callback to report when a new server joins the cluster.
-         reconnected_cb:
-         Callback to report success reconnection.
-         name:
-         Label the connection with name (shown in NATS monitoring
-         pedantic:
-         Turn on NATS server pedantic mode that performs extra checks on the protocol.
-         https://docs.nats.io/using-nats/developer/connecting/misc#turn-on-pedantic-mode
-         verbose:
-         Verbose mode produce more feedback about code execution.
-         allow_reconnect:
-         Whether recover connection automatically or not.
-         connect_timeout:
-         Timeout in seconds to establish connection with NATS server.
-         reconnect_time_wait:
-         Time in seconds to wait for reestablish connection to NATS server
-         max_reconnect_attempts:
-         Maximum attempts number to reconnect to NATS server.
-         ping_interval:
-         Interval in seconds to ping.
-         max_outstanding_pings:
-         Maximum number of failed pings
-         dont_randomize:
-         Boolean indicating should client randomly shuffle servers list for reconnection randomness.
-         flusher_queue_size:
-         Max count of commands awaiting to be flushed to the socket
-         no_echo:
-         Boolean indicating should commands be echoed.
-         tls_hostname:
-         Hostname for TLS.
-         token:
-         Auth token for NATS auth.
-         drain_timeout:
-         Timeout in seconds to drain subscriptions.
-         signature_cb:
-         A callback used to sign a nonce from the server while authenticating with nkeys.
-         The user should sign the nonce and return the base64 encoded signature.
-         user_jwt_cb:
-         A callback used to fetch and return the account signed JWT for this user.
-         user_credentials:
-         A user credentials file or tuple of files.
-         nkeys_seed:
-         Path-like object containing nkeys seed that will be used.
-         nkeys_seed_str:
-         Nkeys seed to be used.
-         inbox_prefix:
-         Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
-         pending_size:
-         Max size of the pending buffer for publishing commands.
-         flush_timeout:
-         Max duration to wait for a forced flush to occur
-         """
+        closed_cb:
+        Callback to report when client stops reconnection to NATS.
+        discovered_server_cb:
+        A callback to report when a new server joins the cluster.
+        reconnected_cb:
+        Callback to report success reconnection.
+        name:
+        Label the connection with name (shown in NATS monitoring
+        pedantic:
+        Turn on NATS server pedantic mode that performs extra checks on the protocol.
+        https://docs.nats.io/using-nats/developer/connecting/misc#turn-on-pedantic-mode
+        verbose:
+        Verbose mode produce more feedback about code execution.
+        allow_reconnect:
+        Whether recover connection automatically or not.
+        connect_timeout:
+        Timeout in seconds to establish connection with NATS server.
+        reconnect_time_wait:
+        Time in seconds to wait for reestablish connection to NATS server
+        max_reconnect_attempts:
+        Maximum attempts number to reconnect to NATS server.
+        ping_interval:
+        Interval in seconds to ping.
+        max_outstanding_pings:
+        Maximum number of failed pings
+        dont_randomize:
+        Boolean indicating should client randomly shuffle servers list for reconnection randomness.
+        flusher_queue_size:
+        Max count of commands awaiting to be flushed to the socket
+        no_echo:
+        Boolean indicating should commands be echoed.
+        tls_hostname:
+        Hostname for TLS.
+        token:
+        Auth token for NATS auth.
+        drain_timeout:
+        Timeout in seconds to drain subscriptions.
+        signature_cb:
+        A callback used to sign a nonce from the server while authenticating with nkeys.
+        The user should sign the nonce and return the base64 encoded signature.
+        user_jwt_cb:
+        A callback used to fetch and return the account signed JWT for this user.
+        user_credentials:
+        A user credentials file or tuple of files.
+        nkeys_seed:
+        Path-like object containing nkeys seed that will be used.
+        nkeys_seed_str:
+        Nkeys seed to be used.
+        inbox_prefix:
+        Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
+        pending_size:
+        Max size of the pending buffer for publishing commands.
+        flush_timeout:
+        Max duration to wait for a forced flush to occur
+        """
 
-         error_cb: "ErrorCallback" | None
-         disconnected_cb: "Callback" | None
-         closed_cb: Callback | None
-         discovered_server_cb: "Callback" | None
-         reconnected_cb: "Callback" | None
-         name: str | None
-         pedantic: bool
-         verbose: bool
-         allow_reconnect: bool
-         connect_timeout: int
-         reconnect_time_wait: int
-         max_reconnect_attempts: int
-         ping_interval: int
-         max_outstanding_pings: int
-         dont_randomize: bool
-         flusher_queue_size: int
-         no_echo: bool
-         tls_hostname: str | None
-         token: str | None
-         drain_timeout: int
-         signature_cb: "SignatureCallback" | None
-         user_jwt_cb: "JWTCallback" | None
-         user_credentials: "Credentials" | None
-         nkeys_seed: str | None
-         nkeys_seed_str: str | None
-         inbox_prefix: str | bytes
-         pending_size: int
-         flush_timeout: float | None
+        error_cb: "ErrorCallback" | None
+        disconnected_cb: "Callback" | None
+        closed_cb: Callback | None
+        discovered_server_cb: "Callback" | None
+        reconnected_cb: "Callback" | None
+        name: str | None
+        pedantic: bool
+        verbose: bool
+        allow_reconnect: bool
+        connect_timeout: int
+        reconnect_time_wait: int
+        max_reconnect_attempts: int
+        ping_interval: int
+        max_outstanding_pings: int
+        dont_randomize: bool
+        flusher_queue_size: int
+        no_echo: bool
+        tls_hostname: str | None
+        token: str | None
+        drain_timeout: int
+        signature_cb: "SignatureCallback" | None
+        user_jwt_cb: "JWTCallback" | None
+        user_credentials: "Credentials" | None
+        nkeys_seed: str | None
+        nkeys_seed_str: str | None
+        inbox_prefix: str | bytes
+        pending_size: int
+        flush_timeout: float | None
 
 
 class NatsBroker(
@@ -211,12 +211,12 @@ class NatsBroker(
         pending_size: int = DEFAULT_PENDING_SIZE,
         flush_timeout: float | None = None,
         js_options: Union["JsInitOptions", dict[str, Any], None] = None,
-         graceful_timeout: float | None = None,
-         ack_policy: AckPolicy = EMPTY,
-         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
-         parser: Optional["CustomCallable"] = None,
-         dependencies: Iterable["Dependant"] = (),
+        graceful_timeout: float | None = None,
+        ack_policy: AckPolicy = EMPTY,
+        decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
+        parser: Optional["CustomCallable"] = None,
+        dependencies: Iterable["Dependant"] = (),
         middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
         routers: Iterable[NatsRegistrator] = (),
         security: Optional["BaseSecurity"] = None,
@@ -293,27 +293,25 @@ class NatsBroker(
                 Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
             pending_size:
                 Max size of the pending buffer for publishing commands.
-            flush_timeout:
-                Max duration to wait for a forced flush to occur
-            js_options:
-                JetStream initialization options.
-            graceful_timeout:
-                Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
+             flush_timeout:
+                 Max duration to wait for a forced flush to occur
+             graceful_timeout:
+                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
              ack_policy:
                  Default acknowledgement policy for all subscribers. Individual subscribers can override.
              decoder:
-                 Custom decoder object
+                 Custom decoder object.
              codec:
-                 Custom codec object
+                 Custom codec object.
              parser:
                  Custom parser object.
-            dependencies:
-                Dependencies to apply to all broker subscribers.
-            middlewares:
-                "Middlewares to apply to all broker publishers/subscribers.
-            routers:
-                "Routers to apply to broker.
-            security:
+             dependencies:
+                 Dependencies to apply to all broker subscribers.
+             middlewares:
+                 Middlewares to apply to all broker publishers/subscribers.
+             routers:
+                 Routers to apply to broker.
+             security:
                 Security options to connect broker and generate AsyncAPI server security information.
             specification_url:
                 AsyncAPI hardcoded server addresses. Use `servers` if not specified.
@@ -396,16 +394,16 @@ class NatsBroker(
             user_jwt_cb=user_jwt_cb,
             # Basic args
             routers=routers,
-             config=NatsBrokerConfig(
-                 producer=producer,
-                 js_producer=js_producer,
-                 js_options=js_options or {},
-                 # both args
-                 broker_middlewares=middlewares,
-                 broker_parser=parser,
-                 broker_decoder=decoder,
-                 broker_codec=codec,
-                 logger=make_nats_logger_state(
+            config=NatsBrokerConfig(
+                producer=producer,
+                js_producer=js_producer,
+                js_options=js_options or {},
+                # both args
+                broker_middlewares=middlewares,
+                broker_parser=parser,
+                broker_decoder=decoder,
+                broker_codec=codec,
+                logger=make_nats_logger_state(
                     logger=logger,
                     log_level=log_level,
                 ),

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -50,123 +50,124 @@ from .logging import make_nats_logger_state
 from .registrator import NatsRegistrator
 
 if TYPE_CHECKING:
-    from types import TracebackType
+     from types import TracebackType
 
-    from fast_depends.dependencies import Dependant
-    from fast_depends.library.serializer import SerializerProto
-    from nats.aio.client import (
-        Callback,
-        Credentials,
-        ErrorCallback,
-        JWTCallback,
-        SignatureCallback,
-    )
-    from nats.js.api import Placement, RePublish, StorageType
-    from nats.js.kv import KeyValue
-    from nats.js.object_store import ObjectStore
-    from typing_extensions import TypedDict
+     from fast_depends.dependencies import Dependant
+     from fast_depends.library.serializer import SerializerProto
+     from nats.aio.client import (
+     Callback,
+     Credentials,
+     ErrorCallback,
+     JWTCallback,
+     SignatureCallback,
+     )
+     from nats.js.api import Placement, RePublish, StorageType
+     from nats.js.kv import KeyValue
+     from nats.js.object_store import ObjectStore
+     from typing_extensions import TypedDict
 
-    from faststream._internal.basic_types import LoggerProto, SendableMessage
-    from faststream._internal.types import BrokerMiddleware, CustomCallable
-    from faststream.nats.configs.broker import JsInitOptions
-    from faststream.nats.helpers import KVBucketDeclarer, OSBucketDeclarer
-    from faststream.nats.message import NatsMessage
-    from faststream.nats.schemas import PubAck, Schedule
-    from faststream.security import BaseSecurity
-    from faststream.specification.schema.extra import Tag, TagDict
+     from faststream._internal.basic_types import LoggerProto, SendableMessage
+     from faststream._internal.parser import CodecProto
+     from faststream._internal.types import BrokerMiddleware, CustomCallable
+     from faststream.nats.configs.broker import JsInitOptions
+     from faststream.nats.helpers import KVBucketDeclarer, OSBucketDeclarer
+     from faststream.nats.message import NatsMessage
+     from faststream.nats.schemas import PubAck, Schedule
+     from faststream.security import BaseSecurity
+     from faststream.specification.schema.extra import Tag, TagDict
 
-    class NatsInitKwargs(TypedDict, total=False):
-        """NatsBroker.connect() method type hints.
+     class NatsInitKwargs(TypedDict, total=False):
+         """NatsBroker.connect() method type hints.
 
-        Args:
-            error_cb:
-                Callback to report errors.
-            disconnected_cb: \
-                Callback to report disconnection from NATS.
-            closed_cb:
-                Callback to report when client stops reconnection to NATS.
-            discovered_server_cb:
-                A callback to report when a new server joins the cluster.
-            reconnected_cb:
-                Callback to report success reconnection.
-            name:
-                Label the connection with name (shown in NATS monitoring
-            pedantic:
-                Turn on NATS server pedantic mode that performs extra checks on the protocol.
-                https://docs.nats.io/using-nats/developer/connecting/misc#turn-on-pedantic-mode
-            verbose:
-                Verbose mode produce more feedback about code execution.
-            allow_reconnect:
-                Whether recover connection automatically or not.
-            connect_timeout:
-                Timeout in seconds to establish connection with NATS server.
-            reconnect_time_wait:
-                Time in seconds to wait for reestablish connection to NATS server
-            max_reconnect_attempts:
-                Maximum attempts number to reconnect to NATS server.
-            ping_interval:
-                Interval in seconds to ping.
-            max_outstanding_pings:
-                Maximum number of failed pings
-            dont_randomize:
-                Boolean indicating should client randomly shuffle servers list for reconnection randomness.
-            flusher_queue_size:
-                Max count of commands awaiting to be flushed to the socket
-            no_echo:
-                Boolean indicating should commands be echoed.
-            tls_hostname:
-                Hostname for TLS.
-            token:
-                Auth token for NATS auth.
-            drain_timeout:
-                Timeout in seconds to drain subscriptions.
-            signature_cb:
-                A callback used to sign a nonce from the server while authenticating with nkeys.
-                The user should sign the nonce and return the base64 encoded signature.
-            user_jwt_cb:
-                A callback used to fetch and return the account signed JWT for this user.
-            user_credentials:
-                A user credentials file or tuple of files.
-            nkeys_seed:
-                Path-like object containing nkeys seed that will be used.
-            nkeys_seed_str:
-                Nkeys seed to be used.
-            inbox_prefix:
-                Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
-            pending_size:
-                Max size of the pending buffer for publishing commands.
-            flush_timeout:
-                Max duration to wait for a forced flush to occur
-        """
+         Args:
+         error_cb:
+         Callback to report errors.
+         disconnected_cb: \
+         Callback to report disconnection from NATS.
+         closed_cb:
+         Callback to report when client stops reconnection to NATS.
+         discovered_server_cb:
+         A callback to report when a new server joins the cluster.
+         reconnected_cb:
+         Callback to report success reconnection.
+         name:
+         Label the connection with name (shown in NATS monitoring
+         pedantic:
+         Turn on NATS server pedantic mode that performs extra checks on the protocol.
+         https://docs.nats.io/using-nats/developer/connecting/misc#turn-on-pedantic-mode
+         verbose:
+         Verbose mode produce more feedback about code execution.
+         allow_reconnect:
+         Whether recover connection automatically or not.
+         connect_timeout:
+         Timeout in seconds to establish connection with NATS server.
+         reconnect_time_wait:
+         Time in seconds to wait for reestablish connection to NATS server
+         max_reconnect_attempts:
+         Maximum attempts number to reconnect to NATS server.
+         ping_interval:
+         Interval in seconds to ping.
+         max_outstanding_pings:
+         Maximum number of failed pings
+         dont_randomize:
+         Boolean indicating should client randomly shuffle servers list for reconnection randomness.
+         flusher_queue_size:
+         Max count of commands awaiting to be flushed to the socket
+         no_echo:
+         Boolean indicating should commands be echoed.
+         tls_hostname:
+         Hostname for TLS.
+         token:
+         Auth token for NATS auth.
+         drain_timeout:
+         Timeout in seconds to drain subscriptions.
+         signature_cb:
+         A callback used to sign a nonce from the server while authenticating with nkeys.
+         The user should sign the nonce and return the base64 encoded signature.
+         user_jwt_cb:
+         A callback used to fetch and return the account signed JWT for this user.
+         user_credentials:
+         A user credentials file or tuple of files.
+         nkeys_seed:
+         Path-like object containing nkeys seed that will be used.
+         nkeys_seed_str:
+         Nkeys seed to be used.
+         inbox_prefix:
+         Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
+         pending_size:
+         Max size of the pending buffer for publishing commands.
+         flush_timeout:
+         Max duration to wait for a forced flush to occur
+         """
 
-        error_cb: "ErrorCallback" | None
-        disconnected_cb: "Callback" | None
-        closed_cb: Callback | None
-        discovered_server_cb: "Callback" | None
-        reconnected_cb: "Callback" | None
-        name: str | None
-        pedantic: bool
-        verbose: bool
-        allow_reconnect: bool
-        connect_timeout: int
-        reconnect_time_wait: int
-        max_reconnect_attempts: int
-        ping_interval: int
-        max_outstanding_pings: int
-        dont_randomize: bool
-        flusher_queue_size: int
-        no_echo: bool
-        tls_hostname: str | None
-        token: str | None
-        drain_timeout: int
-        signature_cb: "SignatureCallback" | None
-        user_jwt_cb: "JWTCallback" | None
-        user_credentials: "Credentials" | None
-        nkeys_seed: str | None
-        nkeys_seed_str: str | None
-        inbox_prefix: str | bytes
-        pending_size: int
-        flush_timeout: float | None
+         error_cb: "ErrorCallback" | None
+         disconnected_cb: "Callback" | None
+         closed_cb: Callback | None
+         discovered_server_cb: "Callback" | None
+         reconnected_cb: "Callback" | None
+         name: str | None
+         pedantic: bool
+         verbose: bool
+         allow_reconnect: bool
+         connect_timeout: int
+         reconnect_time_wait: int
+         max_reconnect_attempts: int
+         ping_interval: int
+         max_outstanding_pings: int
+         dont_randomize: bool
+         flusher_queue_size: int
+         no_echo: bool
+         tls_hostname: str | None
+         token: str | None
+         drain_timeout: int
+         signature_cb: "SignatureCallback" | None
+         user_jwt_cb: "JWTCallback" | None
+         user_credentials: "Credentials" | None
+         nkeys_seed: str | None
+         nkeys_seed_str: str | None
+         inbox_prefix: str | bytes
+         pending_size: int
+         flush_timeout: float | None
 
 
 class NatsBroker(
@@ -210,11 +211,12 @@ class NatsBroker(
         pending_size: int = DEFAULT_PENDING_SIZE,
         flush_timeout: float | None = None,
         js_options: Union["JsInitOptions", dict[str, Any], None] = None,
-        graceful_timeout: float | None = None,
-        ack_policy: AckPolicy = EMPTY,
-        decoder: Optional["CustomCallable"] = None,
-        parser: Optional["CustomCallable"] = None,
-        dependencies: Iterable["Dependant"] = (),
+         graceful_timeout: float | None = None,
+         ack_policy: AckPolicy = EMPTY,
+         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
+         parser: Optional["CustomCallable"] = None,
+         dependencies: Iterable["Dependant"] = (),
         middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
         routers: Iterable[NatsRegistrator] = (),
         security: Optional["BaseSecurity"] = None,
@@ -297,12 +299,14 @@ class NatsBroker(
                 JetStream initialization options.
             graceful_timeout:
                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-            ack_policy:
-                Default acknowledgement policy for all subscribers. Individual subscribers can override.
-            decoder:
-                Custom decoder object
-            parser:
-                Custom parser object.
+             ack_policy:
+                 Default acknowledgement policy for all subscribers. Individual subscribers can override.
+             decoder:
+                 Custom decoder object
+             codec:
+                 Custom codec object
+             parser:
+                 Custom parser object.
             dependencies:
                 Dependencies to apply to all broker subscribers.
             middlewares:
@@ -392,15 +396,16 @@ class NatsBroker(
             user_jwt_cb=user_jwt_cb,
             # Basic args
             routers=routers,
-            config=NatsBrokerConfig(
-                producer=producer,
-                js_producer=js_producer,
-                js_options=js_options or {},
-                # both args
-                broker_middlewares=middlewares,
-                broker_parser=parser,
-                broker_decoder=decoder,
-                logger=make_nats_logger_state(
+             config=NatsBrokerConfig(
+                 producer=producer,
+                 js_producer=js_producer,
+                 js_options=js_options or {},
+                 # both args
+                 broker_middlewares=middlewares,
+                 broker_parser=parser,
+                 broker_decoder=decoder,
+                 broker_codec=codec,
+                 logger=make_nats_logger_state(
                     logger=logger,
                     log_level=log_level,
                 ),

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -293,25 +293,27 @@ class NatsBroker(
                 Prefix for generating unique inboxes, subjects with that prefix and NUID.ß
             pending_size:
                 Max size of the pending buffer for publishing commands.
-             flush_timeout:
-                 Max duration to wait for a forced flush to occur
-             graceful_timeout:
-                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-             ack_policy:
-                 Default acknowledgement policy for all subscribers. Individual subscribers can override.
-             decoder:
-                 Custom decoder object.
-             codec:
-                 Custom codec object.
-             parser:
-                 Custom parser object.
-             dependencies:
-                 Dependencies to apply to all broker subscribers.
-             middlewares:
-                 Middlewares to apply to all broker publishers/subscribers.
-             routers:
-                 Routers to apply to broker.
-             security:
+            flush_timeout:
+                Max duration to wait for a forced flush to occur
+            js_options:
+                JetStream options to pass to the connection.
+            graceful_timeout:
+                Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
+            ack_policy:
+                Default acknowledgement policy for all subscribers. Individual subscribers can override.
+            decoder:
+                Custom decoder object.
+            codec:
+                Custom codec object.
+            parser:
+                Custom parser object.
+            dependencies:
+                Dependencies to apply to all broker subscribers.
+            middlewares:
+                Middlewares to apply to all broker publishers/subscribers.
+            routers:
+                Routers to apply to broker.
+            security:
                 Security options to connect broker and generate AsyncAPI server security information.
             specification_url:
                 AsyncAPI hardcoded server addresses. Use `servers` if not specified.

--- a/faststream/nats/broker/registrator.py
+++ b/faststream/nats/broker/registrator.py
@@ -16,25 +16,26 @@ from faststream.nats.schemas import JStream, KvWatch, ObjWatch, PullSub
 from faststream.nats.subscriber.factory import create_subscriber
 
 if TYPE_CHECKING:
-    from fast_depends.dependencies import Dependant
+     from fast_depends.dependencies import Dependant
 
-    from faststream._internal.types import (
-        BrokerMiddleware,
-        CustomCallable,
-    )
-    from faststream.nats.publisher.usecase import LogicPublisher
-    from faststream.nats.subscriber.usecases import (
-        BatchPullStreamSubscriber,
-        ConcurrentCoreSubscriber,
-        ConcurrentPullStreamSubscriber,
-        ConcurrentPushStreamSubscriber,
-        CoreSubscriber,
-        KeyValueWatchSubscriber,
-        LogicSubscriber,
-        ObjStoreWatchSubscriber,
-        PullStreamSubscriber,
-        PushStreamSubscriber,
-    )
+     from faststream._internal.parser import CodecProto
+     from faststream._internal.types import (
+     BrokerMiddleware,
+     CustomCallable,
+     )
+     from faststream.nats.publisher.usecase import LogicPublisher
+     from faststream.nats.subscriber.usecases import (
+     BatchPullStreamSubscriber,
+     ConcurrentCoreSubscriber,
+     ConcurrentPullStreamSubscriber,
+     ConcurrentPushStreamSubscriber,
+     CoreSubscriber,
+     KeyValueWatchSubscriber,
+     LogicSubscriber,
+     ObjStoreWatchSubscriber,
+     PullStreamSubscriber,
+     PushStreamSubscriber,
+     )
 
 
 class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
@@ -73,6 +74,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -111,6 +113,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
@@ -149,6 +152,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -187,6 +191,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
@@ -225,6 +230,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -263,6 +269,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
@@ -301,6 +308,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -339,6 +347,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -377,6 +386,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -415,6 +425,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int | None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -453,6 +464,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+         codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int | None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -545,6 +557,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         return subscriber.add_call(
             parser_=parser,
             decoder_=decoder,
+            codec_=codec,
             dependencies_=dependencies,
         )
 

--- a/faststream/nats/broker/registrator.py
+++ b/faststream/nats/broker/registrator.py
@@ -504,13 +504,13 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
             kv_watch: KeyValue watch parameters container.
             obj_watch: ObjectStore watch parameters container.
             inbox_prefix: Prefix for generating unique inboxes, subjects with that prefix and NUID.
-             stream: Subscribe to NATS Stream with `subject` filter.
-             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-             parser: Parser to map original **nats-py** Msg to FastStream one.
-             decoder: Function to decode FastStream msg bytes body to python objects.
-             codec: Custom codec object.
-             max_workers: Number of workers to process messages concurrently.
-             ack_policy: Whether to `ack` message at start of consuming or not.
+            stream: Subscribe to NATS Stream with `subject` filter.
+            dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+            parser: Parser to map original **nats-py** Msg to FastStream one.
+            decoder: Function to decode FastStream msg bytes body to python objects.
+            codec: Custom codec object.
+            max_workers: Number of workers to process messages concurrently.
+            ack_policy: Whether to `ack` message at start of consuming or not.
             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
             title: AsyncAPI subscriber object title.
             description: AsyncAPI subscriber object description. Uses decorated docstring as default.

--- a/faststream/nats/broker/registrator.py
+++ b/faststream/nats/broker/registrator.py
@@ -16,26 +16,26 @@ from faststream.nats.schemas import JStream, KvWatch, ObjWatch, PullSub
 from faststream.nats.subscriber.factory import create_subscriber
 
 if TYPE_CHECKING:
-     from fast_depends.dependencies import Dependant
+    from fast_depends.dependencies import Dependant
 
-     from faststream._internal.parser import CodecProto
-     from faststream._internal.types import (
-     BrokerMiddleware,
-     CustomCallable,
-     )
-     from faststream.nats.publisher.usecase import LogicPublisher
-     from faststream.nats.subscriber.usecases import (
-     BatchPullStreamSubscriber,
-     ConcurrentCoreSubscriber,
-     ConcurrentPullStreamSubscriber,
-     ConcurrentPushStreamSubscriber,
-     CoreSubscriber,
-     KeyValueWatchSubscriber,
-     LogicSubscriber,
-     ObjStoreWatchSubscriber,
-     PullStreamSubscriber,
-     PushStreamSubscriber,
-     )
+    from faststream._internal.parser import CodecProto
+    from faststream._internal.types import (
+        BrokerMiddleware,
+        CustomCallable,
+    )
+    from faststream.nats.publisher.usecase import LogicPublisher
+    from faststream.nats.subscriber.usecases import (
+        BatchPullStreamSubscriber,
+        ConcurrentCoreSubscriber,
+        ConcurrentPullStreamSubscriber,
+        ConcurrentPushStreamSubscriber,
+        CoreSubscriber,
+        KeyValueWatchSubscriber,
+        LogicSubscriber,
+        ObjStoreWatchSubscriber,
+        PullStreamSubscriber,
+        PushStreamSubscriber,
+    )
 
 
 class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
@@ -74,7 +74,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -113,7 +113,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
@@ -152,7 +152,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -191,7 +191,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
@@ -230,7 +230,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -269,7 +269,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int = ...,
         ack_policy: AckPolicy = EMPTY,
@@ -308,7 +308,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -347,7 +347,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -386,7 +386,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -425,7 +425,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int | None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -464,7 +464,7 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
-         codec: Optional["CodecProto"] = None,
+        codec: Optional["CodecProto"] = None,
         persistent: bool = True,
         max_workers: int | None = None,
         ack_policy: AckPolicy = EMPTY,
@@ -504,12 +504,13 @@ class NatsRegistrator(Registrator[Msg, NatsBrokerConfig]):
             kv_watch: KeyValue watch parameters container.
             obj_watch: ObjectStore watch parameters container.
             inbox_prefix: Prefix for generating unique inboxes, subjects with that prefix and NUID.
-            stream: Subscribe to NATS Stream with `subject` filter.
-            dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-            parser: Parser to map original **nats-py** Msg to FastStream one.
-            decoder: Function to decode FastStream msg bytes body to python objects.
-            max_workers: Number of workers to process messages concurrently.
-            ack_policy: Whether to `ack` message at start of consuming or not.
+             stream: Subscribe to NATS Stream with `subject` filter.
+             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+             parser: Parser to map original **nats-py** Msg to FastStream one.
+             decoder: Function to decode FastStream msg bytes body to python objects.
+             codec: Custom codec object.
+             max_workers: Number of workers to process messages concurrently.
+             ack_policy: Whether to `ack` message at start of consuming or not.
             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
             title: AsyncAPI subscriber object title.
             description: AsyncAPI subscriber object description. Uses decorated docstring as default.

--- a/faststream/rabbit/__init__.py
+++ b/faststream/rabbit/__init__.py
@@ -1,4 +1,13 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.testing.app import TestApp
+
+if TYPE_CHECKING:
+    from aio_pika import IncomingMessage
+
+    from faststream._internal.parser import ParserProto
+
+    RabbitParserType = ParserProto["IncomingMessage"]
 
 try:
     from .annotations import RabbitMessage
@@ -28,6 +37,7 @@ __all__ = (
     "RabbitBroker",
     "RabbitExchange",
     "RabbitMessage",
+    "RabbitParserType",
     "RabbitPublishCommand",
     "RabbitPublisher",
     "RabbitQueue",

--- a/faststream/rabbit/__init__.py
+++ b/faststream/rabbit/__init__.py
@@ -3,11 +3,9 @@ from typing import TYPE_CHECKING
 from faststream._internal.testing.app import TestApp
 
 if TYPE_CHECKING:
-    from aio_pika import IncomingMessage
-
     from faststream._internal.parser import ParserProto
 
-    RabbitParserType = ParserProto["IncomingMessage"]
+    RabbitParserType = ParserProto["IncomingMessage"]  # type: ignore[name-defined]
 
 try:
     from .annotations import RabbitMessage

--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -127,14 +127,15 @@ class RabbitBroker(
             timeout: Connection establishment timeout.
             fail_fast: Broker startup raises `AMQPConnectionError` if RabbitMQ is unreachable.
             reconnect_interval: Time to sleep between reconnection attempts.
-            default_channel: Default channel settings to use.
-            app_id: Application name to mark outgoing messages by.
-            graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-            ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
-            decoder: Custom decoder object.
-            parser: Custom parser object.
-            dependencies: Dependencies to apply to all broker subscribers.
-            middlewares: Middlewares to apply to all broker publishers/subscribers.
+             default_channel: Default channel settings to use.
+             app_id: Application name to mark outgoing messages by.
+             graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
+             ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
+             decoder: Custom decoder object.
+             codec: Custom codec object.
+             parser: Custom parser object.
+             dependencies: Dependencies to apply to all broker subscribers.
+             middlewares: Middlewares to apply to all broker publishers/subscribers.
             routers: RabbitRouters to build a broker with.
             security: Security options to connect broker and generate AsyncAPI server security information.
             specification_url: AsyncAPI hardcoded server addresses. Use `servers` if not specified.

--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -127,15 +127,15 @@ class RabbitBroker(
             timeout: Connection establishment timeout.
             fail_fast: Broker startup raises `AMQPConnectionError` if RabbitMQ is unreachable.
             reconnect_interval: Time to sleep between reconnection attempts.
-             default_channel: Default channel settings to use.
-             app_id: Application name to mark outgoing messages by.
-             graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
-             ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
-             decoder: Custom decoder object.
-             codec: Custom codec object.
-             parser: Custom parser object.
-             dependencies: Dependencies to apply to all broker subscribers.
-             middlewares: Middlewares to apply to all broker publishers/subscribers.
+            default_channel: Default channel settings to use.
+            app_id: Application name to mark outgoing messages by.
+            graceful_timeout: Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down.
+            ack_policy: Default acknowledgement policy for all subscribers. Individual subscribers can override.
+            decoder: Custom decoder object.
+            codec: Custom codec object.
+            parser: Custom parser object.
+            dependencies: Dependencies to apply to all broker subscribers.
+            middlewares: Middlewares to apply to all broker publishers/subscribers.
             routers: RabbitRouters to build a broker with.
             security: Security options to connect broker and generate AsyncAPI server security information.
             specification_url: AsyncAPI hardcoded server addresses. Use `servers` if not specified.

--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from yarl import URL
 
     from faststream._internal.basic_types import LoggerProto
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -93,6 +94,7 @@ class RabbitBroker(
         graceful_timeout: float | None = None,
         ack_policy: AckPolicy = EMPTY,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         parser: Optional["CustomCallable"] = None,
         dependencies: Iterable["Dependant"] = (),
         middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
@@ -197,6 +199,7 @@ class RabbitBroker(
                 broker_middlewares=middlewares,
                 broker_parser=parser,
                 broker_decoder=decoder,
+                broker_codec=codec,
                 logger=make_rabbit_logger_state(
                     logger=logger,
                     log_level=log_level,

--- a/faststream/rabbit/broker/registrator.py
+++ b/faststream/rabbit/broker/registrator.py
@@ -62,12 +62,13 @@ class RabbitRegistrator(Registrator[IncomingMessage, RabbitBrokerConfig]):
             exchange (Union[str, RabbitExchange, None], optional): RabbitMQ exchange to bind queue to. Uses default exchange if not presented. **FastStream** declares exchange object automatically by default.
             channel (Optional[Channel], optional): Channel to use for consuming messages.
             consume_args (dict[str, Any] | None, optional): Extra consumer arguments to use in `queue.consume(...)` method.
-            ack_policy (AckPolicy, optional): Acknowledgement policy for message processing.
-            dependencies (Iterable[Dependant], optional): Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-            parser (Optional[CustomCallable], optional): Parser to map original **IncomingMessage** Msg to FastStream one.
-            decoder (Optional[CustomCallable], optional): Function to decode FastStream msg bytes body to python objects.
-            no_reply (bool, optional): Whether to disable **FastStream** RPC and Reply To auto responses or not.
-            title (Optional[str], optional): AsyncAPI subscriber object title.
+             ack_policy (AckPolicy, optional): Acknowledgement policy for message processing.
+             dependencies (Iterable[Dependant], optional): Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+             parser (Optional[CustomCallable], optional): Parser to map original **IncomingMessage** Msg to FastStream one.
+             decoder (Optional[CustomCallable], optional): Function to decode FastStream msg bytes body to python objects.
+             codec (Optional[CodecProto], optional): Custom codec object.
+             no_reply (bool, optional): Whether to disable **FastStream** RPC and Reply To auto responses or not.
+             title (Optional[str], optional): AsyncAPI subscriber object title.
             description (Optional[str], optional): AsyncAPI subscriber object description. Uses decorated docstring as default.
             include_in_schema (bool, optional): Whether to include operation in AsyncAPI schema or not.
             persistent (bool): Whether to make the subscriber persistent or not.

--- a/faststream/rabbit/broker/registrator.py
+++ b/faststream/rabbit/broker/registrator.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from aio_pika.abc import DateType, HeadersType, TimeoutType
     from fast_depends.dependencies import Dependant
 
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -46,6 +47,7 @@ class RabbitRegistrator(Registrator[IncomingMessage, RabbitBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         no_reply: bool = False,
         persistent: bool = True,
         # AsyncAPI information
@@ -94,6 +96,7 @@ class RabbitRegistrator(Registrator[IncomingMessage, RabbitBrokerConfig]):
         return subscriber.add_call(
             parser_=parser,
             decoder_=decoder,
+            codec_=codec,
             dependencies_=dependencies,
         )
 

--- a/faststream/rabbit/broker/registrator.py
+++ b/faststream/rabbit/broker/registrator.py
@@ -62,13 +62,13 @@ class RabbitRegistrator(Registrator[IncomingMessage, RabbitBrokerConfig]):
             exchange (Union[str, RabbitExchange, None], optional): RabbitMQ exchange to bind queue to. Uses default exchange if not presented. **FastStream** declares exchange object automatically by default.
             channel (Optional[Channel], optional): Channel to use for consuming messages.
             consume_args (dict[str, Any] | None, optional): Extra consumer arguments to use in `queue.consume(...)` method.
-             ack_policy (AckPolicy, optional): Acknowledgement policy for message processing.
-             dependencies (Iterable[Dependant], optional): Dependencies list (`[Dependant(),]`) to apply to the subscriber.
-             parser (Optional[CustomCallable], optional): Parser to map original **IncomingMessage** Msg to FastStream one.
-             decoder (Optional[CustomCallable], optional): Function to decode FastStream msg bytes body to python objects.
-             codec (Optional[CodecProto], optional): Custom codec object.
-             no_reply (bool, optional): Whether to disable **FastStream** RPC and Reply To auto responses or not.
-             title (Optional[str], optional): AsyncAPI subscriber object title.
+            ack_policy (AckPolicy, optional): Acknowledgement policy for message processing.
+            dependencies (Iterable[Dependant], optional): Dependencies list (`[Dependant(),]`) to apply to the subscriber.
+            parser (Optional[CustomCallable], optional): Parser to map original **IncomingMessage** Msg to FastStream one.
+            decoder (Optional[CustomCallable], optional): Function to decode FastStream msg bytes body to python objects.
+            codec (Optional[CodecProto], optional): Custom codec object.
+            no_reply (bool, optional): Whether to disable **FastStream** RPC and Reply To auto responses or not.
+            title (Optional[str], optional): AsyncAPI subscriber object title.
             description (Optional[str], optional): AsyncAPI subscriber object description. Uses decorated docstring as default.
             include_in_schema (bool, optional): Whether to include operation in AsyncAPI schema or not.
             persistent (bool): Whether to make the subscriber persistent or not.

--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -3,12 +3,9 @@ from typing import TYPE_CHECKING
 from faststream._internal.testing.app import TestApp
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from typing import Any
-
     from faststream._internal.parser import ParserProto
 
-    RedisParserType = ParserProto["Mapping[str, Any]"]
+    RedisParserType = ParserProto["Mapping[str, Any]"]  # type: ignore[name-defined]
 
 try:
     from .annotations import (

--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -1,4 +1,14 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.testing.app import TestApp
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+    from faststream._internal.parser import ParserProto
+
+    RedisParserType = ParserProto["Mapping[str, Any]"]
 
 try:
     from .annotations import (
@@ -33,6 +43,7 @@ __all__ = (
     "RedisChannelMessage",
     "RedisListMessage",
     "RedisMessage",
+    "RedisParserType",
     "RedisPublishCommand",
     "RedisPublisher",
     "RedisResponse",

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypedDict
 
     from faststream._internal.basic_types import LoggerProto, SendableMessage
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import BrokerMiddleware, CustomCallable
     from faststream.redis.message import RedisChannelMessage
     from faststream.security import BaseSecurity
@@ -109,6 +110,7 @@ class RedisBroker(
         graceful_timeout: float | None = 15.0,
         ack_policy: AckPolicy = EMPTY,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         parser: Optional["CustomCallable"] = None,
         dependencies: Iterable["Dependant"] = (),
         middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
@@ -260,6 +262,7 @@ class RedisBroker(
                 broker_middlewares=middlewares,
                 broker_parser=parser,
                 broker_decoder=decoder,
+                broker_codec=codec,
                 logger=make_redis_logger_state(
                     logger=logger,
                     log_level=log_level,

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -170,17 +170,19 @@ class RedisBroker(
                 The class to use for parsing messages. Defaults to DefaultParser.
             encoder_class:
                 The class to use for encoding messages. Defaults to Encoder.
-            graceful_timeout:
-                Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down. Defaults to 15.0.
-            ack_policy:
-                Default acknowledgement policy for all subscribers. Individual subscribers can override.
-            decoder:
-                Custom decoder object. Defaults to None.
-            parser:
-                Custom parser object. Defaults to None.
-            dependencies:
-                Dependencies to apply to all broker subscribers. Defaults to ().
-            middlewares:
+             graceful_timeout:
+                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down. Defaults to 15.0.
+             ack_policy:
+                 Default acknowledgement policy for all subscribers. Individual subscribers can override.
+             decoder:
+                 Custom decoder object. Defaults to None.
+             codec:
+                 Custom codec object. Defaults to None.
+             parser:
+                 Custom parser object. Defaults to None.
+             dependencies:
+                 Dependencies to apply to all broker subscribers. Defaults to ().
+             middlewares:
                 Middlewares to apply to all broker publishers/subscribers. Defaults to ().
             routers:
                 Routers to apply to broker. Defaults to ().

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -170,19 +170,19 @@ class RedisBroker(
                 The class to use for parsing messages. Defaults to DefaultParser.
             encoder_class:
                 The class to use for encoding messages. Defaults to Encoder.
-             graceful_timeout:
-                 Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down. Defaults to 15.0.
-             ack_policy:
-                 Default acknowledgement policy for all subscribers. Individual subscribers can override.
-             decoder:
-                 Custom decoder object. Defaults to None.
-             codec:
-                 Custom codec object. Defaults to None.
-             parser:
-                 Custom parser object. Defaults to None.
-             dependencies:
-                 Dependencies to apply to all broker subscribers. Defaults to ().
-             middlewares:
+            graceful_timeout:
+                Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down. Defaults to 15.0.
+            ack_policy:
+                Default acknowledgement policy for all subscribers. Individual subscribers can override.
+            decoder:
+                Custom decoder object. Defaults to None.
+            codec:
+                Custom codec object. Defaults to None.
+            parser:
+                Custom parser object. Defaults to None.
+            dependencies:
+                Dependencies to apply to all broker subscribers. Defaults to ().
+            middlewares:
                 Middlewares to apply to all broker publishers/subscribers. Defaults to ().
             routers:
                 Routers to apply to broker. Defaults to ().

--- a/faststream/redis/broker/registrator.py
+++ b/faststream/redis/broker/registrator.py
@@ -15,6 +15,7 @@ from faststream.redis.subscriber.factory import create_subscriber
 if TYPE_CHECKING:
     from fast_depends.dependencies import Dependant
 
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         BrokerMiddleware,
         CustomCallable,
@@ -55,6 +56,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -77,6 +79,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -99,6 +102,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -120,6 +124,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -142,6 +147,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -164,6 +170,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -186,6 +193,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -208,6 +216,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -230,6 +239,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -252,6 +262,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         dependencies: Iterable["Dependant"] = (),
         parser: Optional["CustomCallable"] = None,
         decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
         ack_policy: AckPolicy = EMPTY,
         no_reply: bool = False,
         message_format: type["MessageFormat"] | None = None,
@@ -304,6 +315,7 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         return subscriber.add_call(
             parser_=parser or self._parser,
             decoder_=decoder or self._decoder,
+            codec_=codec,
             dependencies_=dependencies,
         )
 

--- a/faststream/redis/broker/registrator.py
+++ b/faststream/redis/broker/registrator.py
@@ -278,13 +278,14 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         Args:
             channel: Redis PubSub object name to send message.
             list: Redis List object name to send message.
-            stream: Redis Stream object name to send message.
-            ack_policy: Acknowledgement policy for message processing.
-            dependencies: Dependencies list (`[Depends(),]`) to apply to the subscriber.
-            parser: Parser to map original **IncomingMessage** Msg to FastStream one.
-            decoder: Function to decode FastStream msg bytes body to python objects.
-            no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
-            message_format: Which format to use when parsing messages.
+             stream: Redis Stream object name to send message.
+             ack_policy: Acknowledgement policy for message processing.
+             dependencies: Dependencies list (`[Depends(),]`) to apply to the subscriber.
+             parser: Parser to map original **IncomingMessage** Msg to FastStream one.
+             decoder: Function to decode FastStream msg bytes body to python objects.
+             codec: Custom codec object.
+             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
+             message_format: Which format to use when parsing messages.
             persistent: Whether to make the subscriber persistent or not.
             max_workers: Number of workers to process messages concurrently.
             title: AsyncAPI subscriber object title.

--- a/faststream/redis/broker/registrator.py
+++ b/faststream/redis/broker/registrator.py
@@ -278,14 +278,14 @@ class RedisRegistrator(Registrator[UnifyRedisDict, RedisBrokerConfig]):
         Args:
             channel: Redis PubSub object name to send message.
             list: Redis List object name to send message.
-             stream: Redis Stream object name to send message.
-             ack_policy: Acknowledgement policy for message processing.
-             dependencies: Dependencies list (`[Depends(),]`) to apply to the subscriber.
-             parser: Parser to map original **IncomingMessage** Msg to FastStream one.
-             decoder: Function to decode FastStream msg bytes body to python objects.
-             codec: Custom codec object.
-             no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
-             message_format: Which format to use when parsing messages.
+            stream: Redis Stream object name to send message.
+            ack_policy: Acknowledgement policy for message processing.
+            dependencies: Dependencies list (`[Depends(),]`) to apply to the subscriber.
+            parser: Parser to map original **IncomingMessage** Msg to FastStream one.
+            decoder: Function to decode FastStream msg bytes body to python objects.
+            codec: Custom codec object.
+            no_reply: Whether to disable **FastStream** RPC and Reply To auto responses or not.
+            message_format: Which format to use when parsing messages.
             persistent: Whether to make the subscriber persistent or not.
             max_workers: Number of workers to process messages concurrently.
             title: AsyncAPI subscriber object title.

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -70,7 +70,7 @@ class CodecTestcase(BaseTestcaseConfig):
         # which TestBroker.__aenter__ calls before yielding — hence it propagates
         # from the "async with" expression rather than from the body.
         with pytest.raises(ValueError, match="codec"):
-            async with self.patch_broker(broker) as br:
+            async with self.patch_broker(broker):
                 pass  # pragma: no cover
 
     async def test_broker_level_codec(

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -46,9 +46,9 @@ class CodecTestcase(BaseTestcaseConfig):
             mock(m)
 
         async with self.patch_broker(broker) as br:
-            await br.publish(b"hello", queue)
+            await br.publish({"key": "value"}, queue)
 
-        mock.assert_called_once_with(b"hello")
+        mock.assert_called_once_with({"key": "value"})
 
     async def test_codec_and_decoder_conflict_raises(
         self,

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -1,0 +1,97 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from faststream._internal.parser import DefaultCodec
+from tests.brokers.base.basic import BaseTestcaseConfig
+
+
+@pytest.mark.asyncio()
+class CodecTestcase(BaseTestcaseConfig):
+    async def test_codec_decode_called(
+        self,
+        mock: MagicMock,
+        queue: str,
+    ) -> None:
+        class TrackingCodec(DefaultCodec):
+            async def decode(self, msg):
+                mock()
+                return await super().decode(msg)
+
+        codec = TrackingCodec()
+        broker = self.get_broker()
+
+        args, kwargs = self.get_subscriber_params(queue, codec=codec)
+
+        @broker.subscriber(*args, **kwargs)
+        async def handle(m) -> None:
+            pass
+
+        async with self.patch_broker(broker) as br:
+            await br.publish(b"hello", queue)
+
+        mock.assert_called_once()
+
+    async def test_codec_not_set_uses_default(
+        self,
+        mock: MagicMock,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker()
+
+        args, kwargs = self.get_subscriber_params(queue)
+
+        @broker.subscriber(*args, **kwargs)
+        async def handle(m) -> None:
+            mock(m)
+
+        async with self.patch_broker(broker) as br:
+            await br.publish(b"hello", queue)
+
+        mock.assert_called_once_with(b"hello")
+
+    async def test_codec_and_decoder_conflict_raises(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker()
+        codec = DefaultCodec()
+
+        async def my_decoder(msg, original):
+            return await original(msg)
+
+        args, kwargs = self.get_subscriber_params(queue, codec=codec, decoder=my_decoder)
+
+        @broker.subscriber(*args, **kwargs)
+        async def handle(m) -> None:
+            pass  # pragma: no cover
+
+        # ValueError raised inside _get_parser_and_decoder() during start(),
+        # which TestBroker.__aenter__ calls before yielding — hence it propagates
+        # from the "async with" expression rather than from the body.
+        with pytest.raises(ValueError, match="codec"):
+            async with self.patch_broker(broker) as br:
+                pass  # pragma: no cover
+
+    async def test_broker_level_codec(
+        self,
+        mock: MagicMock,
+        queue: str,
+    ) -> None:
+        class TrackingCodec(DefaultCodec):
+            async def decode(self, msg):
+                mock()
+                return await super().decode(msg)
+
+        broker = self.get_broker(codec=TrackingCodec())
+
+        args, kwargs = self.get_subscriber_params(queue)
+
+        @broker.subscriber(*args, **kwargs)
+        async def handle(m) -> None:
+            pass
+
+        async with self.patch_broker(broker) as br:
+            await br.publish(b"hello", queue)
+
+        mock.assert_called_once()

--- a/tests/brokers/confluent/test_codec.py
+++ b/tests/brokers/confluent/test_codec.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.brokers.base.codec import CodecTestcase
+
+from .basic import ConfluentMemoryTestcaseConfig
+
+
+@pytest.mark.confluent()
+@pytest.mark.asyncio()
+class TestConfluentCodec(ConfluentMemoryTestcaseConfig, CodecTestcase):
+    pass

--- a/tests/brokers/kafka/test_codec.py
+++ b/tests/brokers/kafka/test_codec.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.brokers.base.codec import CodecTestcase
+
+from .basic import KafkaMemoryTestcaseConfig
+
+
+@pytest.mark.kafka()
+@pytest.mark.asyncio()
+class TestKafkaCodec(KafkaMemoryTestcaseConfig, CodecTestcase):
+    pass

--- a/tests/brokers/mqtt/test_codec.py
+++ b/tests/brokers/mqtt/test_codec.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.brokers.base.codec import CodecTestcase
+
+from .basic import MQTTMemoryTestcaseConfig
+
+
+@pytest.mark.mqtt()
+@pytest.mark.asyncio()
+class TestMQTTCodec(MQTTMemoryTestcaseConfig, CodecTestcase):
+    pass

--- a/tests/brokers/nats/test_codec.py
+++ b/tests/brokers/nats/test_codec.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.brokers.base.codec import CodecTestcase
+
+from .basic import NatsMemoryTestcaseConfig
+
+
+@pytest.mark.nats()
+@pytest.mark.asyncio()
+class TestNatsCodec(NatsMemoryTestcaseConfig, CodecTestcase):
+    pass

--- a/tests/brokers/rabbit/test_codec.py
+++ b/tests/brokers/rabbit/test_codec.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.brokers.base.codec import CodecTestcase
+
+from .basic import RabbitMemoryTestcaseConfig
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+class TestRabbitCodec(RabbitMemoryTestcaseConfig, CodecTestcase):
+    pass

--- a/tests/brokers/redis/test_codec.py
+++ b/tests/brokers/redis/test_codec.py
@@ -1,0 +1,11 @@
+import pytest
+
+from tests.brokers.base.codec import CodecTestcase
+
+from .basic import RedisMemoryTestcaseConfig
+
+
+@pytest.mark.redis()
+@pytest.mark.asyncio()
+class TestRedisCodec(RedisMemoryTestcaseConfig, CodecTestcase):
+    pass


### PR DESCRIPTION
# Codec Protocol + Subscriber Wiring

## What

Adds `CodecProto` — a stateful, async codec interface for encoding/decoding message bodies — and wires the decode side into the subscriber pipeline. This enables use cases like Avro + Schema Registry where the codec needs state (registry client), async network calls, and custom wire framing.

WIP #2837 

## Changes

- **`CodecProto`** protocol with `async encode()` and `async decode()` in `faststream/_internal/parser.py`
- **`DefaultCodec`** class wrapping existing `encode_message`/`decode_message` — zero behavior change for existing code
- **`codec=` parameter** on all 6 brokers' `__init__()` and `subscriber()` methods
- **Codec-aware decoder resolution** in `_get_parser_and_decoder()` — when `codec=` is set, `codec.decode` replaces the decoder callable
- **`ValueError`** when both `codec=` and `decoder=` are provided (ambiguous)
- **Broker parser type aliases** (`KafkaParserType`, `NatsParserType`, etc.) exported from each broker's `__init__.py`
- **`CodecTestcase`** base class + tests for all 6 brokers (24 tests total)

## What's NOT in this PR

- `codec.encode()` is defined but not wired into producers yet — production-side is the next PR
- No deprecation of the existing `decoder=` parameter

## Usage

```python
from faststream.kafka import KafkaBroker
from faststream._internal.parser import DefaultCodec

class MyCodec(DefaultCodec):
    async def decode(self, msg):
        # custom decode logic (e.g. Avro schema registry lookup)
        return await super().decode(msg)

broker = KafkaBroker(codec=MyCodec())

# or per-subscriber:
@broker.subscriber("topic", codec=MyCodec())
async def handler(msg): ...
```
