### PR TITLE
Allow aiokafka 0.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
 [project.optional-dependencies]
 rabbit = ["aio-pika>=9,<10"]
 
-kafka = ["aiokafka>=0.9,<0.14"]
+kafka = ["aiokafka>=0.9,<0.15"]
 
 confluent = [
     "confluent-kafka>=2,!=2.8.1,<3; python_version < '3.13'",


### PR DESCRIPTION
# Description

Follow-up to #2871. Bumps the upper bound of the `kafka` extra from `aiokafka<0.14` to `aiokafka<0.15` so that aiokafka 0.14 can be installed via `pip install faststream[kafka]`.

aiokafka 0.14 is the first release that exposes the `client_rack` consumer option that was wired through `KafkaBroker` in #2871. With the previous `<0.14` pin the new `client_rack` argument is accepted by FastStream but the underlying `AIOKafkaConsumer` does not know about it on a default install — bumping the upper bound lifts that gap.

The change is a single-line edit in `pyproject.toml`. I raised the question about this pin in the original #2871 description; bringing it here as its own focused PR so it can be reviewed independently.

## Verification

Installed `aiokafka==0.14.0` locally and ran the kafka unit suite (`pytest tests/brokers/kafka -m "not connected and not slow"`): **171 passed, 197 deselected, 1 xfailed**. No regressions.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code adheres to the style guidelines
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation (no docs change needed — pin only)
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix (existing kafka unit suite verifies compatibility; no new tests required for a pin change)
- [x] Both new and existing unit tests pass successfully on my local environment
