### PR TITLE
feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding

### DIFF
--- a/faststream/_internal/endpoint/subscriber/usecase.py
+++ b/faststream/_internal/endpoint/subscriber/usecase.py
@@ -15,6 +15,7 @@ from typing_extensions import Self, overload, override
 
 from faststream._internal.endpoint.usecase import Endpoint
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import BatchCodecProto
 from faststream._internal.types import (
     AsyncCallable,
     MsgType,
@@ -160,8 +161,19 @@ class SubscriberUsecase(Endpoint, Generic[MsgType]):
             msg = "Cannot use both 'codec' and 'decoder' — 'codec' replaces 'decoder'."
             raise ValueError(msg)
 
+        is_batch = getattr(self._decoder, "__name__", "") == "decode_batch"
+
         if codec:
-            async_decoder: AsyncCallable = codec.decode
+            if is_batch:
+                if isinstance(codec, BatchCodecProto):
+                    async_decoder: AsyncCallable = codec.decode_batch
+                else:
+                    msg = (
+                        "Batch subscriber requires a codec implementing BatchCodecProto."
+                    )
+                    raise ValueError(msg)
+            else:
+                async_decoder = codec.decode
         elif decoder:
             async_decoder = ParserComposition(decoder, self._decoder)
         else:

--- a/faststream/_internal/parser.py
+++ b/faststream/_internal/parser.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 
 from faststream.message.utils import decode_message, encode_message
 
@@ -69,6 +69,22 @@ class CodecProto(Protocol):
     ) -> tuple[bytes, str | None]:
         """Encode a Python object into bytes and content_type."""
         ...
+
+
+@runtime_checkable
+class BatchCodecProto(Protocol):
+    @abstractmethod
+    async def encode_batch(
+        self,
+        msgs: Sequence["SendableMessage"],
+        serializer: "SerializerProto | None" = None,
+    ) -> list[tuple[bytes, str | None]]: ...
+
+    @abstractmethod
+    async def decode_batch(
+        self,
+        msg: "StreamMessage[Sequence[Any]]",
+    ) -> list["DecodedMessage"]: ...
 
 
 class DefaultCodec:

--- a/faststream/_internal/parser.py
+++ b/faststream/_internal/parser.py
@@ -64,7 +64,7 @@ class CodecProto(Protocol):
     @abstractmethod
     async def encode(
         self,
-        msg: "SendableMessage",
+        msg: "Sequence[SendableMessage] | SendableMessage",
         serializer: "SerializerProto | None" = None,
     ) -> tuple[bytes, str | None]:
         """Encode a Python object into bytes and content_type."""
@@ -79,7 +79,7 @@ class DefaultCodec:
 
     async def encode(
         self,
-        msg: "SendableMessage",
+        msg: "Sequence[SendableMessage] | SendableMessage",
         serializer: "SerializerProto | None" = None,
     ) -> tuple[bytes, str | None]:
         return encode_message(msg, serializer)

--- a/faststream/_internal/parser.py
+++ b/faststream/_internal/parser.py
@@ -64,11 +64,9 @@ class CodecProto(Protocol):
     @abstractmethod
     async def encode(
         self,
-        msg: "Sequence[SendableMessage] | SendableMessage",
+        msg: "SendableMessage",
         serializer: "SerializerProto | None" = None,
-    ) -> tuple[bytes, str | None]:
-        """Encode a Python object into bytes and content_type."""
-        ...
+    ) -> tuple[bytes, str | None]: ...
 
 
 @runtime_checkable
@@ -88,14 +86,12 @@ class BatchCodecProto(Protocol):
 
 
 class DefaultCodec:
-    """Default codec that delegates to the shared encode_message/decode_message functions."""
-
     async def decode(self, msg: "StreamMessage[Any]") -> "DecodedMessage":
         return decode_message(msg)
 
     async def encode(
         self,
-        msg: "Sequence[SendableMessage] | SendableMessage",
+        msg: "SendableMessage",
         serializer: "SerializerProto | None" = None,
     ) -> tuple[bytes, str | None]:
         return encode_message(msg, serializer)

--- a/faststream/_internal/producer.py
+++ b/faststream/_internal/producer.py
@@ -5,6 +5,7 @@ from faststream._internal.types import PublishCommandType_contra
 from faststream.exceptions import IncorrectState
 
 if TYPE_CHECKING:
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import AsyncCallable
     from faststream.response import PublishCommand
 
@@ -12,6 +13,7 @@ if TYPE_CHECKING:
 class ProducerProto(Protocol[PublishCommandType_contra]):
     _parser: "AsyncCallable"
     _decoder: "AsyncCallable"
+    codec: "CodecProto"
 
     @abstractmethod
     async def publish(self, cmd: "PublishCommandType_contra") -> Any:
@@ -57,6 +59,14 @@ class ProducerUnset(ProducerProto):
 
     @_decoder.setter
     def _decoder(self, value: "AsyncCallable", /) -> "AsyncCallable":
+        raise IncorrectState(self.msg)
+
+    @property
+    def codec(self) -> "CodecProto":
+        raise IncorrectState(self.msg)
+
+    @codec.setter
+    def codec(self, value: "CodecProto", /) -> None:
         raise IncorrectState(self.msg)
 
     async def publish(self, cmd: "PublishCommand") -> Any | None:

--- a/faststream/confluent/configs/broker.py
+++ b/faststream/confluent/configs/broker.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from faststream.__about__ import SERVICE_NAME
 from faststream._internal.configs import BrokerConfig
+from faststream._internal.parser import DefaultCodec
 from faststream.confluent.helpers import (
     AdminService,
     AsyncConfluentConsumer,
@@ -61,7 +62,11 @@ class KafkaBrokerConfig(BrokerConfig):
             config=self.connection_config,
             logger=self.logger,
         )
-        self.producer.connect(native_producer, serializer=self.fd_config._serializer)
+        self.producer.connect(
+            native_producer,
+            serializer=self.fd_config._serializer,
+            codec=self.broker_codec or DefaultCodec(),
+        )
         await self.admin.connect(
             self.connection_config,
             logger=self.logger,

--- a/faststream/confluent/publisher/producer.py
+++ b/faststream/confluent/publisher/producer.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
-from faststream._internal.parser import DefaultCodec
+from faststream._internal.parser import BatchCodecProto, DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.confluent.parser import AsyncConfluentParser
 from faststream.confluent.response import KafkaPublishCommand
@@ -163,9 +163,16 @@ class AsyncConfluentFastProducerImpl(AsyncConfluentFastProducer):
 
         headers_to_send = cmd.headers_to_publish()
 
-        for message_position, msg in enumerate(cmd.batch_bodies):
-            message, content_type = await self.codec.encode(msg, self.serializer)
+        if isinstance(self.codec, BatchCodecProto):
+            encoded_batch = await self.codec.encode_batch(
+                cmd.batch_bodies, self.serializer
+            )
+        else:
+            encoded_batch = [
+                await self.codec.encode(msg, self.serializer) for msg in cmd.batch_bodies
+            ]
 
+        for message_position, (message, content_type) in enumerate(encoded_batch):
             if content_type:
                 final_headers = {
                     "content-type": content_type,

--- a/faststream/confluent/publisher/producer.py
+++ b/faststream/confluent/publisher/producer.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from confluent_kafka import Message
     from fast_depends.library.serializer import SerializerProto
 
-    from faststream._internal.parser import CodecProto, DefaultCodec
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import CustomCallable
     from faststream.confluent.helpers.client import AsyncConfluentProducer
 
@@ -103,7 +103,7 @@ class AsyncConfluentFastProducerImpl(AsyncConfluentFastProducer):
     ) -> None:
         self._producer: ProducerState = EmptyProducerState()
         self.serializer: SerializerProto | None = None
-        self.codec: "CodecProto" = DefaultCodec()
+        self.codec: CodecProto = DefaultCodec()
 
         # NOTE: register default parser to be compatible with request
         default = AsyncConfluentParser()

--- a/faststream/confluent/publisher/producer.py
+++ b/faststream/confluent/publisher/producer.py
@@ -9,7 +9,6 @@ from faststream._internal.producer import ProducerProto
 from faststream.confluent.parser import AsyncConfluentParser
 from faststream.confluent.response import KafkaPublishCommand
 from faststream.exceptions import FeatureNotSupportedException
-from faststream.message import encode_message
 
 from .state import EmptyProducerState, ProducerState, RealProducer
 
@@ -140,7 +139,7 @@ class AsyncConfluentFastProducerImpl(AsyncConfluentFastProducer):
         cmd: "KafkaPublishCommand",
     ) -> "asyncio.Future[Message | None] | Message | None":
         """Publish a message to a topic."""
