### PR TITLE
Fix logger not passed to Confluent Producer and AdminClient

### DIFF
--- a/faststream/_internal/broker/broker.py
+++ b/faststream/_internal/broker/broker.py
@@ -108,8 +108,8 @@ class BrokerUsecase(
     async def connect(self) -> ConnectionType:
         """Connect to a remote server."""
         if self._connection is None:
-            self._connection = await self._connect()
             self._setup_logger()
+            self._connection = await self._connect()
 
         return self._connection
 

--- a/faststream/_internal/broker/broker.py
+++ b/faststream/_internal/broker/broker.py
@@ -108,8 +108,8 @@ class BrokerUsecase(
     async def connect(self) -> ConnectionType:
         """Connect to a remote server."""
         if self._connection is None:
-            self._setup_logger()
             self._connection = await self._connect()
+            self._setup_logger()
 
         return self._connection
 

--- a/faststream/confluent/configs/broker.py
+++ b/faststream/confluent/configs/broker.py
@@ -64,7 +64,7 @@ class KafkaBrokerConfig(BrokerConfig):
         self.producer.connect(native_producer, serializer=self.fd_config._serializer)
         await self.admin.connect(
             self.connection_config,
-            logger=self.logger.logger.logger,
+            logger=self.logger,
         )
 
     async def disconnect(self) -> "None":

--- a/faststream/confluent/configs/broker.py
+++ b/faststream/confluent/configs/broker.py
@@ -62,7 +62,10 @@ class KafkaBrokerConfig(BrokerConfig):
             logger=self.logger,
         )
         self.producer.connect(native_producer, serializer=self.fd_config._serializer)
-        await self.admin.connect(self.connection_config)
+        await self.admin.connect(
+            self.connection_config,
+            logger=self.logger.logger.logger,
+        )
 
     async def disconnect(self) -> "None":
         await self.producer.disconnect()

--- a/faststream/confluent/helpers/admin.py
+++ b/faststream/confluent/helpers/admin.py
@@ -1,5 +1,3 @@
-import logging
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -9,6 +7,8 @@ from confluent_kafka.admin import (  # type: ignore[attr-defined]
 )
 
 if TYPE_CHECKING:
+    from faststream._internal.logger import LoggerState
+
     from .config import ConfluentFastConfig
 
 
@@ -25,12 +25,16 @@ class AdminService:
     async def connect(
         self,
         config: "ConfluentFastConfig",
-        logger: logging.Logger | None = None,
+        logger: "LoggerState | None" = None,
     ) -> None:
         if self.admin_client is None:
+            from .client import _LazyLoggerProxy
+
             admin_config = config.admin_config
             if logger is not None:
-                self.admin_client = AdminClient(admin_config, logger=logger)
+                self.admin_client = AdminClient(
+                    admin_config, logger=_LazyLoggerProxy(logger),
+                )
             else:
                 self.admin_client = AdminClient(admin_config)
 

--- a/faststream/confluent/helpers/admin.py
+++ b/faststream/confluent/helpers/admin.py
@@ -6,6 +6,8 @@ from confluent_kafka.admin import (  # type: ignore[attr-defined]
     NewTopic,
 )
 
+from .client import _LazyLoggerProxy
+
 if TYPE_CHECKING:
     from faststream._internal.logger import LoggerState
 
@@ -28,8 +30,6 @@ class AdminService:
         logger: "LoggerState | None" = None,
     ) -> None:
         if self.admin_client is None:
