### PR TITLE
docs(kafka,confluent): document per-message attributes via KafkaPublishMessage in publish_batch

### DIFF
--- a/docs/docs/en/confluent/Publisher/batch_publisher.md
+++ b/docs/docs/en/confluent/Publisher/batch_publisher.md
@@ -56,6 +56,43 @@ The application in the example implements both of these ways, so feel free to us
     Also, you can publishes messages in batches right from a `broker` object: just call
     `#!python broker.publish_batch("msg2", "msg2", topic="output_data")`
 
+## Per-Message Attributes with `KafkaPublishMessage`
+
+When publishing in batches, you often need to assign **different keys, headers, or timestamps to each message** within the same batch. To support this scenario, **FastStream** provides the `#!python KafkaPublishMessage` helper — a semantic alias for `#!python KafkaResponse` that is intended to be used directly inside `#!python publish_batch(...)` calls.
+
+By wrapping a payload into `#!python KafkaPublishMessage`, you can attach per-message attributes such as:
+
+* `#!python key` — the **Kafka** message key used for partitioning;
+* `#!python headers` — custom headers for the individual message;
+* `#!python timestamp_ms` — an explicit message timestamp;
+* `#!python correlation_id` — a custom correlation identifier.
+
+You can freely mix `#!python KafkaPublishMessage` instances with raw payloads in the same call. Plain values (strings, bytes, dicts, models, etc.) are published as-is and use the default key (`#!python None`) inherited from the `#!python publish_batch(...)` call:
+
+```python linenums="1"
+from faststream.confluent import KafkaBroker, KafkaPublishMessage
+
+broker = KafkaBroker()
+
+
+@broker.subscriber("input")
+async def handler() -> None:
+    await broker.publish_batch(
+        KafkaPublishMessage("user:1", key=b"user1"),
+        KafkaPublishMessage("user:2", key=b"user2"),
+        "user:3",  # Uses default key (None)
+        topic="output",
+    )
+```
+
+In the example above, the first two messages are sent with their own dedicated keys (`#!python b"user1"` and `#!python b"user2"`), while the third message — passed as a plain string — falls back to the default key.
+
+!!! note
+    `#!python KafkaPublishMessage` is the recommended, more semantic name when constructing outgoing messages for `#!python publish_batch(...)`. Under the hood it is the same object as `#!python KafkaResponse`, so both names are fully interchangeable.
+
+!!! tip
+    Use `#!python KafkaPublishMessage` whenever messages within a single batch need to be routed to different partitions via distinct keys, or when you need to attach per-message metadata — this is the cleanest way to control individual message attributes without splitting the batch into separate `#!python publish(...)` calls.
+
 ## Why Publish in Batches?
 
 In the above example, we've explored how to leverage the `#!python @broker.publisher(...)` decorator to efficiently publish messages in batches using **FastStream** and **Kafka**. By following the two key steps outlined in the previous sections, you can significantly enhance the performance and reliability of your **Kafka**-based applications.

--- a/docs/docs/en/kafka/Publisher/batch_publisher.md
+++ b/docs/docs/en/kafka/Publisher/batch_publisher.md
@@ -56,6 +56,43 @@ The application in the example implements both of these ways, so feel free to us
     Also, you can publishes messages in batches right from a `broker` object: just call
     `#!python broker.publish_batch("msg2", "msg2", topic="output_data")`
 
