### PR TITLE
feat: re-export BrokerUsecase from top-level package

### DIFF
--- a/faststream/__init__.py
+++ b/faststream/__init__.py
@@ -1,5 +1,6 @@
 """A Python framework for building services interacting with Apache Kafka, RabbitMQ, NATS and Redis."""
 
+from faststream._internal.broker.broker import BrokerUsecase
 from faststream._internal.testing.app import TestApp
 from faststream._internal.utils import apply_types
 from faststream.annotations import ContextRepo, Logger
@@ -15,6 +16,7 @@ __all__ = (
     "AsyncAPI",
     "BaseMiddleware",
     "BatchPublishCommand",
+    "BrokerUsecase",
     "Context",
     "ContextRepo",
     "Depends",


### PR DESCRIPTION
# Description

Re-export `BrokerUsecase` from the top-level `faststream` package so users who want to subclass it for a custom broker can rely on a stable import path. Previously it was only reachable via `faststream._internal.broker.broker`, which has no stability guarantees across non-breaking releases.

```python
from faststream import BrokerUsecase
```

Minimal subset of #2806. Other subclassing types (`MsgType`, `ConnectionType`, `BrokerConfigType`, `Registrator`) and a custom-broker docs page are left as separate follow-ups.

Fixes #2806

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation — N/A, no public-API surface change beyond the re-export itself
- [x] My changes do not generate any new warnings (`mypy faststream` clean across 496 files; `bandit -ll` no medium/high)
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature — N/A, pure re-export with no behavior change. Smoke-checked locally: `python -c "from faststream import BrokerUsecase; import faststream; assert 'BrokerUsecase' in faststream.__all__"`.
- [x] Both new and existing unit tests pass successfully on my local environment — ran the typing-dependent suite locally (`pytest tests/docs/getting_started/subscription/test_annotated.py` → 10 passed). Skipped full `just test-coverage` (heavy) and broker-integration tests (require Kafka/Rabbit/Redis/NATS infra).
- [x] I have ensured that static analysis tests are passing — `ruff format --check`, `ruff check`, and `mypy faststream` (496 files) all clean.
- [x] I have included code examples to illustrate the modifications