### PR TITLE
Add consumer_only flag to KafkaBroker

### DIFF
--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -88,6 +88,9 @@ if TYPE_CHECKING:
             client_rack: A rack identifier for this client. Used by the
                 broker for rack-aware fetching, letting a consumer read from
                 the closest replica. Requires aiokafka 0.14.0 or newer.
+            consumer_only: When True the broker skips creating the
+                producer and admin clients, letting deployments use Kafka
+                credentials scoped to read-only ACLs. Defaults to False.
             acks: One of ``0``, ``1``, ``all``. The number of acknowledgments
                 the producer requires the leader to have received before considering a
                 request complete. This controls the durability of records that are
@@ -162,6 +165,7 @@ if TYPE_CHECKING:
         client_id: str | None
         # consumer args
         client_rack: str | None
+        consumer_only: bool
         # publisher args
         acks: Literal[0, 1, -1, "all"] | object
         key_serializer: Callable[[Any], bytes] | None
@@ -204,6 +208,7 @@ class KafkaBroker(
         client_id: str | None = SERVICE_NAME,
         # consumer args
         client_rack: str | None = None,
+        consumer_only: bool = False,
         # publisher args
         acks: Literal[0, 1, -1, "all"] | object = _missing,
         key_serializer: Callable[[Any], bytes] | None = None,
@@ -277,6 +282,9 @@ class KafkaBroker(
             client_rack (Optional[str]):
                 A rack identifier for this client. Used by the broker for rack-aware fetching, letting a consumer read from the
                 closest replica. Requires aiokafka 0.14.0 or newer.
+            consumer_only (bool):
+                When True the broker skips creating the producer and admin clients during ``start()``, letting deployments use
+                Kafka credentials scoped to read-only ACLs. Defaults to False.
             acks (Union[Literal[0, 1, -1, "all"], object]):
                 One of ``0``, ``1``, ``all``. The number of acknowledgments the producer requires the leader to have received before considering a
                 request complete. This controls the durability of records that are sent. The following settings are common:
@@ -430,6 +438,7 @@ class KafkaBroker(
             config=KafkaBrokerConfig(
                 client_id=client_id,
                 client_rack=client_rack,
+                consumer_only=consumer_only,
                 builder=builder,
                 producer=AioKafkaFastProducerImpl(
                     parser=parser,

--- a/faststream/kafka/configs/broker.py
+++ b/faststream/kafka/configs/broker.py
@@ -27,6 +27,7 @@ class KafkaBrokerConfig(BrokerConfig):
 
     client_id: str | None = SERVICE_NAME
     client_rack: str | None = None
+    consumer_only: bool = False
 
     _admin_client: Optional["aiokafka.admin.client.AIOKafkaAdminClient"] = None
 
@@ -39,16 +40,22 @@ class KafkaBrokerConfig(BrokerConfig):
         return self._admin_client
 
     async def connect(self, **connection_kwargs: Any) -> "None":
-        producer = aiokafka.AIOKafkaProducer(**connection_kwargs)
-        await self.producer.connect(producer, serializer=self.fd_config._serializer)
+        # In consumer-only mode the broker neither produces messages nor needs
+        # admin permissions, so skip creating those clients to allow callers
+        # to use credentials scoped to read-only ACLs.
+        if not self.consumer_only:
+            producer = aiokafka.AIOKafkaProducer(**connection_kwargs)
+            await self.producer.connect(producer, serializer=self.fd_config._serializer)
 
-        admin_options, _ = filter_by_dict(
-            AdminClientConnectionParams,
-            connection_kwargs,
-        )
+            admin_options, _ = filter_by_dict(
+                AdminClientConnectionParams,
+                connection_kwargs,
+            )
 
-        self._admin_client = aiokafka.admin.client.AIOKafkaAdminClient(**admin_options)
-        await self._admin_client.start()
+            self._admin_client = aiokafka.admin.client.AIOKafkaAdminClient(
+                **admin_options
+            )
+            await self._admin_client.start()
 
         consumer_options, _ = filter_by_dict(
             ConsumerConnectionParams,
@@ -65,4 +72,5 @@ class KafkaBrokerConfig(BrokerConfig):
             await self._admin_client.close()
             self._admin_client = None
 
-        await self.producer.disconnect()
+        if not self.consumer_only:
+            await self.producer.disconnect()

--- a/tests/brokers/kafka/test_consumer_only.py
+++ b/tests/brokers/kafka/test_consumer_only.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from faststream.kafka import KafkaBroker
+from faststream.kafka.configs.broker import KafkaBrokerConfig
+
+
+@pytest.mark.kafka()
+class TestConsumerOnly:
+    def test_broker_config_stores_consumer_only(self) -> None:
+        assert KafkaBrokerConfig(consumer_only=True).consumer_only is True
+
+    def test_broker_config_consumer_only_defaults_to_false(self) -> None:
+        assert KafkaBrokerConfig().consumer_only is False
+
+    def test_broker_forwards_consumer_only_to_config(self) -> None:
+        broker = KafkaBroker(consumer_only=True)
+        assert broker.config.broker_config.consumer_only is True
+
+    def test_broker_consumer_only_defaults_to_false(self) -> None:
+        broker = KafkaBroker()
+        assert broker.config.broker_config.consumer_only is False
+
+    @pytest.mark.asyncio()
+    async def test_connect_skips_producer_and_admin_when_consumer_only(self) -> None:
+        config = KafkaBrokerConfig(consumer_only=True)
+        # The producer must not be touched when consumer_only is set.
+        config.producer = MagicMock()
+        config.producer.connect = AsyncMock()
+
+        with (
+            patch(
+                "faststream.kafka.configs.broker.aiokafka.AIOKafkaProducer"
+            ) as producer_cls,
+            patch(
+                "faststream.kafka.configs.broker.aiokafka.admin.client.AIOKafkaAdminClient"
+            ) as admin_cls,
+        ):
+            await config.connect(bootstrap_servers="localhost:9092")
+
+        producer_cls.assert_not_called()
+        admin_cls.assert_not_called()
+        config.producer.connect.assert_not_called()
+        # The consumer builder still gets wired up so subscribers work.
+        assert callable(config.builder)
+
+    @pytest.mark.asyncio()
+    async def test_connect_creates_producer_and_admin_by_default(self) -> None:
+        config = KafkaBrokerConfig()
+        config.producer = MagicMock()
+        config.producer.connect = AsyncMock()
+
+        with (
+            patch(
+                "faststream.kafka.configs.broker.aiokafka.AIOKafkaProducer"
+            ) as producer_cls,
+            patch(
+                "faststream.kafka.configs.broker.aiokafka.admin.client.AIOKafkaAdminClient"
+            ) as admin_cls,
+        ):
+            admin_cls.return_value.start = AsyncMock()
+            await config.connect(bootstrap_servers="localhost:9092")
+
+        producer_cls.assert_called_once()
+        admin_cls.assert_called_once()
+        config.producer.connect.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_disconnect_skips_producer_when_consumer_only(self) -> None:
+        config = KafkaBrokerConfig(consumer_only=True)
+        config.producer = MagicMock()
+        config.producer.disconnect = AsyncMock()
+
+        await config.disconnect()
+
+        config.producer.disconnect.assert_not_called()


### PR DESCRIPTION
# Description

Closes #2879.

When deploying a subscriber-only Kafka service it is common to scope credentials to READ + DESCRIBE ACLs on specific topics. Today `KafkaBroker` always creates a producer and admin client during `connect()`, which fails or raises against such credentials even when no publishers are registered.

Per @Lancetnik`s direction on #2879 ("We just need to disable the creation of producer & admin clients when the flag is set"), this PR adds a `consumer_only` flag to `KafkaBroker` and `KafkaBrokerConfig`:

- When `consumer_only=True`, `KafkaBrokerConfig.connect()` skips creating the `AIOKafkaProducer` and `AIOKafkaAdminClient`, and `disconnect()` leaves the producer alone.
- The consumer builder is still wired up so subscribers continue to work normally.
- Default is `False`, so existing behavior is completely unchanged.



## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code adheres to the style guidelines (`ruff check` and `ruff format` are clean)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation (the new argument is documented in both the `KafkaBroker` docstring and `KafkaInitKwargs`)
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix (`tests/brokers/kafka/test_consumer_only.py`, 7 cases including mocked `connect()`/`disconnect()` to assert producer/admin clients are not created when the flag is set, and *are* created on the default path)
- [x] Both new and existing unit tests pass successfully on my local environment (`pytest tests/brokers/kafka -m "not connected and not slow"` — 171 passed)