### PR TITLE
feat(asgi): add Mount for prefix-based routing in AsgiFastStream

### DIFF
--- a/faststream/asgi/__init__.py
+++ b/faststream/asgi/__init__.py
@@ -2,6 +2,7 @@ from .annotations import Request
 from .app import AsgiFastStream
 from .factories import AsyncAPIRoute, make_asyncapi_asgi, make_ping_asgi
 from .handlers import HttpHandler, get, post
+from .mount import Mount
 from .params import Header, Query
 from .response import AsgiResponse
 
@@ -11,6 +12,7 @@ __all__ = (
     "AsyncAPIRoute",
     "Header",
     "HttpHandler",
+    "Mount",
     "Query",
     "Request",
     "get",

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -19,6 +19,7 @@ from faststream.exceptions import INSTALL_UVICORN, StartupValidationError
 
 from .factories import AsyncAPIRoute, make_try_it_out_handler
 from .handlers import HttpHandler
+from .mount import Mount
 from .response import AsgiResponse
 from .websocket import WebSocketClose
 
@@ -92,7 +93,7 @@ class AsgiFastStream(Application):
         self,
         broker: Optional["BrokerUsecase[Any, Any]"] = None,
         /,
-        asgi_routes: Sequence[tuple[str, "ASGIApp"]] = (),
+        asgi_routes: Sequence[tuple[str, "ASGIApp"] | Mount] = (),
         logger: Optional["LoggerProto"] = logger,
         provider: Provider | None = None,
         serializer: Optional["SerializerProto"] = EMPTY,
@@ -105,7 +106,12 @@ class AsgiFastStream(Application):
         specification: Optional["SpecificationFactory"] = None,
         asyncapi_path: str | AsyncAPIRoute | None = None,
     ) -> None:
-        self.routes = list(asgi_routes)
+        self.routes: list[tuple[str, Any]] = []
+        for entry in asgi_routes:
+            if isinstance(entry, Mount):
+                self.routes.append((entry.path, entry))
+            else:
+                self.routes.append(entry)
 
         super().__init__(
             broker,
@@ -181,9 +187,9 @@ class AsgiFastStream(Application):
         return asgi_app
 
     def mount(self, path: str, route: "ASGIApp") -> None:
-        asgi_route = (path, route)
-        self.routes.append(asgi_route)
-        self._register_route(asgi_route)
+        entry = Mount(path, route)
+        self.routes.append((entry.path, entry))
+        self._register_route((entry.path, route))
 
     def _register_route(self, asgi_route: tuple[str, "ASGIApp"]) -> None:
         path, route = asgi_route
@@ -204,8 +210,21 @@ class AsgiFastStream(Application):
             return
 
         if scope["type"] == "http":
+            request_path = scope["path"]
             for path, app in self.routes:
-                if scope["path"] == path:
+                if isinstance(app, Mount):
+                    prefix = app.path
+                    if request_path == prefix or request_path.startswith(
+                        prefix + "/"
+                    ):
+                        sub_scope = dict(scope)
+                        sub_scope["path"] = request_path[len(prefix):] or "/"
+                        sub_scope["root_path"] = (
+                            scope.get("root_path", "") + prefix
+                        )
+                        await app.app(sub_scope, receive, send)
+                        return
+                elif request_path == path:
                     await app(scope, receive, send)
                     return
 

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -214,14 +214,10 @@ class AsgiFastStream(Application):
             for path, app in self.routes:
                 if isinstance(app, Mount):
                     prefix = app.path
-                    if request_path == prefix or request_path.startswith(
-                        prefix + "/"
-                    ):
+                    if request_path == prefix or request_path.startswith(prefix + "/"):
                         sub_scope = dict(scope)
-                        sub_scope["path"] = request_path[len(prefix):] or "/"
-                        sub_scope["root_path"] = (
-                            scope.get("root_path", "") + prefix
-                        )
+                        sub_scope["path"] = request_path[len(prefix) :] or "/"
+                        sub_scope["root_path"] = scope.get("root_path", "") + prefix
                         await app.app(sub_scope, receive, send)
                         return
                 elif request_path == path:

--- a/faststream/asgi/mount.py
+++ b/faststream/asgi/mount.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 class Mount:
     def __init__(self, path: str, app: "ASGIApp") -> None:
-        if path != "" and not path.startswith("/"):
+        if path and not path.startswith("/"):
             msg = "Mount path must be empty or start with '/'"
             raise SetupError(msg)
         self.path = path.rstrip("/")

--- a/faststream/asgi/mount.py
+++ b/faststream/asgi/mount.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING
+
+from faststream.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from .types import ASGIApp
+
+
+class Mount:
+    def __init__(self, path: str, app: "ASGIApp") -> None:
+        if path != "" and not path.startswith("/"):
+            msg = "Mount path must be empty or start with '/'"
+            raise SetupError(msg)
+        self.path = path.rstrip("/")
+        self.app = app


### PR DESCRIPTION
Adds `faststream.asgi.Mount` — a small marker class that lets `AsgiFastStream` dispatch a whole subtree of paths to a sub-ASGI application (e.g. `starlette.staticfiles.StaticFiles`), with the same semantics as `starlette.routing.Mount`.

So `("/static", StaticFiles(...))` only matched the literal `GET /static`. Real requests like `/static/foo.css` never reached the sub-app — they always returned 404. There was no way to host static files (or any sub-ASGI tree) directly from `AsgiFastStream`. The `AsgiFastStream.mount(path, app)` helper was a thin wrapper around `routes.append`, doing the same exact-match dispatch despite its name.

The motivating use case is **air-gapped hosting of the AsyncAPI documentation page**: `AsyncAPIRoute` already exposes `asyncapi_css_url`, `asyncapi_js_url`, and `try_it_out_plugin_url` to redirect the three CDN bundles to user-provided URLs, but until now there was no way to actually serve them from the same FastStream app — users had to drop `AsgiFastStream` and switch to plain Starlette.

After this PR:

```python
from faststream.asgi import AsgiFastStream, AsyncAPIRoute, Mount
from faststream.nats import NatsBroker
from starlette.staticfiles import StaticFiles

broker = NatsBroker()

app = AsgiFastStream(
    broker,
    asgi_routes=[
        Mount("/static", StaticFiles(directory="./static")),
    ],
    asyncapi_path=AsyncAPIRoute(
        "/docs/asyncapi",
        asyncapi_css_url="/static/default.min.css",
        asyncapi_js_url="/static/index.js",
        try_it_out_plugin_url="/static/try-it-plugin.js",
    ),
)
```

`GET /static/foo.css` now reaches `StaticFiles`, the AsyncAPI page renders with no outbound network calls.

Fixes #2856

## Backwards compatibility

- Old `(path, handler)` tuples in `asgi_routes` keep their **exact-match** semantics unchanged — they are not `Mount` instances, so the new branch in `__call__` is skipped for them.
- `AsgiFastStream.mount()` semantics changed (now actually mounts).
- `Mount` is purely additive — opt-in via the new class.

## Checklist

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
