### PR TITLE
fix: [2842] fixed problem with parsing pydantic models

### DIFF
--- a/faststream/_internal/_compat.py
+++ b/faststream/_internal/_compat.py
@@ -92,7 +92,7 @@ if PYDANTIC_V2:
         return json_dumps(model_to_jsonable(data))
 
     def get_model_fields(model: type[BaseModel]) -> dict[str, Any]:
-        return model.__pydantic_fields__
+        return model.model_fields
 
     def model_to_json(model: BaseModel, **kwargs: Any) -> str:
         return model.model_dump_json(**kwargs)


### PR DESCRIPTION
# Description

[Right here](https://github.com/ag2ai/faststream/blob/9bf1271938abe7276765934917a2f37c4c8e7032/faststream/_internal/_compat.py#L95) we use `model.__pydantic_fields__`, which works fine after pydantic 2.10. However, lowever versions don't support this attribute, so I replaced it with `model.model_fields` instead. It solved the issue with documentation rendering

Fixes #2842

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (a non-breaking change that resolves an issue)


## Checklist

- [X] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [X] I have conducted a self-review of my own code
- [X] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [X] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [X] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [X] I have ensured that static analysis tests are passing by running `just static-analysis`
- [X] I have included code examples to illustrate the modifications
