### PR TITLE
Handle NOGROUP error on Redis stream subscriber

### DIFF
--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -17,6 +17,7 @@ try:
         RedisStreamMessage,
     )
     from .broker import RedisBroker, RedisPublisher, RedisRoute, RedisRouter
+    from .exceptions import StreamGroupNotFoundError
     from .parser import BinaryMessageFormatV1
     from .response import RedisPublishCommand, RedisResponse
     from .schemas import ListSub, PubSub, StreamSub
@@ -47,6 +48,7 @@ __all__ = (
     "RedisRoute",
     "RedisRouter",
     "RedisStreamMessage",
+    "StreamGroupNotFoundError",
     "StreamSub",
     "TestApp",
     "TestRedisBroker",

--- a/faststream/redis/exceptions.py
+++ b/faststream/redis/exceptions.py
@@ -1,0 +1,10 @@
+from faststream.exceptions import FastStreamException
+
+
+class StreamGroupNotFoundError(FastStreamException):
+    """Raised when a consumer group is not found in a Redis stream.
+
+    Typically happens after a ``FLUSHALL``, ``FLUSHDB``, or manual
+    deletion of the stream/group.  The subscriber cannot proceed and
+    must be restarted to recreate the group.
+    """

--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import math
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Optional, TypeAlias
@@ -8,6 +9,7 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.subscriber.mixins import ConcurrentMixin
 from faststream._internal.endpoint.utils import process_msg
+from faststream.redis.exceptions import StreamGroupNotFoundError
 from faststream.redis.message import (
     BatchStreamMessage,
     DefaultStreamMessage,
@@ -83,7 +85,32 @@ class _StreamHandlerMixin(LogicSubscriber):
     async def _consume(self, *args: Any, start_signal: "Event") -> None:
         if await self._client.ping():
             start_signal.set()
-        await super()._consume(*args, start_signal=start_signal)
+
+        while self.running:
+            try:
+                await self._get_msgs(*args)
+
+            except ResponseError as e:  # noqa: PERF203
+                if "NOGROUP" in str(e):
+                    msg = (
+                        f"Consumer group `{self.stream_sub.group}` for stream "
+                        f"`{self.stream_sub.name}` no longer exists. "
+                        "The stream was likely deleted or flushed. "
+                        "Stopping subscriber — restart the application to recreate the group."
+                    )
+                    raise StreamGroupNotFoundError(msg) from e
+                raise
+
+            except Exception as e:
+                self._log(
+                    log_level=logging.ERROR,
+                    message="Message fetch error",
+                    exc_info=e,
+                )
+
+            finally:
+                if not start_signal.is_set():
+                    start_signal.set()
 
     @override
     async def start(self) -> None:

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -12,6 +12,7 @@ from faststream.redis import (
     RedisStreamMessage,
     StreamSub,
 )
+from faststream.redis.exceptions import StreamGroupNotFoundError
 from tests.brokers.base.consume import BrokerRealConsumeTestcase
 from tests.tools import spy_decorator
 
@@ -965,3 +966,55 @@ class TestConsumeStream(RedisTestcaseConfig):
 
             calls = [call(msg) for msg in expected_messages]
             mock.assert_has_calls(calls=calls)
+
+    async def test_consume_stream_group_deleted(
+        self,
+        queue: str,
+        mock: MagicMock,
+    ) -> None:
+        """Subscriber stops when the consumer group is deleted (NOGROUP)."""
+        consume_broker = self.get_broker(apply_types=True)
+
+        event = asyncio.Event()
+
+        @consume_broker.subscriber(
+            stream=StreamSub(queue, group="test_group", consumer="consumer1"),
+        )
+        async def handler(msg: RedisMessage) -> None:
+            mock(msg)
+            event.set()
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+
+            # Publish a message so the subscriber reads and starts consuming
+            await br.publish("hello", stream=queue)
+            await asyncio.wait_for(event.wait(), timeout=3)
+            assert mock.call_count >= 1
+
+            # Delete the stream — this removes the consumer group too
+            await br._connection.delete(queue)
+
+            # Give the subscriber time to try reading and hit NOGROUP
+            await asyncio.sleep(0.5)
+
+            # Publish another message — subscriber should NOT receive it
+            # because it already stopped due to NOGROUP
+            event.clear()
+            await br.publish("world", stream=queue)
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(event.wait(), timeout=1)
+
+            # The subscriber task should have finished with StreamGroupNotFoundError
+            tasks = br.subscribers[0].tasks
+            assert all(t.done() for t in tasks)
+            found = False
+            for t in tasks:
+                try:
+                    exc = t.exception()
+                    if isinstance(exc, StreamGroupNotFoundError):
+                        found = True
+                        break
+                except (asyncio.CancelledError, asyncio.InvalidStateError):
+                    pass
+            assert found, "Expected at least one task to raise StreamGroupNotFoundError"

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -967,15 +967,15 @@ class TestConsumeStream(RedisTestcaseConfig):
             calls = [call(msg) for msg in expected_messages]
             mock.assert_has_calls(calls=calls)
 
+    @pytest.mark.slow()
     async def test_consume_stream_group_deleted(
         self,
         queue: str,
         mock: MagicMock,
+        event: asyncio.Event,
     ) -> None:
         """Subscriber stops when the consumer group is deleted (NOGROUP)."""
         consume_broker = self.get_broker(apply_types=True)
-
-        event = asyncio.Event()
 
         @consume_broker.subscriber(
             stream=StreamSub(queue, group="test_group", consumer="consumer1"),


### PR DESCRIPTION
# Description

When a Redis stream or consumer group is deleted (e.g. by `FLUSHALL`, `FLUSHDB`, or manual deletion), the stream subscriber entered an **infinite loop** — constantly retrying `XREADGROUP`, getting `NOGROUP` error, logging it, sleeping 5s, and retrying indefinitely. No alert fired, the application appeared healthy, but no messages were processed.

This PR stops the subscriber immediately when the group is not found, raising a clear `SetupError` that surfaces the infrastructure issue.

Fixes #2611

## Changes

### `faststream/redis/subscriber/usecases/stream_subscriber.py`

Overrode `_consume` in `_StreamHandlerMixin` to detect `ResponseError` with `NOGROUP` and raise `SetupError` with a descriptive message instead of retrying.

### `tests/brokers/redis/test_consume.py`

Added `test_consume_stream_group_deleted`:
- Creates a stream with consumer group
- Publishes a message and waits for the subscriber to receive it
- Deletes the stream (`DEL`)
- Publishes another message and verifies the subscriber does NOT receive it

## Design Decision

FastStream is a consumer of infrastructure, not its owner. Silently recreating a deleted group/stream would hide infrastructure incidents. Application should fail fast, orchestrator restarts, startup-time group creation re-establishes the group. Users who want self-healing can implement via middleware / error hooks.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix
- [x] Both new and existing unit tests pass successfully on my local environment
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
BODY