### PR TITLE
fix: Encode unsafe AsyncAPI reference path parts, including {} and /

### DIFF
--- a/faststream/confluent/helpers/admin.py
+++ b/faststream/confluent/helpers/admin.py
@@ -33,7 +33,8 @@ class AdminService:
             admin_config = config.admin_config
             if logger is not None:
                 self.admin_client = AdminClient(
-                    admin_config, logger=_LazyLoggerProxy(logger),
+                    admin_config,
+                    logger=_LazyLoggerProxy(logger),
                 )
             else:
                 self.admin_client = AdminClient(admin_config)

--- a/faststream/specification/asyncapi/utils.py
+++ b/faststream/specification/asyncapi/utils.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 
 def to_camelcase(*names: str) -> str:
@@ -46,6 +47,15 @@ def resolve_payloads(
 
 def clear_key(key: str) -> str:
     return key.replace("/", ".")
+
+
+def ref(*parts: str) -> dict[str, str]:
+    return {"$ref": "#/" + "/".join(_encode_json_pointer_part(p) for p in parts)}
+
+
+def _encode_json_pointer_part(part: str) -> str:
+    pointer_part = part.replace("~", "~0").replace("/", "~1")
+    return quote(pointer_part, safe="~:._-")
 
 
 def move_pydantic_refs(

--- a/faststream/specification/asyncapi/v2_6_0/generate.py
+++ b/faststream/specification/asyncapi/v2_6_0/generate.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from faststream._internal._compat import DEF_KEY
 from faststream._internal.constants import ContentTypes
-from faststream.specification.asyncapi.utils import clear_key, move_pydantic_refs
+from faststream.specification.asyncapi.utils import clear_key, move_pydantic_refs, ref
 from faststream.specification.asyncapi.v2_6_0.schema import (
     ApplicationInfo,
     ApplicationSchema,
@@ -287,9 +287,7 @@ def _resolve_msg_payloads(
             if formatted_payload_title not in payloads:
                 payloads[formatted_payload_title] = p
             one_of_list.append(
-                Reference(**{
-                    "$ref": f"#/components/schemas/{formatted_payload_title}",
-                }),
+                Reference(**ref("components", "schemas", formatted_payload_title)),
             )
 
     elif one_of is not None:
@@ -300,7 +298,7 @@ def _resolve_msg_payloads(
             p_title = clear_key(p_title)
             if p_title not in payloads:
                 payloads[p_title] = p
-            one_of_list.append(Reference(**{"$ref": f"#/components/schemas/{p_title}"}))
+            one_of_list.append(Reference(**ref("components", "schemas", p_title)))
 
     if not one_of_list:
         payloads.update(m.payload.pop(DEF_KEY, {}))
@@ -314,7 +312,7 @@ def _resolve_msg_payloads(
             )
 
         payloads[p_title] = m.payload
-        m.payload = {"$ref": f"#/components/schemas/{p_title}"}
+        m.payload = ref("components", "schemas", p_title)
 
     else:
         m.payload["oneOf"] = one_of_list
@@ -322,4 +320,4 @@ def _resolve_msg_payloads(
     assert m.title
     message_title = clear_key(m.title)
     messages[message_title] = m
-    return Reference(**{"$ref": f"#/components/messages/{message_title}"})
+    return Reference(**ref("components", "messages", message_title))

--- a/faststream/specification/asyncapi/v3_0_0/generate.py
+++ b/faststream/specification/asyncapi/v3_0_0/generate.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from faststream._internal._compat import DEF_KEY
 from faststream._internal.constants import ContentTypes
-from faststream.specification.asyncapi.utils import clear_key, move_pydantic_refs
+from faststream.specification.asyncapi.utils import clear_key, move_pydantic_refs, ref
 from faststream.specification.asyncapi.v3_0_0.schema import (
     ApplicationInfo,
     ApplicationSchema,
@@ -173,7 +173,7 @@ def get_broker_server(
 
         if specification.security is not None:
             broker_meta["security"] = [
-                Reference(**{"$ref": f"#/components/securitySchemes/{sec}"})
+                Reference(**ref("components", "securitySchemes", sec))
                 for security_item in specification.security.get_requirement()
                 for sec in security_item
             ]
@@ -214,7 +214,7 @@ def get_broker_channels(
     operations = {}
 
     channel_servers = [
-        {"$ref": f"#/servers/{server_name}"} for server_name in (servers or ())
+        ref("servers", server_name) for server_name in (servers or ())
     ] or None
 
     for sub in filter(lambda s: s.specification.include_in_schema, broker.subscribers):
@@ -246,12 +246,10 @@ def get_broker_channels(
 
             operations[operation_key] = Operation.from_sub(
                 messages=[
-                    Reference(**{
-                        "$ref": f"#/channels/{channel_key}/messages/{msg_name}",
-                    })
+                    Reference(**ref("channels", channel_key, "messages", msg_name))
                     for msg_name in channel_obj.messages
                 ],
-                channel=Reference(**{"$ref": f"#/channels/{channel_key}"}),
+                channel=Reference(**ref("channels", channel_key)),
                 operation=sub_channel.operation,
             )
 
@@ -270,12 +268,10 @@ def get_broker_channels(
 
             operations[channel_key] = Operation.from_pub(
                 messages=[
-                    Reference(**{
-                        "$ref": f"#/channels/{channel_key}/messages/{msg_name}",
-                    })
+                    Reference(**ref("channels", channel_key, "messages", msg_name))
                     for msg_name in channel_obj.messages
                 ],
-                channel=Reference(**{"$ref": f"#/channels/{channel_key}"}),
+                channel=Reference(**ref("channels", channel_key)),
                 operation=pub_channel.operation,
             )
 
@@ -304,7 +300,7 @@ def get_asgi_routes(
             channels[channel_name] = channel
             operation = Operation(
                 action=Action.RECEIVE,
-                channel=Reference(**{"$ref": f"#/channels/{channel_name}"}),
+                channel=Reference(**ref("channels", channel_name)),
                 bindings=OperationBinding(
                     http=http_bindings.OperationBinding(
                         method=_get_http_binding_method(asgi_app.methods),
@@ -349,14 +345,14 @@ def _resolve_msg_payloads(
                 for def_name, def_schema in defs.items():
                     payloads[clear_key(def_name)] = def_schema
             processed_payloads[clear_key(name)] = payload
-            one_of_list.append(Reference(**{"$ref": f"#/components/schemas/{name}"}))
+            one_of_list.append(Reference(**ref("components", "schemas", name)))
 
         payloads.update(processed_payloads)
         m.payload["oneOf"] = one_of_list
         assert m.title
         messages[clear_key(m.title)] = m
         return Reference(
-            **{"$ref": f"#/components/messages/{channel_name}:{message_name}"},
+            **ref("components", "messages", f"{channel_name}:{message_name}"),
         )
 
     payloads.update(m.payload.pop(DEF_KEY, {}))
@@ -371,9 +367,9 @@ def _resolve_msg_payloads(
         )
 
     payloads[payload_name] = m.payload
-    m.payload = {"$ref": f"#/components/schemas/{payload_name}"}
+    m.payload = ref("components", "schemas", payload_name)
     assert m.title
     messages[clear_key(m.title)] = m
     return Reference(
-        **{"$ref": f"#/components/messages/{channel_name}:{message_name}"},
+        **ref("components", "messages", f"{channel_name}:{message_name}"),
     )

--- a/tests/asyncapi/base/v2_6_0/naming.py
+++ b/tests/asyncapi/base/v2_6_0/naming.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 import pytest
 from dirty_equals import Contains, HasLen, IsPartialDict, IsStr
@@ -267,6 +268,22 @@ class SubscriberNaming(BaseNaming):
 
         assert schema["components"]["schemas"]["custom:Message:Payload"] == {
             "title": "custom:Message:Payload",
+        }
+
+    def test_path_channel_refs_are_uri_encoded(self) -> None:
+        broker = self.broker_class()
+
+        @broker.subscriber("/test/topic/{user_id}")
+        async def sub(name: str, age: int) -> None: ...
+
+        schema = self.get_spec(broker).to_jsonable()
+
+        channel_key = next(iter(schema["channels"]))
+        message_key = next(iter(schema["components"]["messages"]))
+        encoded_message_key = quote(message_key, safe="~:._-")
+
+        assert schema["channels"][channel_key]["publish"]["message"] == {
+            "$ref": f"#/components/messages/{encoded_message_key}",
         }
 
     def test_multi_subscribers_naming_default(self) -> None:

--- a/tests/asyncapi/base/v3_0_0/naming.py
+++ b/tests/asyncapi/base/v3_0_0/naming.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 import pytest
 from dirty_equals import Contains, HasLen, IsPartialDict, IsStr
@@ -272,6 +273,30 @@ class SubscriberNaming(BaseNaming):
         assert schema["components"]["schemas"]["custom:Message:Payload"] == {
             "title": "custom:Message:Payload",
         }
+
+    def test_path_channel_refs_are_uri_encoded(self) -> None:
+        broker = self.broker_class()
+
+        @broker.subscriber("/test/topic/{user_id}")
+        async def sub(name: str, age: int) -> None: ...
+
+        schema = self.get_spec(broker).to_jsonable()
+
+        channel_key = next(iter(schema["channels"]))
+        message_name = next(iter(schema["channels"][channel_key]["messages"]))
+        message_key = next(iter(schema["components"]["messages"]))
+        operation = next(iter(schema["operations"].values()))
+
+        encoded_channel_key = quote(channel_key, safe="~:._-")
+        encoded_message_key = quote(message_key, safe="~:._-")
+
+        assert schema["channels"][channel_key]["messages"][message_name] == {
+            "$ref": f"#/components/messages/{encoded_message_key}",
+        }
+        assert operation["channel"] == {"$ref": f"#/channels/{encoded_channel_key}"}
+        assert operation["messages"] == [
+            {"$ref": f"#/channels/{encoded_channel_key}/messages/{message_name}"},
+        ]
 
     def test_multi_subscribers_naming_default(self) -> None:
         broker = self.broker_class()

--- a/tests/brokers/confluent/test_lazy_logger_proxy.py
+++ b/tests/brokers/confluent/test_lazy_logger_proxy.py
@@ -15,8 +15,13 @@ def test_proxy_drops_records_before_setup() -> None:
     proxy = _LazyLoggerProxy(state)
 
     record = logging.LogRecord(
-        name="test", level=logging.WARNING, pathname="", lineno=0,
-        msg="should be dropped", args=(), exc_info=None,
+        name="test",
+        level=logging.WARNING,
+        pathname="",
+        lineno=0,
+        msg="should be dropped",
+        args=(),
+        exc_info=None,
     )
     # Must not raise
     proxy.handle(record)
@@ -38,8 +43,13 @@ def test_proxy_forwards_after_setup() -> None:
     state.logger = RealLoggerObject(real_logger)
 
     record = logging.LogRecord(
-        name="test", level=logging.WARNING, pathname="", lineno=0,
-        msg="should arrive", args=(), exc_info=None,
+        name="test",
+        level=logging.WARNING,
+        pathname="",
+        lineno=0,
+        msg="should arrive",
+        args=(),
+        exc_info=None,
     )
     proxy.handle(record)
 


### PR DESCRIPTION
# Description

Encode unsafe AsyncAPI reference path parts, including {} for path and / for mqtt topics

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