+## Per-Message Attributes with `KafkaPublishMessage`
+
+When publishing in batches, you often need to assign **different keys, headers, or timestamps to each message** within the same batch. To support this scenario, **FastStream** provides the `#!python KafkaPublishMessage` helper — a semantic alias for `#!python KafkaResponse` that is intended to be used directly inside `#!python publish_batch(...)` calls.
+
+By wrapping a payload into `#!python KafkaPublishMessage`, you can attach per-message attributes such as:
+
+* `#!python key` — the **Kafka** message key used for partitioning;
+* `#!python headers` — custom headers for the individual message;
+* `#!python timestamp_ms` — an explicit message timestamp;
+* `#!python correlation_id` — a custom correlation identifier.
+
+You can freely mix `#!python KafkaPublishMessage` instances with raw payloads in the same call. Plain values (strings, bytes, dicts, models, etc.) are published as-is and use the default key (`#!python None`) inherited from the `#!python publish_batch(...)` call:
+
+```python linenums="1"
+from faststream.kafka import KafkaBroker, KafkaPublishMessage
+
+broker = KafkaBroker()
+
+
+@broker.subscriber("input")
+async def handler() -> None:
+    await broker.publish_batch(
+        KafkaPublishMessage("user:1", key=b"user1"),
+        KafkaPublishMessage("user:2", key=b"user2"),
+        "user:3",  # Uses default key (None)
+        topic="output",
+    )
+```
+
+In the example above, the first two messages are sent with their own dedicated keys (`#!python b"user1"` and `#!python b"user2"`), while the third message — passed as a plain string — falls back to the default key.
+
+!!! note
+    `#!python KafkaPublishMessage` is the recommended, more semantic name when constructing outgoing messages for `#!python publish_batch(...)`. Under the hood it is the same object as `#!python KafkaResponse`, so both names are fully interchangeable.
+
+!!! tip
+    Use `#!python KafkaPublishMessage` whenever messages within a single batch need to be routed to different partitions via distinct keys, or when you need to attach per-message metadata — this is the cleanest way to control individual message attributes without splitting the batch into separate `#!python publish(...)` calls.
+
 ## Why Publish in Batches?
 
 In the above example, we've explored how to leverage the `#!python @broker.publisher(...)` decorator to efficiently publish messages in batches using **FastStream** and **Kafka**. By following the two key steps outlined in the previous sections, you can significantly enhance the performance and reliability of your **Kafka**-based applications.


### PR DESCRIPTION
# Description

This PR extends the **Publishing in Batches** documentation pages for both the `kafka` (AIOKafka) and `confluent` brokers with a dedicated section that explains how to attach **per-message attributes** (key, headers, `timestamp_ms`, `correlation_id`) to individual messages inside a single `publish_batch(...)` call by wrapping payloads into `KafkaPublishMessage`.

`KafkaPublishMessage` is already exported from `faststream.kafka` and `faststream.confluent` (it is a semantic alias for `KafkaResponse`) and is supported by `KafkaPublishCommand` via per-message keys (`extract_per_message_keys_and_bodies` / `key_for_index`), but its usage inside `publish_batch(...)` is currently not documented. As a result, users who want to send a batch with different keys per message either don't discover this feature or fall back to issuing separate `publish(...)` calls.

The new section documents:

- the purpose of `KafkaPublishMessage` as the recommended, more semantic helper for `publish_batch(...)`;
- the supported per-message attributes (`key`, `headers`, `timestamp_ms`, `correlation_id`);
- the fact that `KafkaPublishMessage` instances can be freely mixed with raw payloads in a single call, and that raw payloads fall back to the default key (`None`);
- a minimal end-to-end example mirroring the behavior used in `tests/brokers/{kafka,confluent}/test_publish.py`;
- a `note` clarifying that `KafkaPublishMessage` and `KafkaResponse` are fully interchangeable;
- a `tip` describing when this approach is preferred (different partitions per message in one batch / per-message metadata).

The wording, admonition style (`!!! note`, `!!! tip`), inline code highlighting (`#!python ...`) and bold broker names (**FastStream**, **Kafka**) follow the existing documentation conventions used throughout `docs/docs/en/{kafka,confluent}/...`.

The two pages receive the same section; the only difference is the import line in the example (`from faststream.kafka import ...` vs `from faststream.confluent import ...`).

Fixes # (no related issue)

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors) — docs-only change, formatting matches surrounding pages
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature — N/A, the documented behavior is already covered by `tests/brokers/kafka/test_publish.py` and `tests/brokers/confluent/test_publish.py`
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage` — N/A for a docs-only change
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis` — N/A for a docs-only change
- [x] I have included code examples to illustrate the modifications

## Files changed

- `docs/docs/en/kafka/Publisher/batch_publisher.md` — +37 / −0
- `docs/docs/en/confluent/Publisher/batch_publisher.md` — +37 / −0
