### PR TITLE
Feat: Ability to configure topic params in confluent create_topics

### DIFF
--- a/faststream/confluent/__init__.py
+++ b/faststream/confluent/__init__.py
@@ -4,7 +4,7 @@ try:
     from .annotations import KafkaMessage
     from .broker import KafkaBroker, KafkaPublisher, KafkaRoute, KafkaRouter
     from .response import KafkaPublishCommand, KafkaPublishMessage, KafkaResponse
-    from .schemas import TopicPartition
+    from .schemas import Topic, TopicPartition
     from .testing import TestKafkaBroker
 
 except ImportError as e:
@@ -26,5 +26,6 @@ __all__ = (
     "KafkaRouter",
     "TestApp",
     "TestKafkaBroker",
+    "Topic",
     "TopicPartition",
 )

--- a/faststream/confluent/broker/registrator.py
+++ b/faststream/confluent/broker/registrator.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         BatchPublisher,
         DefaultPublisher,
     )
-    from faststream.confluent.schemas import TopicPartition
+    from faststream.confluent.schemas import Topic, TopicPartition
     from faststream.confluent.subscriber.usecase import (
         BatchSubscriber,
         ConcurrentDefaultSubscriber,
@@ -47,7 +47,7 @@ class KafkaRegistrator(
     @overload  # type: ignore[override]
     def subscriber(
         self,
-        *topics: str,
+        *topics: Union[str, "Topic"],
         partitions: Sequence["TopicPartition"] = (),
         polling_interval: float = 0.1,
         group_id: str | None = None,
@@ -90,7 +90,7 @@ class KafkaRegistrator(
     @overload
     def subscriber(
         self,
-        *topics: str,
+        *topics: Union[str, "Topic"],
         partitions: Sequence["TopicPartition"] = (),
         polling_interval: float = 0.1,
         group_id: str | None = None,
@@ -133,7 +133,7 @@ class KafkaRegistrator(
     @overload
     def subscriber(
         self,
-        *topics: str,
+        *topics: Union[str, "Topic"],
         partitions: Sequence["TopicPartition"] = (),
         polling_interval: float = 0.1,
         group_id: str | None = None,
@@ -176,7 +176,7 @@ class KafkaRegistrator(
     @overload
     def subscriber(
         self,
-        *topics: str,
+        *topics: Union[str, "Topic"],
         partitions: Sequence["TopicPartition"] = (),
         polling_interval: float = 0.1,
         group_id: str | None = None,
@@ -223,7 +223,7 @@ class KafkaRegistrator(
     @override
     def subscriber(
         self,
-        *topics: str,
+        *topics: Union[str, "Topic"],
         partitions: Sequence["TopicPartition"] = (),
         polling_interval: float = 0.1,
         group_id: str | None = None,

--- a/faststream/confluent/helpers/admin.py
+++ b/faststream/confluent/helpers/admin.py
@@ -6,6 +6,8 @@ from confluent_kafka.admin import (  # type: ignore[attr-defined]
     NewTopic,
 )
 
+from faststream.confluent.schemas import Topic
+
 if TYPE_CHECKING:
     from .config import ConfluentFastConfig
 
@@ -34,10 +36,21 @@ class AdminService:
         )
         return self.admin_client
 
-    def create_topics(self, topics: list[str]) -> list[CreateResult]:
-        create_result = self.client.create_topics(
-            [NewTopic(topic, num_partitions=1, replication_factor=1) for topic in topics],
-        )
+    def create_topics(self, topics: list[str | Topic]) -> list[CreateResult]:
+        new_topics = []
+        for topic in topics:
+            if isinstance(topic, Topic):
+                new_topics.append(
+                    NewTopic(
+                        topic.name,
+                        num_partitions=topic.num_partitions or 1,
+                        replication_factor=topic.replication_factor or 1,
+                    )
+                )
+            else:
+                new_topics.append(NewTopic(topic, num_partitions=1, replication_factor=1))
+
+        create_result = self.client.create_topics(new_topics)
 
         final_results = []
         for topic, f in create_result.items():

--- a/faststream/confluent/helpers/client.py
+++ b/faststream/confluent/helpers/client.py
@@ -10,7 +10,7 @@ import anyio
 from confluent_kafka import Consumer, KafkaError, KafkaException, Message, Producer
 
 from faststream._internal.utils.functions import call_or_await, run_in_executor
-from faststream.confluent.schemas import TopicPartition
+from faststream.confluent.schemas import Topic, TopicPartition
 from faststream.exceptions import SetupError
 
 from . import config as config_module
@@ -186,7 +186,7 @@ class AsyncConfluentConsumer:
 
     def __init__(
         self,
-        *topics: str,
+        *topics: str | Topic,
         config: config_module.ConfluentFastConfig,
         logger: "LoggerState",
         admin_service: "AdminService",
@@ -272,7 +272,7 @@ class AsyncConfluentConsumer:
         self._thread_pool = ThreadPoolExecutor(max_workers=1)
 
     @property
-    def topics_to_create(self) -> list[str]:
+    def topics_to_create(self) -> list[str | Topic]:
         return list({*self.topics, *(p.topic for p in self.partitions)})
 
     async def start(self) -> None:
@@ -298,7 +298,9 @@ class AsyncConfluentConsumer:
             )
 
         if self.topics:
-            subscribe_kwargs: dict[str, Any] = {"topics": self.topics}
+            subscribe_kwargs: dict[str, Any] = {
+                "topics": [t.name if isinstance(t, Topic) else t for t in self.topics]
+            }
             if self._on_assign is not None:
                 subscribe_kwargs["on_assign"] = self._on_assign
             if self._on_revoke is not None:

--- a/faststream/confluent/schemas/__init__.py
+++ b/faststream/confluent/schemas/__init__.py
@@ -1,3 +1,4 @@
 from faststream.confluent.schemas.partition import TopicPartition
+from faststream.confluent.schemas.topic import Topic
 
-__all__ = ("TopicPartition",)
+__all__ = ("TopicPartition", "Topic")

--- a/faststream/confluent/schemas/topic.py
+++ b/faststream/confluent/schemas/topic.py
@@ -1,0 +1,35 @@
+class Topic:
+    __slots__ = (
+        "name",
+        "num_partitions",
+        "replication_factor",
+    )
+
+    def __init__(
+        self,
+        name: str,
+        num_partitions: int | None = None,
+        replication_factor: int | None = None,
+    ) -> None:
+        self.name = name
+        self.num_partitions = num_partitions
+        self.replication_factor = replication_factor
+
+    def add_prefix(self, prefix: str) -> "Topic":
+        return Topic(
+            name=f"{prefix}{self.name}",
+            num_partitions=self.num_partitions,
+            replication_factor=self.replication_factor,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Topic):
+            return (
+                self.name == other.name
+                and self.num_partitions == other.num_partitions
+                and self.replication_factor == other.replication_factor
+            )
+        return False
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.num_partitions, self.replication_factor))

--- a/faststream/confluent/subscriber/config.py
+++ b/faststream/confluent/subscriber/config.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from faststream._internal.configs import (
     SubscriberSpecificationConfig,
@@ -11,12 +11,12 @@ from faststream.confluent.configs import KafkaBrokerConfig
 from faststream.middlewares import AckPolicy
 
 if TYPE_CHECKING:
-    from faststream.confluent.schemas import TopicPartition
+    from faststream.confluent.schemas import Topic, TopicPartition
 
 
 @dataclass(kw_only=True)
 class KafkaSubscriberSpecificationConfig(SubscriberSpecificationConfig):
-    topics: Sequence[str] = field(default_factory=list)
+    topics: Sequence[Union[str, "Topic"]] = field(default_factory=list)
     partitions: Iterable["TopicPartition"] = field(default_factory=list)
 
 
@@ -24,7 +24,7 @@ class KafkaSubscriberSpecificationConfig(SubscriberSpecificationConfig):
 class KafkaSubscriberConfig(SubscriberUsecaseConfig):
     _outer_config: "KafkaBrokerConfig" = field(default_factory=KafkaBrokerConfig)
 
-    topics: Sequence[str] = field(default_factory=list)
+    topics: Sequence[Union[str, "Topic"]] = field(default_factory=list)
     partitions: Sequence["TopicPartition"] = field(default_factory=list)
     polling_interval: float = 0.1
     group_id: str | None = None

--- a/faststream/confluent/subscriber/usecase.py
+++ b/faststream/confluent/subscriber/usecase.py
@@ -18,7 +18,7 @@ from faststream._internal.endpoint.utils import process_msg
 from faststream._internal.types import MsgType
 from faststream.confluent.parser import AsyncConfluentParser
 from faststream.confluent.publisher.fake import KafkaFakePublisher
-from faststream.confluent.schemas import TopicPartition
+from faststream.confluent.schemas import Topic, TopicPartition
 
 if TYPE_CHECKING:
     from faststream._internal.endpoint.publisher import PublisherProto
@@ -65,8 +65,14 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
         return self._outer_config.client_id
 
     @property
-    def topics(self) -> list[str]:
-        return [f"{self._outer_config.prefix}{t}" for t in self._topics]
+    def topics(self) -> list[Any]:
+        res: list[Any] = []
+        for t in self._topics:
+            if isinstance(t, Topic):
+                res.append(t.add_prefix(self._outer_config.prefix))
+            else:
+                res.append(f"{self._outer_config.prefix}{t}")
+        return res
 
     @property
     def partitions(self) -> list[TopicPartition]:
@@ -200,8 +206,8 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
 
     @property
     def topic_names(self) -> list[str]:
-        topics = self.topics or (f"{p.topic}-{p.partition}" for p in self.partitions)
-        return [f"{self._outer_config.prefix}{t}" for t in topics]
+        topics = self._topics or (f"{p.topic}-{p.partition}" for p in self._partitions)
+        return [f"{self._outer_config.prefix}{getattr(t, 'name', t)}" for t in topics]
 
     @staticmethod
     def build_log_context(
@@ -239,7 +245,9 @@ class DefaultSubscriber(LogicSubscriber[Message]):
         if message is None:
             topic = ",".join(self.topic_names)
         else:
-            topic = message.raw_message.topic() or ",".join(self.topics)
+            topic = message.raw_message.topic() or ",".join(
+                getattr(t, "name", t) for t in self.topics
+            )
 
         return self.build_log_context(
             message=message,

--- a/tests/brokers/confluent/test_topic.py
+++ b/tests/brokers/confluent/test_topic.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+from faststream.confluent.helpers.admin import AdminService
+from faststream.confluent.schemas import Topic
+
+
+def test_admin_create_topics() -> None:
+    admin = AdminService()
+    admin.admin_client = MagicMock()
+    
+    mock_f_fut = MagicMock()
+    admin.client.create_topics.return_value = {"my-topic": mock_f_fut, "my-other": mock_f_fut}
+
+    topics = [
+        "my-topic",
+        Topic("my-other", num_partitions=3, replication_factor=2)
+    ]
+    
+    admin.create_topics(topics) # type: ignore[arg-type]
+    
+    admin.client.create_topics.assert_called_once()
+    args, _kwargs = admin.client.create_topics.call_args
+    new_topics = args[0]
+    
+    assert len(new_topics) == 2
+    
+    assert new_topics[0].topic == "my-topic"
+    assert new_topics[0].num_partitions == 1
+    assert new_topics[0].replication_factor == 1
+    
+    assert new_topics[1].topic == "my-other"
+    assert new_topics[1].num_partitions == 3
+    assert new_topics[1].replication_factor == 2


### PR DESCRIPTION
# Description
In context of Confluent create_topics function:
Instead of using default values for num_partitions and replication_factor as 1. We want to give an ability to make it configurable, like 

```python
@broker.subscriber(
    Topic("topic-name", num_partitions=3),
    Topic("topic-name2", num_partitions=1),
    "topic-without-settings"
)
```

So to do this, I created a Topic Schema which can be initialized with parameters like name, num_partitions and replication_factor (I am not sure what other parameters needs to be configurable.) . Then, we need the subscriber to allow parameter as "Topic" so I changed the topics: Sequence[str] to Sequence[str, "Topic"] in the subscriber/config.py .
The LogicSubscriber property topics() handles the str input ,, so i added an if statement to handle the Topic input to function as

```@property
    def topics(self) -> list[Any]:
        res: list[Any] = []
        for t in self._topics:
            if isinstance(t, Topic):
                res.append(t.add_prefix(self._outer_config.prefix))
            else:
                res.append(f"{self._outer_config.prefix}{t}")
        return res
```
then similarly for AdminService and AsyncConfluentConsumer create_topics function.

Then the Registrator also requires to handle input of type string and Topic so changed all topics: str to topics: Union[str, "Topic"].

Then added a new test that creates new topics and checks if the configuration is correct.

The just static-analysis gave me an error that says that create_subscriber cannot have Topic as arg type.
```python
just static-analysis                      
just _static mypy 
uv run --frozen mypy
faststream/confluent/broker/registrator.py:405: error: Argument 1 to "create_subscriber" has incompatible type "*tuple[str | Topic, ...]"; expected "str"  [arg-type]
Found 1 error in 1 file (checked 502 source files)
error: Recipe `_static` failed on line 115 with exit code 1
error: Recipe `mypy` failed on line 120 with exit code 1
```

And the test-coverage is 16 percent total.

Fixes #1827 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
