### PR TITLE
Expose client_rack option on the Kafka broker

### DIFF
--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -85,6 +85,9 @@ if TYPE_CHECKING:
                 server-side log entries that correspond to this client. Also
                 submitted to :class:`~.consumer.group_coordinator.GroupCoordinator`
                 for logging with respect to consumer group administration.
+            client_rack: A rack identifier for this client. Used by the
+                broker for rack-aware fetching, letting a consumer read from
+                the closest replica. Requires aiokafka 0.14.0 or newer.
             acks: One of ``0``, ``1``, ``all``. The number of acknowledgments
                 the producer requires the leader to have received before considering a
                 request complete. This controls the durability of records that are
@@ -157,6 +160,8 @@ if TYPE_CHECKING:
         sasl_oauth_token_provider: AbstractTokenProvider | None
         loop: asyncio.AbstractEventLoop | None
         client_id: str | None
+        # consumer args
+        client_rack: str | None
         # publisher args
         acks: Literal[0, 1, -1, "all"] | object
         key_serializer: Callable[[Any], bytes] | None
@@ -197,6 +202,8 @@ class KafkaBroker(
         sasl_oauth_token_provider: Optional["AbstractTokenProvider"] = None,
         loop: Optional["asyncio.AbstractEventLoop"] = None,
         client_id: str | None = SERVICE_NAME,
+        # consumer args
+        client_rack: str | None = None,
         # publisher args
         acks: Literal[0, 1, -1, "all"] | object = _missing,
         key_serializer: Callable[[Any], bytes] | None = None,
@@ -267,6 +274,9 @@ class KafkaBroker(
                 A name for this client. This string is passed in each request to servers and can be used to identify specific
                 server-side log entries that correspond to this client. Also submitted to :class:`~.consumer.group_coordinator.GroupCoordinator`
                 for logging with respect to consumer group administration.
+            client_rack (Optional[str]):
+                A rack identifier for this client. Used by the broker for rack-aware fetching, letting a consumer read from the
+                closest replica. Requires aiokafka 0.14.0 or newer.
             acks (Union[Literal[0, 1, -1, "all"], object]):
                 One of ``0``, ``1``, ``all``. The number of acknowledgments the producer requires the leader to have received before considering a
                 request complete. This controls the durability of records that are sent. The following settings are common:
@@ -408,6 +418,10 @@ class KafkaBroker(
             ConsumerConnectionParams,
             connection_params,
         )
+        # client_rack is consumer-only, so it is not part of connection_params
+        # (which is also used to build the producer); inject it here when set.
+        if client_rack is not None:
+            consumer_options["client_rack"] = client_rack
         builder = partial(aiokafka.AIOKafkaConsumer, **consumer_options)
 
         super().__init__(
@@ -415,6 +429,7 @@ class KafkaBroker(
             routers=routers,
             config=KafkaBrokerConfig(
                 client_id=client_id,
+                client_rack=client_rack,
                 builder=builder,
                 producer=AioKafkaFastProducerImpl(
                     parser=parser,

--- a/faststream/kafka/broker/registrator.py
+++ b/faststream/kafka/broker/registrator.py
@@ -59,6 +59,7 @@ class KafkaRegistrator(
         batch: Literal[False] = False,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -108,6 +109,7 @@ class KafkaRegistrator(
         batch: Literal[True] = ...,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -157,6 +159,7 @@ class KafkaRegistrator(
         batch: Literal[False] = False,
         group_id: None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -206,6 +209,7 @@ class KafkaRegistrator(
         batch: Literal[False] = False,
         group_id: str = ...,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -255,6 +259,7 @@ class KafkaRegistrator(
         batch: bool = False,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -309,6 +314,7 @@ class KafkaRegistrator(
         batch: bool = False,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -370,6 +376,10 @@ class KafkaRegistrator(
                 membership (KIP-345). If set, the consumer is treated as a
                 static member, which means it does not join/leave the group
                 on each restart, avoiding unnecessary rebalances.
+            client_rack:
+                A rack identifier for the consumer, used for rack-aware
+                fetching from the closest replica. Overrides the broker-level
+                ``client_rack`` when set. Requires aiokafka 0.14.0 or newer.
             key_deserializer:
                 Any callable that takes a raw message `bytes`
                 key and returns a deserialized one.
@@ -578,6 +588,9 @@ class KafkaRegistrator(
                 "max_poll_records": max_poll_records,
                 "exclude_internal_topics": exclude_internal_topics,
                 "isolation_level": isolation_level,
+                # Forwarded only when set, so an unset subscriber value leaves
+                # the broker-level client_rack default intact.
+                **({"client_rack": client_rack} if client_rack is not None else {}),
             },
             partitions=partitions,
             ack_policy=ack_policy,

--- a/faststream/kafka/broker/router.py
+++ b/faststream/kafka/broker/router.py
@@ -108,6 +108,7 @@ class KafkaRoute(SubscriberRoute):
         batch: bool = False,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -166,6 +167,10 @@ class KafkaRoute(SubscriberRoute):
                 membership (KIP-345). If set, the consumer is treated as a
                 static member, which means it does not join/leave the group
                 on each restart, avoiding unnecessary rebalances.
+            client_rack:
+                A rack identifier for the consumer, used for rack-aware
+                fetching from the closest replica. Overrides the broker-level
+                ``client_rack`` when set. Requires aiokafka 0.14.0 or newer.
             key_deserializer:
                     Any callable that takes a raw message `bytes`
                     key and returns a deserialized one.
@@ -342,6 +347,7 @@ class KafkaRoute(SubscriberRoute):
             max_workers=max_workers,
             group_id=group_id,
             group_instance_id=group_instance_id,
+            client_rack=client_rack,
             key_deserializer=key_deserializer,
             value_deserializer=value_deserializer,
             fetch_max_wait_ms=fetch_max_wait_ms,

--- a/faststream/kafka/configs/broker.py
+++ b/faststream/kafka/configs/broker.py
@@ -26,6 +26,7 @@ class KafkaBrokerConfig(BrokerConfig):
     builder: Callable[..., aiokafka.AIOKafkaConsumer] = lambda: None
 
     client_id: str | None = SERVICE_NAME
+    client_rack: str | None = None
 
     _admin_client: Optional["aiokafka.admin.client.AIOKafkaAdminClient"] = None
 
@@ -53,6 +54,10 @@ class KafkaBrokerConfig(BrokerConfig):
             ConsumerConnectionParams,
             connection_kwargs,
         )
+        # client_rack is consumer-only, so it is not part of connection_kwargs
+        # (which is also used to build the producer); inject it here when set.
+        if self.client_rack is not None:
+            consumer_options["client_rack"] = self.client_rack
         self.builder = partial(aiokafka.AIOKafkaConsumer, **consumer_options)
 
     async def disconnect(self) -> "None":

--- a/faststream/kafka/fastapi/fastapi.py
+++ b/faststream/kafka/fastapi/fastapi.py
@@ -381,6 +381,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
         batch: Literal[False] = False,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -436,6 +437,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
         batch: Literal[True] = ...,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -491,6 +493,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
         batch: Literal[False] = False,
         group_id: None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -546,6 +549,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
         batch: Literal[False] = False,
         group_id: str = ...,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -601,6 +605,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
         batch: bool = False,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -661,6 +666,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
         batch: bool = False,
         group_id: str | None = None,
         group_instance_id: str | None = None,
+        client_rack: str | None = None,
         key_deserializer: Callable[[bytes], Any] | None = None,
         value_deserializer: Callable[[bytes], Any] | None = None,
         fetch_max_bytes: int = 50 * 1024 * 1024,
@@ -728,6 +734,10 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
                 membership (KIP-345). If set, the consumer is treated as a
                 static member, which means it does not join/leave the group
                 on each restart, avoiding unnecessary rebalances.
+            client_rack:
+                A rack identifier for the consumer, used for rack-aware
+                fetching from the closest replica. Overrides the broker-level
+                ``client_rack`` when set. Requires aiokafka 0.14.0 or newer.
             key_deserializer:
                 Any callable that takes a raw message `bytes`
                 key and returns a deserialized one.
@@ -966,6 +976,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
         subscriber = super().subscriber(
             *topics,
             group_id=group_id,
+            client_rack=client_rack,
             max_workers=max_workers,
             key_deserializer=key_deserializer,
             value_deserializer=value_deserializer,

--- a/faststream/kafka/schemas/params.py
+++ b/faststream/kafka/schemas/params.py
@@ -62,6 +62,7 @@ class ConsumerConnectionParams(TypedDict, total=False):
         bootstrap_servers : Required. The bootstrap servers to connect to.
         loop : Optional. The event loop to use for asynchronous operations.
         client_id : The client ID to use for the connection.
+        client_rack : Rack identifier for this client, used for rack-aware fetching from the closest replica.
         group_instance_id : Name of the group instance ID used for static membership (KIP-345).
         request_timeout_ms : The timeout for network requests in milliseconds.
         retry_backoff_ms : The backoff time in milliseconds for retrying failed requests.
@@ -82,6 +83,7 @@ class ConsumerConnectionParams(TypedDict, total=False):
     group_instance_id: str | None
     loop: AbstractEventLoop | None
     client_id: str
+    client_rack: str
     request_timeout_ms: int
     retry_backoff_ms: int
     metadata_max_age_ms: int

--- a/tests/brokers/kafka/test_client_rack.py
+++ b/tests/brokers/kafka/test_client_rack.py
@@ -79,3 +79,16 @@ class TestSubscriberClientRack:
         )
 
         assert route.kwargs["client_rack"] == "route-rack"
+
+    def test_fastapi_router_passes_client_rack(self) -> None:
+        pytest.importorskip("fastapi")
+        from faststream.kafka.fastapi import KafkaRouter as FastAPIKafkaRouter
+
+        router = FastAPIKafkaRouter()
+        sub = router.subscriber(
+            "test-topic",
+            group_id="test-group",
+            client_rack="fastapi-rack",
+        )
+
+        assert sub._connection_args["client_rack"] == "fastapi-rack"

--- a/tests/brokers/kafka/test_client_rack.py
+++ b/tests/brokers/kafka/test_client_rack.py
@@ -1,11 +1,11 @@
 import pytest
 
-from faststream.kafka import KafkaBroker
+from faststream.kafka import KafkaBroker, KafkaRoute
 from faststream.kafka.configs.broker import KafkaBrokerConfig
 
 
 @pytest.mark.kafka()
-class TestClientRack:
+class TestBrokerClientRack:
     def test_broker_config_stores_client_rack(self) -> None:
         config = KafkaBrokerConfig(client_rack="us-east-1a")
 
@@ -28,3 +28,54 @@ class TestClientRack:
         # consumer at all, so older aiokafka versions remain unaffected.
         builder = broker.config.broker_config.builder
         assert "client_rack" not in builder.keywords
+
+
+@pytest.mark.kafka()
+class TestSubscriberClientRack:
+    def test_subscriber_passes_client_rack(self) -> None:
+        broker = KafkaBroker()
+
+        sub = broker.subscriber(
+            "test-topic",
+            group_id="test-group",
+            client_rack="sub-rack",
+        )
+
+        assert sub._connection_args["client_rack"] == "sub-rack"
+
+    def test_subscriber_omits_client_rack_when_not_set(self) -> None:
+        broker = KafkaBroker()
+
+        sub = broker.subscriber("test-topic", group_id="test-group")
+
+        # An unset subscriber value means "no override": client_rack must be
+        # absent so the broker-level default is used instead.
+        assert "client_rack" not in sub._connection_args
+
+    def test_subscriber_client_rack_overrides_broker_default(self) -> None:
+        broker = KafkaBroker(client_rack="broker-rack")
+
+        sub = broker.subscriber(
+            "test-topic",
+            group_id="test-group",
+            client_rack="sub-rack",
+        )
+
+        # The broker-level default still feeds the consumer builder...
+        builder = broker.config.broker_config.builder
+        assert builder.keywords["client_rack"] == "broker-rack"
+        # ...while the subscriber override is forwarded at consume time and
+        # takes precedence over the builder default.
+        assert sub._connection_args["client_rack"] == "sub-rack"
+
+    def test_route_accepts_client_rack(self) -> None:
+        async def handler(msg: str) -> None: ...
+
+        route = KafkaRoute(
+            handler,
+            "test-topic",
+            group_id="test-group",
+            client_rack="route-rack",
+        )
+
+        assert route.kwargs["client_rack"] == "route-rack"

--- a/tests/brokers/kafka/test_client_rack.py
+++ b/tests/brokers/kafka/test_client_rack.py
@@ -1,0 +1,30 @@
+import pytest
+
+from faststream.kafka import KafkaBroker
+from faststream.kafka.configs.broker import KafkaBrokerConfig
+
+
+@pytest.mark.kafka()
+class TestClientRack:
+    def test_broker_config_stores_client_rack(self) -> None:
+        config = KafkaBrokerConfig(client_rack="us-east-1a")
+
+        assert config.client_rack == "us-east-1a"
+
+    def test_broker_config_client_rack_defaults_to_none(self) -> None:
+        assert KafkaBrokerConfig().client_rack is None
+
+    def test_broker_forwards_client_rack_to_consumer(self) -> None:
+        broker = KafkaBroker(client_rack="us-east-1a")
+
+        broker_config = broker.config.broker_config
+        assert broker_config.client_rack == "us-east-1a"
+        assert broker_config.builder.keywords["client_rack"] == "us-east-1a"
+
+    def test_broker_omits_client_rack_when_not_set(self) -> None:
+        broker = KafkaBroker()
+
+        # When client_rack is not provided it must not be passed to the
+        # consumer at all, so older aiokafka versions remain unaffected.
+        builder = broker.config.broker_config.builder
+        assert "client_rack" not in builder.keywords


### PR DESCRIPTION
# Description

`KafkaBroker` did not accept the `client_rack` consumer option, so there was no way to forward it to the underlying `aiokafka.AIOKafkaConsumer` — either at the broker level or via `subscriber(...)`.

This PR adds a `client_rack` argument to `KafkaBroker` (and `KafkaBrokerConfig`) and forwards it to the consumer builder.

**Design note** — `client_rack` is a *consumer-only* option. `AIOKafkaProducer` does not accept it, and in `KafkaBrokerConfig.connect()` the broker's `connection_kwargs` are passed straight to `AIOKafkaProducer(**connection_kwargs)`. So `client_rack` is deliberately **kept out of `connection_params`** and injected into the consumer options separately, and **only when a value is provided**. When `client_rack` is left as the default (`None`) nothing is passed to the consumer, so existing behavior is completely unchanged.

Fixes #2868

## Note on the aiokafka version

`client_rack` exists on `AIOKafkaConsumer` since **aiokafka 0.14.0**, but the `kafka` extra currently pins `aiokafka>=0.9,<0.14`. This PR does **not** change that pin, because:

- The new option is dormant unless the user explicitly sets it, so the change is safe on the currently pinned aiokafka range.
- Bumping the aiokafka upper bound is a separate concern that deserves its own review.

Happy to bump the pin here as well if you'd prefer `client_rack` to be usable out of the box — just let me know which you'd like.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code adheres to the style guidelines of this project (`ruff check` and `ruff format` report no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation (the new argument is documented in the `KafkaBroker` docstring and `KafkaInitKwargs`)
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature (`tests/brokers/kafka/test_client_rack.py`)
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`

The new tests pass, and the kafka unit-test suite (`pytest tests/brokers/kafka -m "not connected and not slow"`) passes locally — 133 passed. I could not run the full `just test-coverage` / connected suites locally, so I am relying on CI for those.