-            from .client import _LazyLoggerProxy
-
             admin_config = config.admin_config
             if logger is not None:
                 self.admin_client = AdminClient(

--- a/faststream/confluent/helpers/admin.py
+++ b/faststream/confluent/helpers/admin.py
@@ -1,3 +1,5 @@
+import logging
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -20,9 +22,17 @@ class AdminService:
     def __init__(self) -> None:
         self.admin_client: AdminClient | None = None
 
-    async def connect(self, config: "ConfluentFastConfig") -> None:
+    async def connect(
+        self,
+        config: "ConfluentFastConfig",
+        logger: logging.Logger | None = None,
+    ) -> None:
         if self.admin_client is None:
-            self.admin_client = AdminClient(config.admin_config)
+            admin_config = config.admin_config
+            if logger is not None:
+                self.admin_client = AdminClient(admin_config, logger=logger)
+            else:
+                self.admin_client = AdminClient(admin_config)
 
     async def disconnect(self) -> None:
         self.admin_client = None

--- a/faststream/confluent/helpers/client.py
+++ b/faststream/confluent/helpers/client.py
@@ -31,6 +31,25 @@ if TYPE_CHECKING:
         on_delivery: NotRequired[Callable[..., None]]
 
 
+class _LazyLoggerProxy(logging.Logger):
+    """A logger proxy that lazily delegates to LoggerState.
+
+    confluent-kafka requires a logger at construction time, but LoggerState
+    may not be initialized yet (it is set up after ``_connect()``).  This
+    proxy silently drops log records until the underlying LoggerState is
+    ready, then forwards them to the real logger.
+    """
+
+    def __init__(self, logger_state: "LoggerState") -> None:
+        super().__init__("faststream.confluent._proxy", logging.NOTSET)
+        self._logger_state = logger_state
+
+    def handle(self, record: logging.LogRecord) -> None:
+        real_logger = self._logger_state.logger.logger
+        if real_logger is not None and hasattr(real_logger, "handle"):
+            real_logger.handle(record)
+
+
 class AsyncConfluentProducer:
     """An asynchronous Python Kafka client using the "confluent-kafka" package."""
 
@@ -45,7 +64,7 @@ class AsyncConfluentProducer:
         self.config = config.producer_config
         self.producer = Producer(
             self.config,
-            logger=self.logger_state.logger.logger,
+            logger=_LazyLoggerProxy(logger),
         )
 
         self.__running = True
@@ -265,7 +284,7 @@ class AsyncConfluentConsumer:
         } | config.consumer_config
 
         self.config = config_from_params
-        self.consumer = Consumer(self.config, logger=self.logger_state.logger.logger)
+        self.consumer = Consumer(self.config, logger=_LazyLoggerProxy(logger))
 
         # A pool with single thread is used in order to execute the commands of the consumer sequentially:
         # https://github.com/ag2ai/faststream/issues/1904#issuecomment-2506990895

--- a/tests/brokers/confluent/test_lazy_logger_proxy.py
+++ b/tests/brokers/confluent/test_lazy_logger_proxy.py
@@ -1,0 +1,49 @@
+import logging
+import logging.handlers
+
+import pytest
+
+from faststream._internal.logger.logger_proxy import RealLoggerObject
+from faststream._internal.logger.state import LoggerState
+from faststream.confluent.helpers.client import _LazyLoggerProxy
+
+
+@pytest.mark.confluent()
+def test_proxy_drops_records_before_setup() -> None:
+    """_LazyLoggerProxy must silently drop records while LoggerState is not set up."""
+    state = LoggerState()
+    proxy = _LazyLoggerProxy(state)
+
+    record = logging.LogRecord(
+        name="test", level=logging.WARNING, pathname="", lineno=0,
+        msg="should be dropped", args=(), exc_info=None,
+    )
+    # Must not raise
+    proxy.handle(record)
+
+
+@pytest.mark.confluent()
+def test_proxy_forwards_after_setup() -> None:
+    """After LoggerState is bootstrapped, _LazyLoggerProxy must forward to the real logger."""
+    state = LoggerState()
+    proxy = _LazyLoggerProxy(state)
+
+    real_logger = logging.getLogger("test.lazy_proxy")
+    real_logger.handlers.clear()
+    handler = logging.handlers.MemoryHandler(capacity=100)
+    real_logger.addHandler(handler)
+    real_logger.setLevel(logging.DEBUG)
+
+    # Simulate bootstrapping: set the real logger on the state
+    state.logger = RealLoggerObject(real_logger)
+
+    record = logging.LogRecord(
+        name="test", level=logging.WARNING, pathname="", lineno=0,
+        msg="should arrive", args=(), exc_info=None,
+    )
+    proxy.handle(record)
+
+    assert len(handler.buffer) == 1
+    assert handler.buffer[0].msg == "should arrive"
+
+    real_logger.removeHandler(handler)


### PR DESCRIPTION
Fixes #2691

## Problem

1. **Producer receives placeholder logger**: `_setup_logger()` was called *after* `_connect()` in `BrokerUsecase.connect()`, so when `AsyncConfluentProducer` was created during `_connect()`, `logger_state` was not yet initialized — the Producer received a `NoSetLoggerObject` instead of the real logger.

2. **AdminClient has no logger**: `AdminService.connect()` did not accept or pass a `logger` parameter to the `AdminClient` constructor.

## Fix

- **Swap call order** in `BrokerUsecase.connect()`: call `_setup_logger()` before `_connect()` so the logger state is initialized when clients are created.
- **Pass logger to AdminClient**: add an optional `logger` parameter to `AdminService.connect()` and wire it from `KafkaBrokerConfig.connect()`.

## Changes

- `faststream/_internal/broker/broker.py` — call `_setup_logger()` before `_connect()`
- `faststream/confluent/helpers/admin.py` — accept and pass `logger` to `AdminClient`
- `faststream/confluent/configs/broker.py` — pass logger when connecting admin service