-        message, content_type = encode_message(cmd.body, serializer=self.serializer)
+        message, content_type = await self.codec.encode(cmd.body, self.serializer)
 
         headers_to_send = {
             "content-type": content_type or "",
@@ -165,7 +164,7 @@ class AsyncConfluentFastProducerImpl(AsyncConfluentFastProducer):
         headers_to_send = cmd.headers_to_publish()
 
         for message_position, msg in enumerate(cmd.batch_bodies):
-            message, content_type = encode_message(msg, serializer=self.serializer)
+            message, content_type = await self.codec.encode(msg, self.serializer)
 
             if content_type:
                 final_headers = {

--- a/faststream/confluent/publisher/producer.py
+++ b/faststream/confluent/publisher/producer.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.confluent.parser import AsyncConfluentParser
 from faststream.confluent.response import KafkaPublishCommand
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from confluent_kafka import Message
     from fast_depends.library.serializer import SerializerProto
 
+    from faststream._internal.parser import CodecProto, DefaultCodec
     from faststream._internal.types import CustomCallable
     from faststream.confluent.helpers.client import AsyncConfluentProducer
 
@@ -29,6 +31,7 @@ class AsyncConfluentFastProducer(ProducerProto[KafkaPublishCommand]):
         self,
         producer: "AsyncConfluentProducer",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None: ...
 
     def __bool__(self) -> bool:
@@ -66,6 +69,7 @@ class FakeConfluentFastProducer(AsyncConfluentFastProducer):
         self,
         producer: "AsyncConfluentProducer",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         raise NotImplementedError
 
@@ -100,6 +104,7 @@ class AsyncConfluentFastProducerImpl(AsyncConfluentFastProducer):
     ) -> None:
         self._producer: ProducerState = EmptyProducerState()
         self.serializer: SerializerProto | None = None
+        self.codec: "CodecProto" = DefaultCodec()
 
         # NOTE: register default parser to be compatible with request
         default = AsyncConfluentParser()
@@ -110,9 +115,11 @@ class AsyncConfluentFastProducerImpl(AsyncConfluentFastProducer):
         self,
         producer: "AsyncConfluentProducer",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         self._producer = RealProducer(producer)
         self.serializer = serializer
+        self.codec = codec or DefaultCodec()
 
     async def disconnect(self) -> None:
         await self._producer.stop()

--- a/faststream/confluent/testing.py
+++ b/faststream/confluent/testing.py
@@ -292,8 +292,8 @@ async def build_message(
     codec: Optional["CodecProto"] = None,
 ) -> MockConfluentMessage:
     """Build a mock confluent_kafka.Message for a sendable message."""
-    _codec = codec or DefaultCodec()
-    msg, content_type = await _codec.encode(message, serializer)
+    codec_instance = codec or DefaultCodec()
+    msg, content_type = await codec_instance.encode(message, serializer)
     k = key or b""
     headers = {
         "content-type": content_type or "",

--- a/faststream/confluent/testing.py
+++ b/faststream/confluent/testing.py
@@ -8,6 +8,7 @@ import anyio
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.confluent.broker import KafkaBroker
 from faststream.confluent.parser import AsyncConfluentParser
@@ -109,6 +110,7 @@ class FakeProducer(AsyncConfluentFastProducer):
         default = AsyncConfluentParser()
         self._parser = ParserComposition(broker._parser, default.parse_message)
         self._decoder = ParserComposition(broker._decoder, default.decode_message)
+        self.codec = broker.config.broker_codec or DefaultCodec()
 
     def __bool__(self) -> bool:
         return True

--- a/faststream/confluent/testing.py
+++ b/faststream/confluent/testing.py
@@ -17,12 +17,13 @@ from faststream.confluent.publisher.usecase import BatchPublisher
 from faststream.confluent.schemas import TopicPartition
 from faststream.confluent.subscriber.usecase import BatchSubscriber
 from faststream.exceptions import SubscriberNotFound
-from faststream.message import encode_message, gen_cor_id
+from faststream.message import gen_cor_id
 
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import SendableMessage
+    from faststream._internal.parser import CodecProto
     from faststream.confluent.publisher.usecase import LogicPublisher
     from faststream.confluent.response import KafkaPublishCommand
     from faststream.confluent.subscriber.usecase import LogicSubscriber
@@ -121,7 +122,7 @@ class FakeProducer(AsyncConfluentFastProducer):
     @override
     async def publish(self, cmd: "KafkaPublishCommand") -> None:
         """Publish a message to the Kafka broker."""
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             topic=cmd.destination,
             key=cmd.key,
@@ -131,6 +132,7 @@ class FakeProducer(AsyncConfluentFastProducer):
             correlation_id=cmd.correlation_id,
             reply_to=cmd.reply_to,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         for handler in _find_handler(
@@ -150,8 +152,8 @@ class FakeProducer(AsyncConfluentFastProducer):
             cmd.destination,
             cmd.partition,
         ):
-            messages = (
-                build_message(
+            messages = [
+                await build_message(
                     message=message,
                     topic=cmd.destination,
                     partition=cmd.partition,
@@ -161,9 +163,10 @@ class FakeProducer(AsyncConfluentFastProducer):
                     correlation_id=cmd.correlation_id,
                     reply_to=cmd.reply_to,
                     serializer=self.broker.config.fd_config._serializer,
+                    codec=self.codec,
                 )
                 for message_position, message in enumerate(cmd.batch_bodies)
-            )
+            ]
 
             if isinstance(handler, BatchSubscriber):
                 await self._execute_handler(list(messages), cmd.destination, handler)
@@ -174,7 +177,7 @@ class FakeProducer(AsyncConfluentFastProducer):
 
     @override
     async def request(self, cmd: "KafkaPublishCommand") -> "MockConfluentMessage":
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             topic=cmd.destination,
             key=cmd.key,
@@ -183,6 +186,7 @@ class FakeProducer(AsyncConfluentFastProducer):
             headers=cmd.headers,
             correlation_id=cmd.correlation_id,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         for handler in _find_handler(
@@ -209,12 +213,13 @@ class FakeProducer(AsyncConfluentFastProducer):
     ) -> "MockConfluentMessage":
         result = await handler.process_message(msg)
 
-        return build_message(
+        return await build_message(
             topic=topic,
             message=result.body,
             headers=result.headers,
             correlation_id=result.correlation_id or gen_cor_id(),
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
 
@@ -273,7 +278,7 @@ class MockConfluentMessage:
         return self._raw_msg
 
 
-def build_message(
+async def build_message(
     message: "SendableMessage",
     topic: str,
     *,
@@ -284,9 +289,11 @@ def build_message(
     headers: dict[str, str] | None = None,
     reply_to: str = "",
     serializer: Optional["SerializerProto"] = None,
+    codec: Optional["CodecProto"] = None,
 ) -> MockConfluentMessage:
     """Build a mock confluent_kafka.Message for a sendable message."""
-    msg, content_type = encode_message(message, serializer)
+    _codec = codec or DefaultCodec()
+    msg, content_type = await _codec.encode(message, serializer)
     k = key or b""
     headers = {
         "content-type": content_type or "",

--- a/faststream/confluent/testing.py
+++ b/faststream/confluent/testing.py
@@ -8,7 +8,7 @@ import anyio
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
-from faststream._internal.parser import DefaultCodec
+from faststream._internal.parser import BatchCodecProto, DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.confluent.broker import KafkaBroker
 from faststream.confluent.parser import AsyncConfluentParser
@@ -147,14 +147,24 @@ class FakeProducer(AsyncConfluentFastProducer):
     @override
     async def publish_batch(self, cmd: "KafkaPublishCommand") -> None:
         """Publish a batch of messages to the Kafka broker."""
+        serializer = self.broker.config.fd_config._serializer
+
+        if isinstance(self.codec, BatchCodecProto):
+            encoded = await self.codec.encode_batch(cmd.batch_bodies, serializer)
+        else:
+            encoded = [
+                await self.codec.encode(body, serializer) for body in cmd.batch_bodies
+            ]
+
         for handler in _find_handler(
             cast("Iterable[LogicSubscriber[Any]]", self.broker.subscribers),
             cmd.destination,
             cmd.partition,
         ):
             messages = [
-                await build_message(
-                    message=message,
+                _build_mock_message(
+                    body=body,
+                    content_type=content_type,
                     topic=cmd.destination,
                     partition=cmd.partition,
                     timestamp_ms=cmd.timestamp_ms,
@@ -162,10 +172,8 @@ class FakeProducer(AsyncConfluentFastProducer):
                     headers=cmd.headers,
                     correlation_id=cmd.correlation_id,
                     reply_to=cmd.reply_to,
-                    serializer=self.broker.config.fd_config._serializer,
-                    codec=self.codec,
                 )
-                for message_position, message in enumerate(cmd.batch_bodies)
+                for message_position, (body, content_type) in enumerate(encoded)
             ]
 
             if isinstance(handler, BatchSubscriber):
@@ -308,6 +316,36 @@ async def build_message(
         topic=topic,
         key=k,
         headers=[(i, j.encode()) for i, j in headers.items()],
+        offset=0,
+        partition=partition or 0,
+        timestamp_type=1,
+        timestamp_ms=timestamp_ms or int(datetime.now(timezone.utc).timestamp() * 1000),
+    )
+
+
+def _build_mock_message(
+    body: bytes,
+    content_type: str | None,
+    topic: str,
+    partition: int | None = None,
+    timestamp_ms: int | None = None,
+    key: bytes | str | None = None,
+    headers: dict[str, str] | None = None,
+    correlation_id: str | None = None,
+    reply_to: str = "",
+) -> MockConfluentMessage:
+    k = key or b""
+    h = {
+        "content-type": content_type or "",
+        "correlation_id": correlation_id or gen_cor_id(),
+        "reply_to": reply_to,
+        **(headers or {}),
+    }
+    return MockConfluentMessage(
+        raw_msg=body,
+        topic=topic,
+        key=k,
+        headers=[(i, j.encode()) for i, j in h.items()],
         offset=0,
         partition=partition or 0,
         timestamp_type=1,

--- a/faststream/kafka/configs/broker.py
+++ b/faststream/kafka/configs/broker.py
@@ -8,6 +8,7 @@ import aiokafka.admin
 
 from faststream.__about__ import SERVICE_NAME
 from faststream._internal.configs import BrokerConfig
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.utils.data import filter_by_dict
 from faststream.exceptions import IncorrectState
 from faststream.kafka.publisher.producer import (
@@ -45,7 +46,11 @@ class KafkaBrokerConfig(BrokerConfig):
         # to use credentials scoped to read-only ACLs.
         if not self.consumer_only:
             producer = aiokafka.AIOKafkaProducer(**connection_kwargs)
-            await self.producer.connect(producer, serializer=self.fd_config._serializer)
+            await self.producer.connect(
+                producer,
+                serializer=self.fd_config._serializer,
+                codec=self.broker_codec or DefaultCodec(),
+            )
 
             admin_options, _ = filter_by_dict(
                 AdminClientConnectionParams,

--- a/faststream/kafka/publisher/producer.py
+++ b/faststream/kafka/publisher/producer.py
@@ -11,7 +11,7 @@ from faststream.kafka.exceptions import BatchBufferOverflowException
 from faststream.kafka.message import KafkaMessage
 from faststream.kafka.parser import AioKafkaParser
 from faststream.kafka.response import KafkaPublishCommand
-from faststream.message import encode_message
+
 
 from .state import EmptyProducerState, ProducerState, RealProducer
 
@@ -111,7 +111,7 @@ class AioKafkaFastProducerImpl(AioKafkaFastProducer):
         cmd: "KafkaPublishCommand",
     ) -> Union["asyncio.Future[RecordMetadata]", "RecordMetadata"]:
         """Publish a message to a topic."""
-        message, content_type = encode_message(cmd.body, serializer=self.serializer)
+        message, content_type = await self.codec.encode(cmd.body, self.serializer)
 
         headers_to_send = {
             "content-type": content_type or "",
@@ -142,7 +142,7 @@ class AioKafkaFastProducerImpl(AioKafkaFastProducer):
         headers_to_send = cmd.headers_to_publish()
 
         for message_position, body in enumerate(cmd.batch_bodies):
-            message, content_type = encode_message(body, serializer=self.serializer)
+            message, content_type = await self.codec.encode(body, self.serializer)
 
             if content_type:
                 final_headers = {

--- a/faststream/kafka/publisher/producer.py
+++ b/faststream/kafka/publisher/producer.py
@@ -12,7 +12,6 @@ from faststream.kafka.message import KafkaMessage
 from faststream.kafka.parser import AioKafkaParser
 from faststream.kafka.response import KafkaPublishCommand
 
-
 from .state import EmptyProducerState, ProducerState, RealProducer
 
 if TYPE_CHECKING:
@@ -22,7 +21,7 @@ if TYPE_CHECKING:
     from aiokafka.structs import RecordMetadata
     from fast_depends.library.serializer import SerializerProto
 
-    from faststream._internal.parser import CodecProto, DefaultCodec
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import CustomCallable
 
 
@@ -73,7 +72,7 @@ class AioKafkaFastProducerImpl(AioKafkaFastProducer):
     ) -> None:
         self._producer: ProducerState = EmptyProducerState()
         self.serializer: SerializerProto | None = None
-        self.codec: "CodecProto" = DefaultCodec()
+        self.codec: CodecProto = DefaultCodec()
 
         # NOTE: register default parser to be compatible with request
         default = AioKafkaParser(msg_class=KafkaMessage, regex=None)

--- a/faststream/kafka/publisher/producer.py
+++ b/faststream/kafka/publisher/producer.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException
 from faststream.kafka.exceptions import BatchBufferOverflowException
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
     from aiokafka.structs import RecordMetadata
     from fast_depends.library.serializer import SerializerProto
 
+    from faststream._internal.parser import CodecProto, DefaultCodec
     from faststream._internal.types import CustomCallable
 
 
@@ -29,6 +31,7 @@ class AioKafkaFastProducer(ProducerProto[KafkaPublishCommand]):
         self,
         producer: "AIOKafkaProducer",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None: ...
 
     async def disconnect(self) -> None: ...
@@ -70,6 +73,7 @@ class AioKafkaFastProducerImpl(AioKafkaFastProducer):
     ) -> None:
         self._producer: ProducerState = EmptyProducerState()
         self.serializer: SerializerProto | None = None
+        self.codec: "CodecProto" = DefaultCodec()
 
         # NOTE: register default parser to be compatible with request
         default = AioKafkaParser(msg_class=KafkaMessage, regex=None)
@@ -80,8 +84,10 @@ class AioKafkaFastProducerImpl(AioKafkaFastProducer):
         self,
         producer: "AIOKafkaProducer",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         self.serializer = serializer
+        self.codec = codec or DefaultCodec()
         await producer.start()
         self._producer = RealProducer(producer)
 
@@ -170,6 +176,7 @@ class FakeAioKafkaFastProducer(AioKafkaFastProducer):
         self,
         producer: "AIOKafkaProducer",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         raise NotImplementedError
 

--- a/faststream/kafka/publisher/producer.py
+++ b/faststream/kafka/publisher/producer.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
-from faststream._internal.parser import DefaultCodec
+from faststream._internal.parser import BatchCodecProto, DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException
 from faststream.kafka.exceptions import BatchBufferOverflowException
@@ -140,9 +140,17 @@ class AioKafkaFastProducerImpl(AioKafkaFastProducer):
 
         headers_to_send = cmd.headers_to_publish()
 
-        for message_position, body in enumerate(cmd.batch_bodies):
-            message, content_type = await self.codec.encode(body, self.serializer)
+        if isinstance(self.codec, BatchCodecProto):
+            encoded_batch = await self.codec.encode_batch(
+                cmd.batch_bodies, self.serializer
+            )
+        else:
+            encoded_batch = [
+                await self.codec.encode(body, self.serializer)
+                for body in cmd.batch_bodies
+            ]
 
+        for message_position, (message, content_type) in enumerate(encoded_batch):
             if content_type:
                 final_headers = {
                     "content-type": content_type,

--- a/faststream/kafka/testing.py
+++ b/faststream/kafka/testing.py
@@ -20,12 +20,13 @@ from faststream.kafka.parser import AioKafkaParser
 from faststream.kafka.publisher.producer import AioKafkaFastProducer
 from faststream.kafka.publisher.usecase import BatchPublisher
 from faststream.kafka.subscriber.usecase import BatchSubscriber
-from faststream.message import encode_message, gen_cor_id
+from faststream.message import gen_cor_id
 
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import SendableMessage
+    from faststream._internal.parser import CodecProto
     from faststream.kafka.publisher.usecase import LogicPublisher
     from faststream.kafka.response import KafkaPublishCommand
     from faststream.kafka.subscriber.usecase import LogicSubscriber
@@ -137,7 +138,7 @@ class FakeProducer(AioKafkaFastProducer):
     @override
     async def publish(self, cmd: "KafkaPublishCommand") -> None:
         """Publish a message to the Kafka broker."""
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             topic=cmd.destination,
             key=cmd.key,
@@ -147,6 +148,7 @@ class FakeProducer(AioKafkaFastProducer):
             correlation_id=cmd.correlation_id,
             reply_to=cmd.reply_to,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         for handler in _find_handler(
@@ -160,7 +162,7 @@ class FakeProducer(AioKafkaFastProducer):
 
     @override
     async def request(self, cmd: "KafkaPublishCommand") -> "ConsumerRecord":
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             topic=cmd.destination,
             key=cmd.key,
@@ -169,6 +171,7 @@ class FakeProducer(AioKafkaFastProducer):
             headers=cmd.headers,
             correlation_id=cmd.correlation_id,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         for handler in _find_handler(
@@ -198,8 +201,8 @@ class FakeProducer(AioKafkaFastProducer):
             cmd.destination,
             cmd.partition,
         ):
-            messages = (
-                build_message(
+            messages = [
+                await build_message(
                     message=message,
                     topic=cmd.destination,
                     partition=cmd.partition,
@@ -209,9 +212,10 @@ class FakeProducer(AioKafkaFastProducer):
                     correlation_id=cmd.correlation_id,
                     reply_to=cmd.reply_to,
                     serializer=self.broker.config.fd_config._serializer,
+                    codec=self.codec,
                 )
                 for message_position, message in enumerate(cmd.batch_bodies)
-            )
+            ]
 
             if isinstance(handler, BatchSubscriber):
                 await self._execute_handler(list(messages), cmd.destination, handler)
@@ -228,16 +232,17 @@ class FakeProducer(AioKafkaFastProducer):
     ) -> "ConsumerRecord":
         result = await handler.process_message(msg)
 
-        return build_message(
+        return await build_message(
             topic=topic,
             message=result.body,
             headers=result.headers,
             correlation_id=result.correlation_id,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
 
-def build_message(
+async def build_message(
     message: "SendableMessage",
     topic: str,
     partition: int | None = None,
@@ -248,9 +253,11 @@ def build_message(
     *,
     reply_to: str = "",
     serializer: Optional["SerializerProto"],
+    codec: Optional["CodecProto"] = None,
 ) -> "ConsumerRecord":
     """Build a Kafka ConsumerRecord for a sendable message."""
-    msg, content_type = encode_message(message, serializer=serializer)
+    from faststream._internal.parser import CodecProto
+    msg, content_type = await (codec or DefaultCodec()).encode(message, serializer)
 
     k = key or b""
 

--- a/faststream/kafka/testing.py
+++ b/faststream/kafka/testing.py
@@ -256,7 +256,6 @@ async def build_message(
     codec: Optional["CodecProto"] = None,
 ) -> "ConsumerRecord":
     """Build a Kafka ConsumerRecord for a sendable message."""
-    from faststream._internal.parser import CodecProto
     msg, content_type = await (codec or DefaultCodec()).encode(message, serializer)
 
     k = key or b""

--- a/faststream/kafka/testing.py
+++ b/faststream/kafka/testing.py
@@ -10,6 +10,7 @@ from aiokafka import ConsumerRecord
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.exceptions import SubscriberNotFound
 from faststream.kafka import TopicPartition
@@ -124,6 +125,7 @@ class FakeProducer(AioKafkaFastProducer):
 
         self._parser = ParserComposition(broker._parser, default.parse_message)
         self._decoder = ParserComposition(broker._decoder, default.decode_message)
+        self.codec = broker.config.broker_codec or DefaultCodec()
 
     def __bool__(self) -> bool:
         return True

--- a/faststream/kafka/testing.py
+++ b/faststream/kafka/testing.py
@@ -10,7 +10,7 @@ from aiokafka import ConsumerRecord
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
-from faststream._internal.parser import DefaultCodec
+from faststream._internal.parser import BatchCodecProto, DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.exceptions import SubscriberNotFound
 from faststream.kafka import TopicPartition
@@ -196,14 +196,24 @@ class FakeProducer(AioKafkaFastProducer):
         cmd: "KafkaPublishCommand",
     ) -> None:
         """Publish a batch of messages to the Kafka broker."""
+        serializer = self.broker.config.fd_config._serializer
+
+        if isinstance(self.codec, BatchCodecProto):
+            encoded = await self.codec.encode_batch(cmd.batch_bodies, serializer)
+        else:
+            encoded = [
+                await self.codec.encode(body, serializer) for body in cmd.batch_bodies
+            ]
+
         for handler in _find_handler(
             cast("list[LogicSubscriber[Any]]", self.broker.subscribers),
             cmd.destination,
             cmd.partition,
         ):
             messages = [
-                await build_message(
-                    message=message,
+                _build_record(
+                    body=body,
+                    content_type=content_type,
                     topic=cmd.destination,
                     partition=cmd.partition,
                     timestamp_ms=cmd.timestamp_ms,
@@ -211,10 +221,8 @@ class FakeProducer(AioKafkaFastProducer):
                     headers=cmd.headers,
                     correlation_id=cmd.correlation_id,
                     reply_to=cmd.reply_to,
-                    serializer=self.broker.config.fd_config._serializer,
-                    codec=self.codec,
                 )
-                for message_position, message in enumerate(cmd.batch_bodies)
+                for message_position, (body, content_type) in enumerate(encoded)
             ]
 
             if isinstance(handler, BatchSubscriber):
@@ -279,6 +287,40 @@ async def build_message(
         checksum=sum(msg),
         offset=0,
         headers=[(i, j.encode()) for i, j in headers.items()],
+        timestamp_type=1,
+        timestamp=timestamp_ms or int(datetime.now(timezone.utc).timestamp() * 1000),
+    )
+
+
+def _build_record(
+    body: bytes,
+    content_type: str | None,
+    topic: str,
+    partition: int | None = None,
+    timestamp_ms: int | None = None,
+    key: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    correlation_id: str | None = None,
+    reply_to: str = "",
+) -> "ConsumerRecord":
+    k = key or b""
+    h = {
+        "content-type": content_type or "",
+        "correlation_id": correlation_id or gen_cor_id(),
+        **(headers or {}),
+    }
+    if reply_to:
+        h["reply_to"] = h.get("reply_to", reply_to)
+    return ConsumerRecord(
+        value=body,
+        topic=topic,
+        partition=partition or 0,
+        key=k,
+        serialized_key_size=len(k),
+        serialized_value_size=len(body),
+        checksum=sum(body),
+        offset=0,
+        headers=[(i, j.encode()) for i, j in h.items()],
         timestamp_type=1,
         timestamp=timestamp_ms or int(datetime.now(timezone.utc).timestamp() * 1000),
     )

--- a/faststream/mqtt/broker/config.py
+++ b/faststream/mqtt/broker/config.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 from faststream._internal.configs import BrokerConfig
+from faststream._internal.parser import DefaultCodec
 from faststream.exceptions import FeatureNotSupportedException, IncorrectState
 from faststream.mqtt.publisher.producer import ZmqttFakeProducer
 from faststream.opentelemetry.middleware import TelemetryMiddleware
@@ -36,7 +37,7 @@ class MQTTBrokerConfig(BrokerConfig):
 
     def connect(self, client: "zmqtt.MQTTClient") -> None:
         self._client = client
-        self.producer.connect(client, self.fd_config._serializer)
+        self.producer.connect(client, self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
 
     def disconnect(self) -> None:
         self._client = None

--- a/faststream/mqtt/broker/config.py
+++ b/faststream/mqtt/broker/config.py
@@ -37,7 +37,9 @@ class MQTTBrokerConfig(BrokerConfig):
 
     def connect(self, client: "zmqtt.MQTTClient") -> None:
         self._client = client
-        self.producer.connect(client, self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
+        self.producer.connect(
+            client, self.fd_config._serializer, codec=self.broker_codec or DefaultCodec()
+        )
 
     def disconnect(self) -> None:
         self._client = None

--- a/faststream/mqtt/publisher/producer.py
+++ b/faststream/mqtt/publisher/producer.py
@@ -9,7 +9,7 @@ from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException, IncorrectState
-from faststream.message import encode_message, gen_cor_id
+from faststream.message import gen_cor_id
 from faststream.mqtt.parser import MQTTParserV5, MQTTParserV311
 from faststream.mqtt.response import MQTTPublishCommand
 
@@ -92,7 +92,7 @@ class ZmqttProducerV311(ZmqttBaseProducer):
         if cmd.headers:
             msg = "MQTT 3.1.1 does not support message headers. Use MQTT 5.0."
             raise FeatureNotSupportedException(msg)
-        payload, _ = encode_message(cmd.body, self.serializer)
+        payload, _ = await self.codec.encode(cmd.body, self.serializer)
         await self._connected_client.publish(
             cmd.destination,
             payload,
@@ -117,7 +117,7 @@ class ZmqttProducerV311(ZmqttBaseProducer):
         await sub.start()
 
         try:
-            payload, _ = encode_message(cmd.body, self.serializer)
+            payload, _ = await self.codec.encode(cmd.body, self.serializer)
             await self._connected_client.publish(
                 cmd.destination,
                 payload,
@@ -144,7 +144,7 @@ class ZmqttProducerV5(ZmqttBaseProducer):
 
     @override
     async def publish(self, cmd: "MQTTPublishCommand") -> None:
-        payload, content_type = encode_message(cmd.body, self.serializer)
+        payload, content_type = await self.codec.encode(cmd.body, self.serializer)
 
         user_props: list[tuple[str, str]] = [
             (k, str(v)) for k, v in (cmd.headers or {}).items()
@@ -174,7 +174,7 @@ class ZmqttProducerV5(ZmqttBaseProducer):
         ID explicitly so the responder echoes it back and the caller can
         verify it on the response StreamMessage.
         """
-        payload, content_type = encode_message(cmd.body, self.serializer)
+        payload, content_type = await self.codec.encode(cmd.body, self.serializer)
         correlation_id = cmd.correlation_id or gen_cor_id()
 
         user_props: list[tuple[str, str]] = [

--- a/faststream/mqtt/publisher/producer.py
+++ b/faststream/mqtt/publisher/producer.py
@@ -16,7 +16,7 @@ from faststream.mqtt.response import MQTTPublishCommand
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
-    from faststream._internal.parser import CodecProto, DefaultCodec
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import AsyncCallable, CustomCallable
 
 
@@ -32,7 +32,7 @@ class ZmqttBaseProducer(ProducerProto[MQTTPublishCommand]):
     ) -> None:
         self.serializer: SerializerProto | None = None
         self._client: zmqtt.MQTTClient | None = None
-        self.codec: "CodecProto" = DefaultCodec()
+        self.codec: CodecProto = DefaultCodec()
 
         self._parser = ParserComposition(parser, default_parser.parse_message)
         self._decoder = ParserComposition(decoder, default_parser.decode_message)

--- a/faststream/mqtt/publisher/producer.py
+++ b/faststream/mqtt/publisher/producer.py
@@ -6,6 +6,7 @@ from typing_extensions import override
 from zmqtt import PublishProperties
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException, IncorrectState
 from faststream.message import encode_message, gen_cor_id
@@ -15,6 +16,7 @@ from faststream.mqtt.response import MQTTPublishCommand
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
+    from faststream._internal.parser import CodecProto, DefaultCodec
     from faststream._internal.types import AsyncCallable, CustomCallable
 
 
@@ -30,6 +32,7 @@ class ZmqttBaseProducer(ProducerProto[MQTTPublishCommand]):
     ) -> None:
         self.serializer: SerializerProto | None = None
         self._client: zmqtt.MQTTClient | None = None
+        self.codec: "CodecProto" = DefaultCodec()
 
         self._parser = ParserComposition(parser, default_parser.parse_message)
         self._decoder = ParserComposition(decoder, default_parser.decode_message)
@@ -38,9 +41,11 @@ class ZmqttBaseProducer(ProducerProto[MQTTPublishCommand]):
         self,
         client: "zmqtt.MQTTClient",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         self._client = client
         self.serializer = serializer
+        self.codec = codec or DefaultCodec()
 
     def disconnect(self) -> None:
         self._client = None
@@ -203,6 +208,7 @@ class ZmqttFakeProducer(ZmqttBaseProducer):
         self,
         client: "zmqtt.MQTTClient",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         raise NotImplementedError
 

--- a/faststream/mqtt/testing.py
+++ b/faststream/mqtt/testing.py
@@ -13,7 +13,6 @@ from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.exceptions import SubscriberNotFound
-from faststream.message import encode_message
 from faststream.mqtt.broker.broker import MQTTBroker
 from faststream.mqtt.parser import MQTTParserV5, MQTTParserV311
 from faststream.mqtt.publisher.producer import ZmqttBaseProducer
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import SendableMessage
+    from faststream._internal.parser import CodecProto
     from faststream.mqtt.publisher.usecase import MQTTPublisher
     from faststream.mqtt.subscriber.usecase import MQTTBaseSubscriber
 
@@ -158,7 +158,7 @@ class FakeProducer(ZmqttBaseProducer):
 
     @override
     async def publish(self, cmd: MQTTPublishCommand) -> None:
-        msg = build_message(
+        msg = await build_message(
             message=cmd.body,
             topic=cmd.destination,
             version=self._version,
@@ -168,6 +168,7 @@ class FakeProducer(ZmqttBaseProducer):
             correlation_id=cmd.correlation_id,
             headers=cmd.headers,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         # For shared subscriptions, only deliver to one subscriber per group
@@ -188,7 +189,7 @@ class FakeProducer(ZmqttBaseProducer):
 
     @override
     async def request(self, cmd: MQTTPublishCommand) -> "zmqtt.Message":
-        msg = build_message(
+        msg = await build_message(
             message=cmd.body,
             topic=cmd.destination,
             version=self._version,
@@ -197,6 +198,7 @@ class FakeProducer(ZmqttBaseProducer):
             correlation_id=cmd.correlation_id,
             headers=cmd.headers,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         for handler in cast("list[MQTTBaseSubscriber]", self.broker.subscribers):
@@ -206,19 +208,20 @@ class FakeProducer(ZmqttBaseProducer):
             with anyio.fail_after(cmd.timeout or 30.0):
                 result = await handler.process_message(msg)
 
-            return build_message(
+            return await build_message(
                 message=result.body,
                 topic=cmd.destination,
                 version=self._version,
                 correlation_id=result.correlation_id,
                 headers=result.headers,
                 serializer=self.broker.config.fd_config._serializer,
+                codec=self.codec,
             )
 
         raise SubscriberNotFound
 
 
-def build_message(
+async def build_message(
     message: "SendableMessage",
     topic: str,
     *,
@@ -229,6 +232,7 @@ def build_message(
     correlation_id: str | None = None,
     headers: dict[str, str] | None = None,
     serializer: Optional["SerializerProto"] = None,
+    codec: Optional["CodecProto"] = None,
 ) -> zmqtt.Message:
     """Build a fake ``zmqtt.Message`` from publish parameters.
 
@@ -236,7 +240,9 @@ def build_message(
     ``MQTTParserV5`` can extract them transparently.
     For MQTT 3.1.1 returns a plain message with raw payload only.
     """
-    payload, content_type = encode_message(message, serializer=serializer)
+    if codec is None:
+        codec = DefaultCodec()
+    payload, content_type = await codec.encode(message, serializer=serializer)
 
     if version == "3.1.1":
         return zmqtt.Message(

--- a/faststream/mqtt/testing.py
+++ b/faststream/mqtt/testing.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 from zmqtt._internal.protocol import _shared_filter_to_actual, _topic_matches
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.exceptions import SubscriberNotFound
 from faststream.message import encode_message
@@ -149,6 +150,7 @@ class FakeProducer(ZmqttBaseProducer):
         default = _parser_for_version(version)
         self._parser = ParserComposition(broker._parser, default.parse_message)
         self._decoder = ParserComposition(broker._decoder, default.decode_message)
+        self.codec = broker.config.broker_codec or DefaultCodec()
 
     @property
     def _version(self) -> Literal["3.1.1", "5.0"]:

--- a/faststream/nats/configs/broker.py
+++ b/faststream/nats/configs/broker.py
@@ -35,9 +35,17 @@ class NatsBrokerConfig(BrokerConfig):
     def connect(self, connection: "Client") -> None:
         stream = connection.jetstream(**self.js_options)
 
-        self.producer.connect(connection, serializer=self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
+        self.producer.connect(
+            connection,
+            serializer=self.fd_config._serializer,
+            codec=self.broker_codec or DefaultCodec(),
+        )
 
-        self.js_producer.connect(stream, serializer=self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
+        self.js_producer.connect(
+            stream,
+            serializer=self.fd_config._serializer,
+            codec=self.broker_codec or DefaultCodec(),
+        )
         self.kv_declarer.connect(stream)
         self.os_declarer.connect(stream)
 

--- a/faststream/nats/configs/broker.py
+++ b/faststream/nats/configs/broker.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 from typing_extensions import TypedDict
 
 from faststream._internal.configs import BrokerConfig
+from faststream._internal.parser import DefaultCodec
 from faststream.nats.broker.state import BrokerState
 from faststream.nats.helpers import KVBucketDeclarer, OSBucketDeclarer
 from faststream.nats.publisher.producer import FakeNatsFastProducer
@@ -34,9 +35,9 @@ class NatsBrokerConfig(BrokerConfig):
     def connect(self, connection: "Client") -> None:
         stream = connection.jetstream(**self.js_options)
 
-        self.producer.connect(connection, serializer=self.fd_config._serializer)
+        self.producer.connect(connection, serializer=self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
 
-        self.js_producer.connect(stream, serializer=self.fd_config._serializer)
+        self.js_producer.connect(stream, serializer=self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
         self.kv_declarer.connect(stream)
         self.os_declarer.connect(stream)
 

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -12,7 +12,7 @@ from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException
-from faststream.message import encode_message
+
 from faststream.nats.helpers.state import (
     ConnectedState,
     ConnectionState,
@@ -91,7 +91,7 @@ class NatsFastProducerImpl(NatsFastProducer):
 
     @override
     async def publish(self, cmd: "NatsPublishCommand") -> None:
-        payload, content_type = encode_message(cmd.body, self.serializer)
+        payload, content_type = await self.codec.encode(cmd.body, self.serializer)
 
         headers_to_send = {
             "content-type": content_type or "",
@@ -107,7 +107,7 @@ class NatsFastProducerImpl(NatsFastProducer):
 
     @override
     async def request(self, cmd: "NatsPublishCommand") -> "Msg":
-        payload, content_type = encode_message(cmd.body, self.serializer)
+        payload, content_type = await self.codec.encode(cmd.body, self.serializer)
 
         headers_to_send = {
             "content-type": content_type or "",
@@ -158,7 +158,7 @@ class NatsJSFastProducer(NatsFastProducer):
 
     @override
     async def publish(self, cmd: "NatsPublishCommand") -> "PubAck":
-        payload, content_type = encode_message(cmd.body, self.serializer)
+        payload, content_type = await self.codec.encode(cmd.body, self.serializer)
 
         headers_to_send = {
             "content-type": content_type or "",
@@ -175,7 +175,7 @@ class NatsJSFastProducer(NatsFastProducer):
 
     @override
     async def request(self, cmd: "NatsPublishCommand") -> "Msg":
-        payload, content_type = encode_message(cmd.body, self.serializer)
+        payload, content_type = await self.codec.encode(cmd.body, self.serializer)
 
         reply_to = self.__state.connection._nc.new_inbox()
         future: asyncio.Future[Msg] = asyncio.Future()

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -12,7 +12,6 @@ from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException
-
 from faststream.nats.helpers.state import (
     ConnectedState,
     ConnectionState,
@@ -27,7 +26,7 @@ if TYPE_CHECKING:
     from nats.aio.msg import Msg
     from nats.js import JetStreamContext
 
-    from faststream._internal.parser import CodecProto, DefaultCodec
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         AsyncCallable,
         CustomCallable,
@@ -68,7 +67,7 @@ class NatsFastProducerImpl(NatsFastProducer):
         decoder: Optional["CustomCallable"],
     ) -> None:
         self.serializer: SerializerProto | None = None
-        self.codec: "CodecProto" = DefaultCodec()
+        self.codec: CodecProto = DefaultCodec()
 
         default = NatsParser(pattern="", is_ack_disabled=True)
         self._parser = ParserComposition(parser, default.parse_message)
@@ -135,7 +134,7 @@ class NatsJSFastProducer(NatsFastProducer):
         decoder: Optional["CustomCallable"],
     ) -> None:
         self.serializer: SerializerProto | None = None
-        self.codec: "CodecProto" = DefaultCodec()
+        self.codec: CodecProto = DefaultCodec()
 
         default = NatsParser(pattern="", is_ack_disabled=True)
         self._parser = ParserComposition(parser, default.parse_message)
@@ -212,7 +211,12 @@ class NatsJSFastProducer(NatsFastProducer):
 
 
 class FakeNatsFastProducer(NatsFastProducer):
-    def connect(self, connection: Any, serializer: Optional["SerializerProto"], codec: Optional["CodecProto"] = None) -> None:
+    def connect(
+        self,
+        connection: Any,
+        serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
+    ) -> None:
         raise NotImplementedError
 
     def disconnect(self) -> None:

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -9,6 +9,7 @@ from nats.js.api import Header
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException
 from faststream.message import encode_message
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
     from nats.aio.msg import Msg
     from nats.js import JetStreamContext
 
+    from faststream._internal.parser import CodecProto, DefaultCodec
     from faststream._internal.types import (
         AsyncCallable,
         CustomCallable,
@@ -38,6 +40,7 @@ class NatsFastProducer(ProducerProto[NatsPublishCommand]):
         self,
         connection: Any,
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None: ...
 
     def disconnect(self) -> None: ...
@@ -65,6 +68,7 @@ class NatsFastProducerImpl(NatsFastProducer):
         decoder: Optional["CustomCallable"],
     ) -> None:
         self.serializer: SerializerProto | None = None
+        self.codec: "CodecProto" = DefaultCodec()
 
         default = NatsParser(pattern="", is_ack_disabled=True)
         self._parser = ParserComposition(parser, default.parse_message)
@@ -76,8 +80,10 @@ class NatsFastProducerImpl(NatsFastProducer):
         self,
         connection: "Client",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         self.serializer = serializer
+        self.codec = codec or DefaultCodec()
         self.__state = ConnectedState(connection)
 
     def disconnect(self) -> None:
@@ -129,6 +135,7 @@ class NatsJSFastProducer(NatsFastProducer):
         decoder: Optional["CustomCallable"],
     ) -> None:
         self.serializer: SerializerProto | None = None
+        self.codec: "CodecProto" = DefaultCodec()
 
         default = NatsParser(pattern="", is_ack_disabled=True)
         self._parser = ParserComposition(parser, default.parse_message)
@@ -140,8 +147,10 @@ class NatsJSFastProducer(NatsFastProducer):
         self,
         connection: "JetStreamContext",
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         self.serializer = serializer
+        self.codec = codec or DefaultCodec()
         self.__state = ConnectedState(connection)
 
     def disconnect(self) -> None:
@@ -203,7 +212,7 @@ class NatsJSFastProducer(NatsFastProducer):
 
 
 class FakeNatsFastProducer(NatsFastProducer):
-    def connect(self, connection: Any, serializer: Optional["SerializerProto"]) -> None:
+    def connect(self, connection: Any, serializer: Optional["SerializerProto"], codec: Optional["CodecProto"] = None) -> None:
         raise NotImplementedError
 
     def disconnect(self) -> None:

--- a/faststream/nats/testing.py
+++ b/faststream/nats/testing.py
@@ -11,7 +11,7 @@ from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker
 from faststream.exceptions import SubscriberNotFound
-from faststream.message import encode_message, gen_cor_id
+from faststream.message import gen_cor_id
 from faststream.nats.broker import NatsBroker
 from faststream.nats.parser import NatsParser
 from faststream.nats.publisher.producer import NatsFastProducer
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
     from faststream._internal.basic_types import SendableMessage
     from faststream._internal.configs.broker import ConfigComposition
+    from faststream._internal.parser import CodecProto
     from faststream.nats.configs import NatsBrokerConfig
     from faststream.nats.publisher.usecase import LogicPublisher
     from faststream.nats.response import NatsPublishCommand
@@ -109,13 +110,14 @@ class FakeProducer(NatsFastProducer):
 
     @override
     async def publish(self, cmd: "NatsPublishCommand") -> None:
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             subject=cmd.destination,
             headers=cmd.headers,
             correlation_id=cmd.correlation_id,
             reply_to=cmd.reply_to,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         for handler in _find_handler(
@@ -134,12 +136,13 @@ class FakeProducer(NatsFastProducer):
 
     @override
     async def request(self, cmd: "NatsPublishCommand") -> "PatchedMessage":
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             subject=cmd.destination,
             headers=cmd.headers,
             correlation_id=cmd.correlation_id,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         for handler in _find_handler(
@@ -167,12 +170,13 @@ class FakeProducer(NatsFastProducer):
     ) -> "PatchedMessage":
         result = await handler.process_message(msg)
 
-        return build_message(
+        return await build_message(
             subject=subject,
             message=result.body,
             headers=result.headers,
             correlation_id=result.correlation_id,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
 
@@ -214,7 +218,7 @@ def _is_handler_matches(
     return False
 
 
-def build_message(
+async def build_message(
     message: "SendableMessage",
     subject: str,
     *,
@@ -222,8 +226,11 @@ def build_message(
     correlation_id: str | None = None,
     headers: dict[str, str] | None = None,
     serializer: Optional["SerializerProto"] = None,
+    codec: Optional["CodecProto"] = None,
 ) -> "PatchedMessage":
-    msg, content_type = encode_message(message, serializer=serializer)
+    if codec is None:
+        codec = DefaultCodec()
+    msg, content_type = await codec.encode(message, serializer=serializer)
     return PatchedMessage(
         _client=None,  # type: ignore[arg-type]
         subject=subject,

--- a/faststream/nats/testing.py
+++ b/faststream/nats/testing.py
@@ -8,6 +8,7 @@ from nats.aio.msg import Msg
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker
 from faststream.exceptions import SubscriberNotFound
 from faststream.message import encode_message, gen_cor_id
@@ -104,6 +105,7 @@ class FakeProducer(NatsFastProducer):
         default = NatsParser(pattern="", is_ack_disabled=True)
         self._parser = ParserComposition(broker._parser, default.parse_message)
         self._decoder = ParserComposition(broker._decoder, default.decode_message)
+        self.codec = broker.config.broker_codec or DefaultCodec()
 
     @override
     async def publish(self, cmd: "NatsPublishCommand") -> None:

--- a/faststream/rabbit/configs/broker.py
+++ b/faststream/rabbit/configs/broker.py
@@ -28,7 +28,10 @@ class RabbitBrokerConfig(BrokerConfig):
 
     def connect(self, connection: "RobustConnection") -> None:
         self.channel_manager.connect(connection)
-        self.producer.connect(serializer=self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
+        self.producer.connect(
+            serializer=self.fd_config._serializer,
+            codec=self.broker_codec or DefaultCodec(),
+        )
 
     def disconnect(self) -> None:
         self.channel_manager.disconnect()

--- a/faststream/rabbit/configs/broker.py
+++ b/faststream/rabbit/configs/broker.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from faststream._internal.configs import BrokerConfig
+from faststream._internal.parser import DefaultCodec
 from faststream.rabbit.helpers.channel_manager import FakeChannelManager
 from faststream.rabbit.helpers.declarer import FakeRabbitDeclarer
 from faststream.rabbit.publisher.producer import FakeAioPikaFastProducer
@@ -27,7 +28,7 @@ class RabbitBrokerConfig(BrokerConfig):
 
     def connect(self, connection: "RobustConnection") -> None:
         self.channel_manager.connect(connection)
-        self.producer.connect(serializer=self.fd_config._serializer)
+        self.producer.connect(serializer=self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
 
     def disconnect(self) -> None:
         self.channel_manager.disconnect()

--- a/faststream/rabbit/parser.py
+++ b/faststream/rabbit/parser.py
@@ -8,7 +8,6 @@ from faststream._internal.utils.path import match_path
 from faststream.message import (
     StreamMessage,
     decode_message,
-    encode_message,
     gen_cor_id,
 )
 from faststream.rabbit.message import RabbitMessage
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import DecodedMessage
+    from faststream._internal.parser import CodecProto
     from faststream.rabbit.types import AioPikaSendableMessage
 
 
@@ -56,7 +56,7 @@ class AioPikaParser:
         return decode_message(msg)
 
     @staticmethod
-    def encode_message(
+    async def encode_message(
         message: "AioPikaSendableMessage",
         *,
         persist: bool = False,
@@ -73,11 +73,13 @@ class AioPikaParser:
         user_id: str | None = None,
         app_id: str | None = None,
         serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
     ) -> Message:
         """Encodes a message for sending using AioPika."""
         if isinstance(message, Message):
             return message
-        message_body, generated_content_type = encode_message(message, serializer)
+        from faststream._internal.parser import DefaultCodec
+        message_body, generated_content_type = await (codec or DefaultCodec()).encode(message, serializer)
 
         delivery_mode = (
             DeliveryMode.PERSISTENT if persist else DeliveryMode.NOT_PERSISTENT

--- a/faststream/rabbit/parser.py
+++ b/faststream/rabbit/parser.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 from aio_pika import Message
 from aio_pika.abc import DeliveryMode
 
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.utils.path import match_path
 from faststream.message import (
     StreamMessage,
@@ -78,8 +79,10 @@ class AioPikaParser:
         """Encodes a message for sending using AioPika."""
         if isinstance(message, Message):
             return message
-        from faststream._internal.parser import DefaultCodec
-        message_body, generated_content_type = await (codec or DefaultCodec()).encode(message, serializer)
+
+        message_body, generated_content_type = await (codec or DefaultCodec()).encode(
+            message, serializer
+        )
 
         delivery_mode = (
             DeliveryMode.PERSISTENT if persist else DeliveryMode.NOT_PERSISTENT

--- a/faststream/rabbit/publisher/producer.py
+++ b/faststream/rabbit/publisher/producer.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
     from fast_depends.library.serializer import SerializerProto
 
-    from faststream._internal.parser import CodecProto, DefaultCodec
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import (
         AsyncCallable,
         CustomCallable,
@@ -59,7 +59,11 @@ class RealLock:
 
 
 class AioPikaFastProducer(ProducerProto[RabbitPublishCommand]):
-    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None: ...
+    def connect(
+        self,
+        serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
+    ) -> None: ...
 
     def disconnect(self) -> None: ...
 
@@ -82,7 +86,11 @@ class FakeAioPikaFastProducer(AioPikaFastProducer):
     def __bool__(self) -> bool:
         return False
 
-    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None:
+    def connect(
+        self,
+        serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
+    ) -> None:
         raise NotImplementedError
 
     def disconnect(self) -> None:
@@ -117,13 +125,17 @@ class AioPikaFastProducerImpl(AioPikaFastProducer):
 
         self.__lock: LockState = LockUnset()
         self.serializer: SerializerProto | None = None
-        self.codec: "CodecProto" = DefaultCodec()
+        self.codec: CodecProto = DefaultCodec()
 
         default_parser = AioPikaParser()
         self._parser = ParserComposition(parser, default_parser.parse_message)
         self._decoder = ParserComposition(decoder, default_parser.decode_message)
 
-    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None:
+    def connect(
+        self,
+        serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
+    ) -> None:
         """Lock initialization.
 
         Should be called in async context due `anyio.Lock` object can't be created outside event loop.
@@ -182,7 +194,10 @@ class AioPikaFastProducerImpl(AioPikaFastProducer):
         **message_options: Unpack["MessageOptions"],
     ) -> Optional["aiormq.abc.ConfirmationFrameType"]:
         message = await AioPikaParser.encode_message(
-            message=message, serializer=self.serializer, codec=self.codec, **message_options
+            message=message,
+            serializer=self.serializer,
+            codec=self.codec,
+            **message_options,
         )
 
         exchange_obj = await self.declarer.declare_exchange(

--- a/faststream/rabbit/publisher/producer.py
+++ b/faststream/rabbit/publisher/producer.py
@@ -10,6 +10,7 @@ import anyio
 from typing_extensions import Unpack, override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream.exceptions import FeatureNotSupportedException, IncorrectState
 from faststream.rabbit.parser import AioPikaParser
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
     from fast_depends.library.serializer import SerializerProto
 
+    from faststream._internal.parser import CodecProto, DefaultCodec
     from faststream._internal.types import (
         AsyncCallable,
         CustomCallable,
@@ -57,7 +59,7 @@ class RealLock:
 
 
 class AioPikaFastProducer(ProducerProto[RabbitPublishCommand]):
-    def connect(self, serializer: Optional["SerializerProto"] = None) -> None: ...
+    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None: ...
 
     def disconnect(self) -> None: ...
 
@@ -80,7 +82,7 @@ class FakeAioPikaFastProducer(AioPikaFastProducer):
     def __bool__(self) -> bool:
         return False
 
-    def connect(self, serializer: Optional["SerializerProto"] = None) -> None:
+    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None:
         raise NotImplementedError
 
     def disconnect(self) -> None:
@@ -115,17 +117,19 @@ class AioPikaFastProducerImpl(AioPikaFastProducer):
 
         self.__lock: LockState = LockUnset()
         self.serializer: SerializerProto | None = None
+        self.codec: "CodecProto" = DefaultCodec()
 
         default_parser = AioPikaParser()
         self._parser = ParserComposition(parser, default_parser.parse_message)
         self._decoder = ParserComposition(decoder, default_parser.decode_message)
 
-    def connect(self, serializer: Optional["SerializerProto"] = None) -> None:
+    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None:
         """Lock initialization.
 
         Should be called in async context due `anyio.Lock` object can't be created outside event loop.
         """
         self.serializer = serializer
+        self.codec = codec or DefaultCodec()
         self.__lock = RealLock()
 
     def disconnect(self) -> None:

--- a/faststream/rabbit/publisher/producer.py
+++ b/faststream/rabbit/publisher/producer.py
@@ -181,8 +181,8 @@ class AioPikaFastProducerImpl(AioPikaFastProducer):
         timeout: "TimeoutType" = None,
         **message_options: Unpack["MessageOptions"],
     ) -> Optional["aiormq.abc.ConfirmationFrameType"]:
-        message = AioPikaParser.encode_message(
-            message=message, serializer=self.serializer, **message_options
+        message = await AioPikaParser.encode_message(
+            message=message, serializer=self.serializer, codec=self.codec, **message_options
         )
 
         exchange_obj = await self.declarer.declare_exchange(

--- a/faststream/rabbit/testing.py
+++ b/faststream/rabbit/testing.py
@@ -12,6 +12,7 @@ from pamqp.header import ContentHeader
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.exceptions import SubscriberNotFound
 from faststream.message import gen_cor_id
@@ -207,6 +208,7 @@ class FakeProducer(AioPikaFastProducer):
             broker._decoder,
             default_parser.decode_message,
         )
+        self.codec = broker.config.broker_codec or DefaultCodec()
 
     @override
     async def publish(

--- a/faststream/rabbit/testing.py
+++ b/faststream/rabbit/testing.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from aio_pika.abc import DateType, HeadersType
     from fast_depends.library.serializer import SerializerProto
 
+    from faststream._internal.parser import CodecProto
     from faststream.rabbit.publisher import RabbitPublisher
     from faststream.rabbit.response import RabbitPublishCommand
     from faststream.rabbit.subscriber import RabbitSubscriber
@@ -119,7 +120,7 @@ class PatchedMessage(IncomingMessage):
         """Rejects a task."""
 
 
-def build_message(
+async def build_message(
     message: "AioPikaSendableMessage" = "",
     queue: Union["RabbitQueue", str] = "",
     exchange: Union["RabbitExchange", str, None] = None,
@@ -139,6 +140,7 @@ def build_message(
     user_id: str | None = None,
     app_id: str | None = None,
     serializer: Optional["SerializerProto"] = None,
+    codec: Optional["CodecProto"] = None,
 ) -> PatchedMessage:
     """Build a patched RabbitMQ message for testing."""
     que = RabbitQueue.validate(queue)
@@ -147,7 +149,7 @@ def build_message(
     routing = routing_key or que.routing()
 
     correlation_id = correlation_id or gen_cor_id()
-    msg = AioPikaParser.encode_message(
+    msg = await AioPikaParser.encode_message(
         message=message,
         persist=persist,
         reply_to=reply_to,
@@ -163,6 +165,7 @@ def build_message(
         user_id=user_id,
         app_id=app_id,
         serializer=serializer,
+        codec=codec,
     )
 
     return PatchedMessage(
@@ -216,7 +219,7 @@ class FakeProducer(AioPikaFastProducer):
         cmd: "RabbitPublishCommand",
     ) -> None:
         """Publish a message to a RabbitMQ queue or exchange."""
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             exchange=cmd.exchange,
             routing_key=cmd.destination,
@@ -224,6 +227,7 @@ class FakeProducer(AioPikaFastProducer):
             headers=cmd.headers,
             reply_to=cmd.reply_to,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
             **cmd.message_options,
         )
 
@@ -248,13 +252,14 @@ class FakeProducer(AioPikaFastProducer):
         cmd: "RabbitPublishCommand",
     ) -> "PatchedMessage":
         """Make a synchronous request to RabbitMQ."""
-        incoming = build_message(
+        incoming = await build_message(
             message=cmd.body,
             exchange=cmd.exchange,
             routing_key=cmd.destination,
             correlation_id=cmd.correlation_id,
             headers=cmd.headers,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
             **cmd.message_options,
         )
 
@@ -277,12 +282,13 @@ class FakeProducer(AioPikaFastProducer):
         handler: "RabbitSubscriber",
     ) -> "PatchedMessage":
         result = await handler.process_message(msg)
-        return build_message(
+        return await build_message(
             routing_key=msg.routing_key,
             message=result.body,
             headers=result.headers,
             correlation_id=result.correlation_id,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
 

--- a/faststream/redis/configs/broker.py
+++ b/faststream/redis/configs/broker.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from faststream._internal.configs import BrokerConfig
+from faststream._internal.parser import DefaultCodec
 from faststream.exceptions import IncorrectState
 
 if TYPE_CHECKING:
@@ -25,7 +26,7 @@ class RedisBrokerConfig(BrokerConfig):
     message_format: type["MessageFormat"]
 
     async def connect(self) -> None:
-        self.producer.connect(self.fd_config._serializer)
+        self.producer.connect(self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
         await self.connection.connect()
 
     async def disconnect(self) -> None:

--- a/faststream/redis/configs/broker.py
+++ b/faststream/redis/configs/broker.py
@@ -26,7 +26,9 @@ class RedisBrokerConfig(BrokerConfig):
     message_format: type["MessageFormat"]
 
     async def connect(self) -> None:
-        self.producer.connect(self.fd_config._serializer, codec=self.broker_codec or DefaultCodec())
+        self.producer.connect(
+            self.fd_config._serializer, codec=self.broker_codec or DefaultCodec()
+        )
         await self.connection.connect()
 
     async def disconnect(self) -> None:

--- a/faststream/redis/parser/binary.py
+++ b/faststream/redis/parser/binary.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import SendableMessage
+    from faststream._internal.parser import CodecProto
 
 
 class FastStreamMessageVersion(int, enum.Enum):
@@ -23,7 +24,7 @@ class BinaryMessageFormatV1(MessageFormat):
     IDENTITY_HEADER = b"\x89BIN\x0d\x0a\x1a\x0a"  # to avoid confusion with other formats
 
     @classmethod
-    def encode(
+    async def encode(
         cls,
         *,
         message: Union[Sequence["SendableMessage"], "SendableMessage"],
@@ -31,13 +32,15 @@ class BinaryMessageFormatV1(MessageFormat):
         headers: dict[str, Any] | None,
         correlation_id: str,
         serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
     ) -> bytes:
-        msg = cls.build(
+        msg = await cls.build(
             message=message,
             reply_to=reply_to,
             headers=headers,
             correlation_id=correlation_id,
             serializer=serializer,
+            codec=codec,
         )
         headers_writer = BinaryWriter()
         for key, value in msg.headers.items():

--- a/faststream/redis/parser/message.py
+++ b/faststream/redis/parser/message.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from faststream._internal.parser import DefaultCodec
+
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
@@ -36,8 +38,6 @@ class MessageFormat(ABC):
         serializer: Optional["SerializerProto"] = None,
         codec: Optional["CodecProto"] = None,
     ) -> "MessageFormat":
-        from faststream._internal.parser import DefaultCodec
-
         codec_instance = codec or DefaultCodec()
         payload, content_type = await codec_instance.encode(message, serializer)
 

--- a/faststream/redis/parser/message.py
+++ b/faststream/redis/parser/message.py
@@ -39,7 +39,7 @@ class MessageFormat(ABC):
         codec: Optional["CodecProto"] = None,
     ) -> "MessageFormat":
         codec_instance = codec or DefaultCodec()
-        payload, content_type = await codec_instance.encode(message, serializer)
+        payload, content_type = await codec_instance.encode(message, serializer)  # type: ignore[arg-type]
 
         headers_to_send = {
             "correlation_id": correlation_id,

--- a/faststream/redis/parser/message.py
+++ b/faststream/redis/parser/message.py
@@ -2,12 +2,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from faststream.message import encode_message
-
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import SendableMessage
+    from faststream._internal.parser import CodecProto
 
 
 class MessageFormat(ABC):
@@ -27,7 +26,7 @@ class MessageFormat(ABC):
         self.headers = headers or {}
 
     @classmethod
-    def build(
+    async def build(
         cls,
         *,
         message: Union[Sequence["SendableMessage"], "SendableMessage"],
@@ -35,8 +34,12 @@ class MessageFormat(ABC):
         headers: dict[str, Any] | None,
         correlation_id: str,
         serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
     ) -> "MessageFormat":
-        payload, content_type = encode_message(message, serializer=serializer)
+        from faststream._internal.parser import DefaultCodec
+
+        codec_instance = codec or DefaultCodec()
+        payload, content_type = await codec_instance.encode(message, serializer)
 
         headers_to_send = {
             "correlation_id": correlation_id,
@@ -58,7 +61,7 @@ class MessageFormat(ABC):
 
     @classmethod
     @abstractmethod
-    def encode(
+    async def encode(
         cls,
         *,
         message: Union[Sequence["SendableMessage"], "SendableMessage"],
@@ -66,6 +69,7 @@ class MessageFormat(ABC):
         headers: dict[str, Any] | None,
         correlation_id: str,
         serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
     ) -> bytes:
         raise NotImplementedError
 

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -5,6 +5,7 @@ import anyio
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream._internal.utils.nuid import NUID
 from faststream.redis.configs.state import RedisClusterConnectionState
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from redis.asyncio.client import Redis
     from redis.asyncio.cluster import RedisCluster
 
+    from faststream._internal.parser import CodecProto, DefaultCodec
     from faststream._internal.types import CustomCallable
     from faststream.redis.configs import ConnectionState
     from faststream.redis.parser import MessageFormat
@@ -37,6 +39,7 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         decoder: Optional["CustomCallable"],
         message_format: type["MessageFormat"],
         serializer: Optional["SerializerProto"],
+        codec: Optional["CodecProto"] = None,
     ) -> None:
         self._connection = connection
 
@@ -50,16 +53,18 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
             default.decode_message,
         )
         self.serializer = serializer
+        self.codec = codec or DefaultCodec()
 
     @override
     async def publish_batch(self, cmd: "RedisPublishCommand") -> int:
         batch = [
-            cmd.message_format.encode(
+            await cmd.message_format.encode(
                 message=msg,
                 correlation_id=cmd.correlation_id or "",
                 reply_to=cmd.reply_to,
                 headers=cmd.headers,
                 serializer=self.serializer,
+                codec=self.codec,
             )
             for msg in cmd.batch_bodies
         ]
@@ -67,8 +72,10 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         connection = cmd.pipeline or self._connection.client
         return cast("int", await connection.rpush(cmd.destination, *batch))
 
-    def connect(self, serializer: Optional["SerializerProto"] = None) -> None:
+    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None:
         self.serializer = serializer
+        if codec is not None:
+            self.codec = codec
 
     def _build_child(
         self, **kwargs: Any
@@ -99,12 +106,13 @@ class RedisFastProducer(BaseRedisFastProducer):
 
     @override
     async def publish(self, cmd: "RedisPublishCommand") -> int | bytes:
-        msg = cmd.message_format.encode(
+        msg = await cmd.message_format.encode(
             message=cmd.body,
             reply_to=cmd.reply_to,
             headers=cmd.headers,
             correlation_id=cmd.correlation_id or "",
             serializer=self.serializer,
+            codec=self.codec,
         )
 
         return await self.__publish(msg, cmd)
@@ -144,12 +152,13 @@ class RedisFastProducer(BaseRedisFastProducer):
         try:
             await psub.subscribe(reply_to)
 
-            msg = cmd.message_format.encode(
+            msg = await cmd.message_format.encode(
                 message=cmd.body,
                 reply_to=reply_to,
                 headers=cmd.headers,
                 correlation_id=cmd.correlation_id or "",
                 serializer=self.serializer,
+                codec=self.codec,
             )
 
             await self.__publish(msg, cmd)
@@ -200,12 +209,13 @@ class RedisClusterFastProducer(BaseRedisFastProducer):
 
     @override
     async def publish(self, cmd: "RedisPublishCommand") -> int | bytes:
-        msg = cmd.message_format.encode(
+        msg = await cmd.message_format.encode(
             message=cmd.body,
             reply_to=cmd.reply_to,
             headers=cmd.headers,
             correlation_id=cmd.correlation_id or "",
             serializer=self.serializer,
+            codec=self.codec,
         )
 
         if cmd.destination_type is DestinationType.Channel:
@@ -233,12 +243,13 @@ class RedisClusterFastProducer(BaseRedisFastProducer):
         try:
             await psub.subscribe(reply_to)
 
-            msg = cmd.message_format.encode(
+            msg = await cmd.message_format.encode(
                 message=cmd.body,
                 reply_to=reply_to,
                 headers=cmd.headers,
                 correlation_id=cmd.correlation_id or "",
                 serializer=self.serializer,
+                codec=self.codec,
             )
 
             if cmd.destination_type is DestinationType.Channel:

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -72,7 +72,11 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         connection = cmd.pipeline or self._connection.client
         return cast("int", await connection.rpush(cmd.destination, *batch))
 
-    def connect(self, serializer: Optional["SerializerProto"] = None, codec: Optional["CodecProto"] = None) -> None:
+    def connect(
+        self,
+        serializer: Optional["SerializerProto"] = None,
+        codec: Optional["CodecProto"] = None,
+    ) -> None:
         self.serializer = serializer
         if codec is not None:
             self.codec = codec

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from redis.asyncio.client import Redis
     from redis.asyncio.cluster import RedisCluster
 
-    from faststream._internal.parser import CodecProto, DefaultCodec
+    from faststream._internal.parser import CodecProto
     from faststream._internal.types import CustomCallable
     from faststream.redis.configs import ConnectionState
     from faststream.redis.parser import MessageFormat

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -18,6 +18,7 @@ import anyio
 from typing_extensions import TypedDict, override
 
 from faststream._internal.endpoint.utils import ParserComposition
+from faststream._internal.parser import DefaultCodec
 from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.exceptions import SetupError, SubscriberNotFound
 from faststream.message import gen_cor_id
@@ -161,6 +162,7 @@ class FakeProducer(RedisFastProducer):
             broker._decoder,
             default.decode_message,
         )
+        self.codec = broker.config.broker_codec or DefaultCodec()
 
     @override
     def _build_child(self, **kwargs: Any) -> "FakeProducer":

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
 
     from faststream._internal.basic_types import SendableMessage
+    from faststream._internal.parser import CodecProto
     from faststream.redis.publisher.usecase import LogicPublisher
     from faststream.redis.subscriber.usecases.basic import LogicSubscriber
 
@@ -170,13 +171,14 @@ class FakeProducer(RedisFastProducer):
 
     @override
     async def publish(self, cmd: "RedisPublishCommand") -> int | bytes:
-        body = build_message(
+        body = await build_message(
             message=cmd.body,
             reply_to=cmd.reply_to,
             correlation_id=cmd.correlation_id or gen_cor_id(),
             headers=cmd.headers,
             message_format=cmd.message_format,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         destination = _make_destination_kwargs(cmd)
@@ -198,12 +200,13 @@ class FakeProducer(RedisFastProducer):
 
     @override
     async def request(self, cmd: "RedisPublishCommand") -> "PubSubMessage":
-        body = build_message(
+        body = await build_message(
             message=cmd.body,
             correlation_id=cmd.correlation_id or gen_cor_id(),
             headers=cmd.headers,
             message_format=cmd.message_format,
             serializer=self.broker.config.fd_config._serializer,
+            codec=self.codec,
         )
 
         destination = _make_destination_kwargs(cmd)
@@ -227,12 +230,13 @@ class FakeProducer(RedisFastProducer):
     @override
     async def publish_batch(self, cmd: "RedisPublishCommand") -> int:
         data_to_send = [
-            build_message(
+            await build_message(
                 m,
                 correlation_id=cmd.correlation_id or gen_cor_id(),
                 headers=cmd.headers,
                 message_format=cmd.message_format,
                 serializer=self.broker.config.fd_config._serializer,
+                codec=self.codec,
             )
             for m in cmd.batch_bodies
         ]
@@ -263,19 +267,20 @@ class FakeProducer(RedisFastProducer):
 
         return PubSubMessage(
             type="message",
-            data=build_message(
+            data=await build_message(
                 message=result.body,
                 headers=result.headers,
                 correlation_id=result.correlation_id or "",
                 message_format=handler.config.message_format,
                 serializer=self.broker.config.fd_config._serializer,
+                codec=self.codec,
             ),
             channel="",
             pattern=None,
         )
 
 
-def build_message(
+async def build_message(
     message: Union[Sequence["SendableMessage"], "SendableMessage"],
     *,
     correlation_id: str,
@@ -283,13 +288,15 @@ def build_message(
     reply_to: str = "",
     headers: dict[str, Any] | None = None,
     serializer: Optional["SerializerProto"] = None,
+    codec: Optional["CodecProto"] = None,
 ) -> bytes:
-    return message_format.encode(
+    return await message_format.encode(
         message=message,
         reply_to=reply_to,
         headers=headers,
         correlation_id=correlation_id,
         serializer=serializer,
+        codec=codec,
     )
 
 

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -158,7 +158,7 @@ class BatchCodecTestcase:
                 serializer: Any = None,
             ) -> list[tuple[bytes, str | None]]:
                 encode_batch_mock()
-                return [await super().encode(m, serializer) for m in msgs]
+                return [await DefaultCodec.encode(self, m, serializer) for m in msgs]
 
             async def decode_batch(self, msg: Any) -> list[Any]:
                 return []

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -107,19 +107,18 @@ class CodecTestcase(BaseTestcaseConfig):
 
         broker = self.get_broker(codec=TrackingCodec())
 
+        args, kwargs = self.get_subscriber_params(queue)
+
+        @broker.subscriber(*args, **kwargs)
+        async def handle(m) -> None:
+            pass
+
         async with self.patch_broker(broker) as br:
-
-            @br.subscriber(queue)
-            async def handler(m) -> None:
-                pass
-
             await br.publish({"key": "value"}, queue)
 
         assert mock.called, "codec.encode was not called on publish"
 
-    async def test_default_codec_encode_matches_encode_message(
-        self, queue: str
-    ) -> None:
+    async def test_default_codec_encode_matches_encode_message(self, queue: str) -> None:
         codec = DefaultCodec()
 
         test_cases = [

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -135,3 +137,77 @@ class CodecTestcase(BaseTestcaseConfig):
                 f"DefaultCodec.encode({msg!r}) = {codec_result!r} "
                 f"but encode_message({msg!r}) = {direct_result!r}"
             )
+
+
+@pytest.mark.asyncio()
+class BatchCodecTestcase:
+    async def test_batch_codec_encode_batch_called(self) -> None:
+        encode_mock = MagicMock()
+        encode_batch_mock = MagicMock()
+
+        class TrackingBatchCodec(DefaultCodec):
+            async def encode(
+                self, msg: Any, serializer: Any = None
+            ) -> tuple[bytes, str | None]:
+                encode_mock()
+                return await super().encode(msg, serializer)
+
+            async def encode_batch(
+                self,
+                msgs: Sequence[Any],
+                serializer: Any = None,
+            ) -> list[tuple[bytes, str | None]]:
+                encode_batch_mock()
+                return [await super().encode(m, serializer) for m in msgs]
+
+            async def decode_batch(self, msg: Any) -> list[Any]:
+                return []
+
+        from faststream._internal.parser import BatchCodecProto
+
+        codec = TrackingBatchCodec()
+        assert isinstance(codec, BatchCodecProto)
+
+        result = await codec.encode_batch(["a", "b", "c"], None)
+        assert len(result) == 3
+        assert encode_batch_mock.called
+        assert not encode_mock.called
+
+    async def test_batch_codec_isinstance_dispatch(self) -> None:
+        from faststream._internal.parser import BatchCodecProto
+
+        class WithBatch(DefaultCodec):
+            async def encode_batch(
+                self,
+                msgs: Sequence[Any],
+                serializer: Any = None,
+            ) -> list[tuple[bytes, str | None]]:
+                return [await super().encode(m, serializer) for m in msgs]
+
+            async def decode_batch(self, msg: Any) -> list[Any]:
+                return []
+
+        class WithoutBatch(DefaultCodec):
+            pass
+
+        assert isinstance(WithBatch(), BatchCodecProto)
+        assert not isinstance(WithoutBatch(), BatchCodecProto)
+
+    async def test_batch_codec_fallback_to_per_item(self) -> None:
+        from faststream._internal.parser import BatchCodecProto
+
+        encode_mock = MagicMock()
+
+        class TrackingCodec(DefaultCodec):
+            async def encode(
+                self, msg: Any, serializer: Any = None
+            ) -> tuple[bytes, str | None]:
+                encode_mock()
+                return await super().encode(msg, serializer)
+
+        codec = TrackingCodec()
+        assert not isinstance(codec, BatchCodecProto)
+
+        results = [await codec.encode(m, None) for m in ["a", "b", "c"]]
+        assert len(results) == 3
+        assert encode_mock.call_count == 3

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -140,18 +140,46 @@ class CodecTestcase(BaseTestcaseConfig):
 
 
 @pytest.mark.asyncio()
-class BatchCodecTestcase:
-    async def test_batch_codec_encode_batch_called(self) -> None:
-        encode_mock = MagicMock()
+class BatchCodecTestcase(BaseTestcaseConfig):
+    async def test_batch_codec_decode_batch_called(
+        self,
+        mock: MagicMock,
+        queue: str,
+    ) -> None:
+        decode_batch_mock = MagicMock()
+
+        class TrackingBatchCodec(DefaultCodec):
+            async def encode_batch(
+                self,
+                msgs: Sequence[Any],
+                serializer: Any = None,
+            ) -> list[tuple[bytes, str | None]]:
+                return [await DefaultCodec.encode(self, m, serializer) for m in msgs]
+
+            async def decode_batch(self, msg: Any) -> list[Any]:
+                decode_batch_mock()
+                return [b.decode() if isinstance(b, bytes) else b for b in msg.body]
+
+        codec = TrackingBatchCodec()
+        broker = self.get_broker(codec=codec)
+
+        @broker.subscriber(queue, batch=True)
+        async def handle(m: list[str]) -> None:
+            mock(m)
+
+        async with self.patch_broker(broker) as br:
+            await br.publish_batch("a", "b", "c", topic=queue)
+
+        assert decode_batch_mock.called, "decode_batch was not called"
+        mock.assert_called_once_with(["a", "b", "c"])
+
+    async def test_batch_codec_encode_batch_called(
+        self,
+        queue: str,
+    ) -> None:
         encode_batch_mock = MagicMock()
 
         class TrackingBatchCodec(DefaultCodec):
-            async def encode(
-                self, msg: Any, serializer: Any = None
-            ) -> tuple[bytes, str | None]:
-                encode_mock()
-                return await super().encode(msg, serializer)
-
             async def encode_batch(
                 self,
                 msgs: Sequence[Any],
@@ -161,17 +189,32 @@ class BatchCodecTestcase:
                 return [await DefaultCodec.encode(self, m, serializer) for m in msgs]
 
             async def decode_batch(self, msg: Any) -> list[Any]:
-                return []
+                return [b.decode() if isinstance(b, bytes) else b for b in msg.body]
 
-        from faststream._internal.parser import BatchCodecProto
+        broker = self.get_broker(codec=TrackingBatchCodec())
 
-        codec = TrackingBatchCodec()
-        assert isinstance(codec, BatchCodecProto)
+        @broker.subscriber(queue, batch=True)
+        async def handle(m: list[str]) -> None:
+            pass
 
-        result = await codec.encode_batch(["a", "b", "c"], None)
-        assert len(result) == 3
-        assert encode_batch_mock.called
-        assert not encode_mock.called
+        async with self.patch_broker(broker) as br:
+            await br.publish_batch("a", "b", "c", topic=queue)
+
+        assert encode_batch_mock.called, "encode_batch was not called on publish"
+
+    async def test_batch_codec_without_batch_proto_raises(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker(codec=DefaultCodec())
+
+        @broker.subscriber(queue, batch=True)
+        async def handle(m: list[str]) -> None:
+            pass
+
+        with pytest.raises(ValueError, match="BatchCodecProto"):
+            async with self.patch_broker(broker):
+                pass
 
     async def test_batch_codec_isinstance_dispatch(self) -> None:
         from faststream._internal.parser import BatchCodecProto
@@ -192,22 +235,3 @@ class BatchCodecTestcase:
 
         assert isinstance(WithBatch(), BatchCodecProto)
         assert not isinstance(WithoutBatch(), BatchCodecProto)
-
-    async def test_batch_codec_fallback_to_per_item(self) -> None:
-        from faststream._internal.parser import BatchCodecProto
-
-        encode_mock = MagicMock()
-
-        class TrackingCodec(DefaultCodec):
-            async def encode(
-                self, msg: Any, serializer: Any = None
-            ) -> tuple[bytes, str | None]:
-                encode_mock()
-                return await super().encode(msg, serializer)
-
-        codec = TrackingCodec()
-        assert not isinstance(codec, BatchCodecProto)
-
-        results = [await codec.encode(m, None) for m in ["a", "b", "c"]]
-        assert len(results) == 3
-        assert encode_mock.call_count == 3

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from faststream._internal.parser import DefaultCodec
+from faststream.message.utils import encode_message
 from tests.brokers.base.basic import BaseTestcaseConfig
 
 
@@ -95,3 +96,43 @@ class CodecTestcase(BaseTestcaseConfig):
             await br.publish(b"hello", queue)
 
         mock.assert_called_once()
+
+    async def test_codec_encode_called(self, queue: str) -> None:
+        mock = MagicMock()
+
+        class TrackingCodec(DefaultCodec):
+            async def encode(self, msg, serializer=None):
+                mock()
+                return await super().encode(msg, serializer)
+
+        broker = self.get_broker(codec=TrackingCodec())
+
+        async with self.patch_broker(broker) as br:
+
+            @br.subscriber(queue)
+            async def handler(m) -> None:
+                pass
+
+            await br.publish({"key": "value"}, queue)
+
+        assert mock.called, "codec.encode was not called on publish"
+
+    async def test_default_codec_encode_matches_encode_message(
+        self, queue: str
+    ) -> None:
+        codec = DefaultCodec()
+
+        test_cases = [
+            None,
+            b"raw bytes",
+            "hello string",
+            {"json": True, "value": 42},
+        ]
+
+        for msg in test_cases:
+            codec_result = await codec.encode(msg, None)
+            direct_result = encode_message(msg, None)
+            assert codec_result == direct_result, (
+                f"DefaultCodec.encode({msg!r}) = {codec_result!r} "
+                f"but encode_message({msg!r}) = {direct_result!r}"
+            )

--- a/tests/brokers/confluent/test_codec.py
+++ b/tests/brokers/confluent/test_codec.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.brokers.base.codec import CodecTestcase
+from tests.brokers.base.codec import BatchCodecTestcase, CodecTestcase
 
 from .basic import ConfluentMemoryTestcaseConfig
 
@@ -8,4 +8,10 @@ from .basic import ConfluentMemoryTestcaseConfig
 @pytest.mark.confluent()
 @pytest.mark.asyncio()
 class TestConfluentCodec(ConfluentMemoryTestcaseConfig, CodecTestcase):
+    pass
+
+
+@pytest.mark.confluent()
+@pytest.mark.asyncio()
+class TestConfluentBatchCodec(ConfluentMemoryTestcaseConfig, BatchCodecTestcase):
     pass

--- a/tests/brokers/kafka/test_codec.py
+++ b/tests/brokers/kafka/test_codec.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.brokers.base.codec import CodecTestcase
+from tests.brokers.base.codec import BatchCodecTestcase, CodecTestcase
 
 from .basic import KafkaMemoryTestcaseConfig
 
@@ -8,4 +8,10 @@ from .basic import KafkaMemoryTestcaseConfig
 @pytest.mark.kafka()
 @pytest.mark.asyncio()
 class TestKafkaCodec(KafkaMemoryTestcaseConfig, CodecTestcase):
+    pass
+
+
+@pytest.mark.kafka()
+@pytest.mark.asyncio()
+class TestKafkaBatchCodec(KafkaMemoryTestcaseConfig, BatchCodecTestcase):
     pass

--- a/tests/brokers/redis/test_cluster_requests.py
+++ b/tests/brokers/redis/test_cluster_requests.py
@@ -11,7 +11,7 @@ class Mid(BaseMiddleware):
     async def on_receive(self) -> None:
         data, headers = BinaryMessageFormatV1.parse(self.msg["data"])
         data *= 2
-        self.msg["data"] = BinaryMessageFormatV1.encode(
+        self.msg["data"] = await BinaryMessageFormatV1.encode(
             message=data,
             reply_to=None,
             correlation_id=headers["correlation_id"],

--- a/tests/brokers/redis/test_parser.py
+++ b/tests/brokers/redis/test_parser.py
@@ -63,8 +63,9 @@ class TestCustomParser(RedisTestcaseConfig, CustomParserTestcase):
     ),
 )
 @pytest.mark.redis()
-def test_binary_message_encode_parse(input: Any, should_be: bytes) -> None:
-    raw_message = BinaryMessageFormatV1.encode(
+@pytest.mark.asyncio()
+async def test_binary_message_encode_parse(input: Any, should_be: bytes) -> None:
+    raw_message = await BinaryMessageFormatV1.encode(
         message=input, reply_to=None, headers=None, correlation_id="id"
     )
     parsed, _ = BinaryMessageFormatV1.parse(raw_message)

--- a/tests/brokers/redis/test_requests.py
+++ b/tests/brokers/redis/test_requests.py
@@ -11,7 +11,7 @@ class Mid(BaseMiddleware):
     async def on_receive(self) -> None:
         data, headers = BinaryMessageFormatV1.parse(self.msg["data"])
         data *= 2
-        self.msg["data"] = BinaryMessageFormatV1.encode(
+        self.msg["data"] = await BinaryMessageFormatV1.encode(
             message=data,
             reply_to=None,
             correlation_id=headers["correlation_id"],


### PR DESCRIPTION
# Production-Side Codec Encode Wiring

PR3 in the parser/codec unification series (#2841 )

## What

Wires `codec.encode()` into all 6 Producers, replacing direct `encode_message()` calls. Adds `BatchCodecProto` for batch-aware codecs. Custom codecs now work symmetrically on both consume and publish sides.

## Changes

### Codec on producers
- `codec: CodecProto` attribute on `ProducerProto` and all 6 producer implementations
- `codec` passed from broker config `connect()` to `producer.connect()`
- `DefaultCodec()` used when no custom codec is set — zero behavior change

### Encode wiring
- 12 direct `encode_message()` calls replaced with `await self.codec.encode()` in Kafka, Confluent, NATS, MQTT producers
- `AioPikaParser.encode_message` converted from sync staticmethod to async with `codec` parameter
- `MessageFormat.build`/`encode` and `BinaryMessageFormatV1.encode` converted to async with `codec` parameter


## Breaking Changes
- `build_message()` in all broker testing modules is now `async` — callers must `await` it
- `AioPikaParser.encode_message()` is now `async` — callers must `await` it
- `MessageFormat.build()` and `MessageFormat.encode()` are now `async`

## What Did NOT Change
- `encode_message()` free function in `faststream/message/utils.py`
- `decode_message()` and consumption-side codec wiring (PR2)
- `CodecProto.decode` / `DefaultCodec.decode`
- `_get_parser_and_decoder()` subscriber wiring

