### PR TITLE
fix(fastapi): register POST {schema_url}/try for AsyncAPI try-it-out

### DIFF
--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -25,6 +25,7 @@ from fastapi.datastructures import Default
 from fastapi.responses import HTMLResponse
 from fastapi.routing import APIRoute, APIRouter
 from fastapi.utils import generate_unique_id
+from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import BaseRoute, _DefaultLifespan
 
@@ -423,6 +424,7 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
                     schemas=schemas,
                     errors=errors,
                     expand_message_examples=expandMessageExamples,
+                    try_it_out_url=f"{schema_url}/try",
                 ),
             )
 
@@ -436,6 +438,42 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
         docs_router.get(schema_url)(serve_asyncapi_schema)
         docs_router.get(f"{schema_url}.json")(download_app_json_schema)
         docs_router.get(f"{schema_url}.yaml")(download_app_yaml_schema)
+
+        # The AsyncAPI docs page renders an interactive "try it out" plugin
+        # that POSTs to ``{schema_url}/try``. Register that endpoint so the
+        # FastAPI plugin can publish messages to the broker, mirroring the
+        # standalone AsgiFastStream behaviour (see issue #2869).
+        from faststream.asgi.factories.asyncapi.try_it_out import (
+            TryItOutProcessor,
+        )
+
+        try:
+            try_processor = TryItOutProcessor(self.broker)
+        except ValueError:
+            # Broker has no associated TestBroker (e.g. a custom broker):
+            # serve the docs without the interactive "try it out" endpoint.
+            try_processor = None
+
+        if try_processor is not None:
+
+            async def try_asyncapi_schema(request: Request) -> Response:
+                """Publish a message coming from the AsyncAPI try-it-out plugin."""
+                try:
+                    body = await request.json()
+                except Exception as e:
+                    return JSONResponse({"details": f"Invalid JSON: {e}"}, 400)
+
+                result = await try_processor.process(body)
+                return Response(
+                    content=result.body,
+                    status_code=result.status_code,
+                    media_type="application/json",
+                )
+
+            docs_router.post(f"{schema_url}/try", include_in_schema=False)(
+                try_asyncapi_schema,
+            )
+
         return docs_router
 
     def include_router(  # type: ignore[override]

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -39,6 +39,7 @@ from faststream._internal.types import (
     T_HandlerReturn,
 )
 from faststream._internal.utils.functions import to_async
+from faststream.asgi.factories.asyncapi.try_it_out import TryItOutProcessor
 from faststream.middlewares import BaseMiddleware
 from faststream.specification.asyncapi.site import get_asyncapi_html
 
@@ -443,10 +444,6 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
         # that POSTs to ``{schema_url}/try``. Register that endpoint so the
         # FastAPI plugin can publish messages to the broker, mirroring the
         # standalone AsgiFastStream behaviour (see issue #2869).
-        from faststream.asgi.factories.asyncapi.try_it_out import (
-            TryItOutProcessor,
-        )
-
         try:
             try_processor = TryItOutProcessor(self.broker)
         except ValueError:

--- a/tests/asyncapi/test_fastapi_router.py
+++ b/tests/asyncapi/test_fastapi_router.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -66,3 +68,66 @@ async def test_fastapi_asyncapi_routes() -> None:
 
             response_html = client.get("/asyncapi_schema")
             assert response_html.status_code == 200
+
+
+@pytest.mark.asyncio()
+async def test_fastapi_asyncapi_try_it_out_delivers_message() -> None:
+    """The try-it-out POST route must deliver a message to the broker (#2869)."""
+    router = NatsRouter()
+    mock = MagicMock()
+
+    @router.subscriber("test-try")
+    async def handler(msg: str) -> None:
+        mock(msg)
+
+    app = FastAPI()
+    app.include_router(router)
+
+    async with TestNatsBroker(router.broker):
+        with TestClient(app) as client:
+            response = client.post(
+                "/asyncapi/try",
+                json={
+                    "channelName": "test-try",
+                    "message": {
+                        "operation_id": "op",
+                        "operation_type": "subscribe",
+                        "message": "hello",
+                    },
+                    "options": {"sendToRealBroker": False},
+                },
+            )
+            assert response.status_code == 200, response.text
+
+    mock.assert_called_once_with("hello")
+
+
+@pytest.mark.asyncio()
+async def test_fastapi_asyncapi_try_it_out_follows_schema_url() -> None:
+    """The try-it-out POST route must track a custom ``schema_url``."""
+    router = NatsRouter(schema_url="/asyncapi_schema")
+
+    @router.subscriber("test-try")
+    async def handler() -> None: ...
+
+    app = FastAPI()
+    app.include_router(router)
+
+    async with TestNatsBroker(router.broker):
+        with TestClient(app) as client:
+            response = client.post(
+                "/asyncapi_schema/try",
+                json={
+                    "channelName": "test-try",
+                    "message": {
+                        "operation_id": "op",
+                        "operation_type": "subscribe",
+                        "message": {},
+                    },
+                    "options": {"sendToRealBroker": False},
+                },
+            )
+            assert response.status_code == 200, response.text
+
+            # default schema_url should not expose the try route
+            assert client.post("/asyncapi/try", json={}).status_code == 404


### PR DESCRIPTION
## Description

The FastAPI plugin renders the AsyncAPI docs page with the interactive "try it out" plugin enabled (`get_asyncapi_html` defaults `try_it_out=True`), but `StreamRouter._asyncapi_router` only registered the `GET` routes (`/asyncapi`, `.json`, `.yaml`). Clicking **Send Message** issued `POST {schema_url}/try`, which returned **404 Not Found**.

This registers the missing `POST {schema_url}/try` endpoint, reusing the existing broker-agnostic `TryItOutProcessor` already used by the standalone `AsgiFastStream` app, and passes `try_it_out_url` to `get_asyncapi_html` so the rendered page targets the registered route (consistent with `AsyncAPIRoute`). Brokers without an associated `TestBroker` keep serving the docs without the try endpoint instead of breaking startup.

Fixes #2869

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint`: ruff-format, ruff-check, codespell — all clean)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix (`tests/asyncapi/test_fastapi_router.py`: two regression tests; full `tests/asyncapi/` and `tests/asgi/` suites pass locally; `mypy` clean)
- [x] Both new and existing unit tests pass successfully on my local environment
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis` (ran `mypy` — clean; bandit/semgrep not run locally)
