### PR TITLE
Document the concurrency model for subscribers

### DIFF
--- a/docs/docs/en/getting-started/subscription/concurrency.md
+++ b/docs/docs/en/getting-started/subscription/concurrency.md
@@ -10,9 +10,9 @@ search:
 
 # Concurrency
 
-**FastStream** gives you two independent levers for processing messages concurrently. Mixing them up is a common source of confusion, so it helps to keep their roles straight.
+By default, a subscriber processes one message at a time: the next message is not handled until the current one is finished. `max_workers` lifts that restriction.
 
-## `max_workers` — handler-level parallelism
+## `max_workers`
 
 `max_workers` is the **number of concurrent handler invocations** a single subscriber may run. It is available on every broker's subscriber decorator:
 
@@ -26,44 +26,11 @@ async def handle(msg): ...
 
 With `max_workers=1` (the default) **FastStream** processes one message at a time per subscriber. With `max_workers=N`, up to `N` invocations of the handler can run at the same time.
 
-## `prefetch_count` — RabbitMQ flow control
+This is handler-level parallelism and it is broker-agnostic: the setting means the same thing for RabbitMQ, Kafka, NATS, Redis and MQTT.
 
-`prefetch_count` is **RabbitMQ-specific**. It comes from AMQP's `basic.qos` and tells the broker how many unacknowledged messages it may have outstanding on a given channel at any time.
+!!! note
+    `max_workers` controls how many messages are processed **at once**, not how many are fetched from the broker. Those are separate concerns, and some brokers expose their own knob for the second one:
 
-It is set at the channel level:
-
-```python hl_lines="6"
-from faststream.rabbit import RabbitBroker
-from faststream.rabbit.schemas import Channel
-
-broker = RabbitBroker(
-    "amqp://guest:guest@localhost:5672/",
-    channel=Channel(prefetch_count=10),
-)
-```
-
-`prefetch_count=N` does **not** mean "process `N` messages at the same time". It means "let the broker push up to `N` messages to this consumer before requiring an ack". It is a buffer / flow-control window — not parallelism.
-
-## How they combine
-
-The two settings are orthogonal:
-
-| `max_workers` | `prefetch_count` | Behavior                                                                                |
-|---------------|------------------|-----------------------------------------------------------------------------------------|
-| `1`           | `1`              | One message in flight, processed sequentially. The classic per-message round trip.       |
-| `1`           | `N`              | Up to `N` messages held locally by the consumer, but **still processed one at a time**.  |
-| `K`           | `N` (≥ `K`)      | Up to `K` invocations of the handler run concurrently; up to `N` may be buffered.        |
-| `K`           | `< K`            | Concurrency is throttled by `prefetch_count`: the broker will not push enough messages to keep all workers busy. |
-
-A useful rule of thumb for RabbitMQ subscribers: set `prefetch_count` at least as large as `max_workers`, otherwise extra workers sit idle waiting for messages.
-
-## Other brokers
-
-- **Kafka / Confluent.** There is no `prefetch_count`. The consumer pulls in batches; tune `max_poll_records` (and friends) to control how many records are fetched per poll, and use `max_workers` for handler parallelism. See [Kafka Subscriber concurrent processing](../../kafka/Subscriber/index.md#concurrent-processing) for the interaction with `AckPolicy`.
-- **Redis, NATS, MQTT.** Only `max_workers` applies. There is no broker-side prefetch knob equivalent to RabbitMQ's.
-
-## The common confusion
-
-> Does `prefetch_count=10` mean ten messages are processed at the same time?
-
-No. It means the **broker** may deliver up to ten messages before it expects acknowledgments. How many are *processed in parallel* is determined by `max_workers`. With the default `max_workers=1`, the ten prefetched messages are processed one after another — `prefetch_count` only changes how aggressively they are pulled from the broker.
+    - **RabbitMQ** — `prefetch_count` controls how many messages the broker may push before requiring an acknowledgement. See [Concurrency and Prefetch](../../rabbit/prefetch.md) for how the two settings interact.
+    - **Kafka / Confluent** — the consumer pulls in batches; tune `max_poll_records` (and friends) to control how many records are fetched per poll. See [Kafka Subscriber concurrent processing](../../kafka/Subscriber/index.md#concurrent-processing) for the interaction with `AckPolicy`.
+    - **NATS, Redis, MQTT** — only `max_workers` applies; there is no broker-side prefetch equivalent.

--- a/docs/docs/en/getting-started/subscription/concurrency.md
+++ b/docs/docs/en/getting-started/subscription/concurrency.md
@@ -10,11 +10,13 @@ search:
 
 # Concurrency
 
-By default, a subscriber processes one message at a time: the next message is not handled until the current one is finished. `max_workers` lifts that restriction.
+By default, a **Kafka**, **Confluent**, **NATS**, **Redis** or **MQTT** subscriber processes one message at a time: the next message is not handled until the current one is finished. `max_workers` lifts that restriction.
+
+**RabbitMQ** works the other way around — it is already concurrent and needs to be *limited* instead. See [Concurrency and Prefetch](../../rabbit/prefetch.md).
 
 ## `max_workers`
 
-`max_workers` is the **number of concurrent handler invocations** a single subscriber may run. It is available on every broker's subscriber decorator:
+`max_workers` is the **number of concurrent handler invocations** a single subscriber may run:
 
 ```python hl_lines="3"
 @broker.subscriber(
@@ -26,11 +28,11 @@ async def handle(msg): ...
 
 With `max_workers=1` (the default) **FastStream** processes one message at a time per subscriber. With `max_workers=N`, up to `N` invocations of the handler can run at the same time.
 
-This is handler-level parallelism and it is broker-agnostic: the setting means the same thing for RabbitMQ, Kafka, NATS, Redis and MQTT.
+!!! note
+    `max_workers` is not available on the RabbitMQ subscriber. RabbitMQ subscribers do not serialize handler invocations in the first place, so there is nothing for `max_workers` to lift — what you tune there is `prefetch_count`, which bounds how many messages the broker may have in flight. See [Concurrency and Prefetch](../../rabbit/prefetch.md).
 
 !!! note
     `max_workers` controls how many messages are processed **at once**, not how many are fetched from the broker. Those are separate concerns, and some brokers expose their own knob for the second one:
 
-    - **RabbitMQ** — `prefetch_count` controls how many messages the broker may push before requiring an acknowledgement. See [Concurrency and Prefetch](../../rabbit/prefetch.md) for how the two settings interact.
     - **Kafka / Confluent** — the consumer pulls in batches; tune `max_poll_records` (and friends) to control how many records are fetched per poll. See [Kafka Subscriber concurrent processing](../../kafka/Subscriber/index.md#concurrent-processing) for the interaction with `AckPolicy`.
     - **NATS, Redis, MQTT** — only `max_workers` applies; there is no broker-side prefetch equivalent.

--- a/docs/docs/en/getting-started/subscription/concurrency.md
+++ b/docs/docs/en/getting-started/subscription/concurrency.md
@@ -1,0 +1,69 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 10
+---
+
+# Concurrency
+
+**FastStream** gives you two independent levers for processing messages concurrently. Mixing them up is a common source of confusion, so it helps to keep their roles straight.
+
+## `max_workers` — handler-level parallelism
+
+`max_workers` is the **number of concurrent handler invocations** a single subscriber may run. It is available on every broker's subscriber decorator:
+
+```python hl_lines="3"
+@broker.subscriber(
+    "test",
+    max_workers=4,
+)
+async def handle(msg): ...
+```
+
+With `max_workers=1` (the default) **FastStream** processes one message at a time per subscriber. With `max_workers=N`, up to `N` invocations of the handler can run at the same time.
+
+## `prefetch_count` — RabbitMQ flow control
+
+`prefetch_count` is **RabbitMQ-specific**. It comes from AMQP's `basic.qos` and tells the broker how many unacknowledged messages it may have outstanding on a given channel at any time.
+
+It is set at the channel level:
+
+```python hl_lines="6"
+from faststream.rabbit import RabbitBroker
+from faststream.rabbit.schemas import Channel
+
+broker = RabbitBroker(
+    "amqp://guest:guest@localhost:5672/",
+    channel=Channel(prefetch_count=10),
+)
+```
+
+`prefetch_count=N` does **not** mean "process `N` messages at the same time". It means "let the broker push up to `N` messages to this consumer before requiring an ack". It is a buffer / flow-control window — not parallelism.
+
+## How they combine
+
+The two settings are orthogonal:
+
+| `max_workers` | `prefetch_count` | Behavior                                                                                |
+|---------------|------------------|-----------------------------------------------------------------------------------------|
+| `1`           | `1`              | One message in flight, processed sequentially. The classic per-message round trip.       |
+| `1`           | `N`              | Up to `N` messages held locally by the consumer, but **still processed one at a time**.  |
+| `K`           | `N` (≥ `K`)      | Up to `K` invocations of the handler run concurrently; up to `N` may be buffered.        |
+| `K`           | `< K`            | Concurrency is throttled by `prefetch_count`: the broker will not push enough messages to keep all workers busy. |
+
+A useful rule of thumb for RabbitMQ subscribers: set `prefetch_count` at least as large as `max_workers`, otherwise extra workers sit idle waiting for messages.
+
+## Other brokers
+
+- **Kafka / Confluent.** There is no `prefetch_count`. The consumer pulls in batches; tune `max_poll_records` (and friends) to control how many records are fetched per poll, and use `max_workers` for handler parallelism. See [Kafka Subscriber concurrent processing](../../kafka/Subscriber/index.md#concurrent-processing) for the interaction with `AckPolicy`.
+- **Redis, NATS, MQTT.** Only `max_workers` applies. There is no broker-side prefetch knob equivalent to RabbitMQ's.
+
+## The common confusion
+
+> Does `prefetch_count=10` mean ten messages are processed at the same time?
+
+No. It means the **broker** may deliver up to ten messages before it expects acknowledgments. How many are *processed in parallel* is determined by `max_workers`. With the default `max_workers=1`, the ten prefetched messages are processed one after another — `prefetch_count` only changes how aggressively they are pulled from the broker.

--- a/docs/docs/en/rabbit/prefetch.md
+++ b/docs/docs/en/rabbit/prefetch.md
@@ -1,0 +1,50 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 10
+---
+
+# Concurrency and Prefetch
+
+RabbitMQ subscribers have two settings that look like they do the same thing but do not: [`max_workers`](../getting-started/subscription/concurrency.md) and `prefetch_count`. Mixing them up is a common source of confusion, so it helps to keep their roles straight.
+
+## `prefetch_count`
+
+`prefetch_count` comes from AMQP's `basic.qos`. It tells the broker how many unacknowledged messages it may have outstanding on a given channel at any time.
+
+It is set at the channel level:
+
+```python hl_lines="6"
+from faststream.rabbit import RabbitBroker
+from faststream.rabbit.schemas import Channel
+
+broker = RabbitBroker(
+    "amqp://guest:guest@localhost:5672/",
+    channel=Channel(prefetch_count=10),
+)
+```
+
+`prefetch_count=N` does **not** mean "process `N` messages at the same time". It means "let the broker push up to `N` messages to this consumer before requiring an ack". It is a buffer / flow-control window — not parallelism.
+
+## How they combine
+
+The two settings are orthogonal:
+
+| `max_workers` | `prefetch_count` | Behavior                                                                                |
+|---------------|------------------|-----------------------------------------------------------------------------------------|
+| `1`           | `1`              | One message in flight, processed sequentially. The classic per-message round trip.       |
+| `1`           | `N`              | Up to `N` messages held locally by the consumer, but **still processed one at a time**.  |
+| `K`           | `N` (≥ `K`)      | Up to `K` invocations of the handler run concurrently; up to `N` may be buffered.        |
+| `K`           | `< K`            | Concurrency is throttled by `prefetch_count`: the broker will not push enough messages to keep all workers busy. |
+
+A useful rule of thumb: set `prefetch_count` at least as large as `max_workers`, otherwise extra workers sit idle waiting for messages.
+
+## The common confusion
+
+> Does `prefetch_count=10` mean ten messages are processed at the same time?
+
+No. It means the **broker** may deliver up to ten messages before it expects acknowledgments. How many are *processed in parallel* is determined by `max_workers`. With the default `max_workers=1`, the ten prefetched messages are processed one after another — `prefetch_count` only changes how aggressively they are pulled from the broker.

--- a/docs/docs/en/rabbit/prefetch.md
+++ b/docs/docs/en/rabbit/prefetch.md
@@ -10,11 +10,13 @@ search:
 
 # Concurrency and Prefetch
 
-RabbitMQ subscribers have two settings that look like they do the same thing but do not: [`max_workers`](../getting-started/subscription/concurrency.md) and `prefetch_count`. Mixing them up is a common source of confusion, so it helps to keep their roles straight.
+RabbitMQ subscribers are concurrent by default. A delivery is handled as it arrives, so several invocations of your handler can be in flight at the same time — you do not opt into that, and there is no `max_workers` option here.
+
+What you tune instead is the opposite: **how many messages the broker is allowed to push at you**. Without a limit it will keep sending as fast as it can, which is rarely what you want.
 
 ## `prefetch_count`
 
-`prefetch_count` comes from AMQP's `basic.qos`. It tells the broker how many unacknowledged messages it may have outstanding on a given channel at any time.
+`prefetch_count` comes from AMQP's `basic.qos`. It tells the broker how many unacknowledged messages it may have outstanding on a channel at any time.
 
 It is set at the channel level:
 
@@ -24,27 +26,52 @@ from faststream.rabbit.schemas import Channel
 
 broker = RabbitBroker(
     "amqp://guest:guest@localhost:5672/",
-    channel=Channel(prefetch_count=10),
+    default_channel=Channel(prefetch_count=10),
 )
 ```
 
-`prefetch_count=N` does **not** mean "process `N` messages at the same time". It means "let the broker push up to `N` messages to this consumer before requiring an ack". It is a buffer / flow-control window — not parallelism.
+With `prefetch_count=10`, the broker will deliver at most ten messages that have not yet been acknowledged. As each one is acked, room opens up for the next.
 
-## How they combine
+You can also give a single subscriber its own channel, so its limit is independent of the rest of the application:
 
-The two settings are orthogonal:
+```python hl_lines="3"
+@broker.subscriber(
+    "heavy-queue",
+    channel=Channel(prefetch_count=1),
+)
+async def handle(msg): ...
+```
 
-| `max_workers` | `prefetch_count` | Behavior                                                                                |
-|---------------|------------------|-----------------------------------------------------------------------------------------|
-| `1`           | `1`              | One message in flight, processed sequentially. The classic per-message round trip.       |
-| `1`           | `N`              | Up to `N` messages held locally by the consumer, but **still processed one at a time**.  |
-| `K`           | `N` (≥ `K`)      | Up to `K` invocations of the handler run concurrently; up to `N` may be buffered.        |
-| `K`           | `< K`            | Concurrency is throttled by `prefetch_count`: the broker will not push enough messages to keep all workers busy. |
+## Why you want a limit
 
-A useful rule of thumb: set `prefetch_count` at least as large as `max_workers`, otherwise extra workers sit idle waiting for messages.
+Leaving `prefetch_count` unset means the broker keeps pushing. For a fast producer and a slow handler that has two costs:
 
-## The common confusion
+- **Memory.** Undelivered work piles up in your process rather than staying in the queue.
+- **Distribution.** Messages already sitting in one consumer's buffer cannot be picked up by another consumer, so adding replicas stops helping.
 
-> Does `prefetch_count=10` mean ten messages are processed at the same time?
+Setting `prefetch_count` to a small number keeps the backlog in RabbitMQ, where it can still be redistributed.
 
-No. It means the **broker** may deliver up to ten messages before it expects acknowledgments. How many are *processed in parallel* is determined by `max_workers`. With the default `max_workers=1`, the ten prefetched messages are processed one after another — `prefetch_count` only changes how aggressively they are pulled from the broker.
+## Choosing a value
+
+There is no universal answer, but the shape of the trade-off is consistent:
+
+| `prefetch_count` | Behavior |
+|---|---|
+| `1` | One unacknowledged message at a time. Slowest throughput, but work spreads evenly across consumers — a good fit for long or uneven tasks. |
+| small (e.g. `10`) | Enough of a buffer to hide network latency while keeping the bulk of the backlog in the queue. A reasonable default. |
+| large / unset | Highest throughput for short, uniform tasks, at the cost of memory and of one consumer hoarding messages. |
+
+If handling a message is slow or its duration varies a lot, prefer a small value. If messages are tiny and uniform, a larger window is usually fine.
+
+## `global_qos`
+
+By default the limit applies to each consumer on the channel separately. `Channel(global_qos=True)` shares one limit across every subscriber using that channel instead:
+
+```python
+broker = RabbitBroker(
+    "amqp://guest:guest@localhost:5672/",
+    default_channel=Channel(prefetch_count=10, global_qos=True),
+)
+```
+
+See the RabbitMQ documentation on [consumer prefetch](https://www.rabbitmq.com/docs/consumer-prefetch){.external-link target="_blank"} for the full semantics.

--- a/docs/docs/navigation_template.txt
+++ b/docs/docs/navigation_template.txt
@@ -12,6 +12,7 @@ search:
         - [Filtering](getting-started/subscription/filtering.md)
         - [Testing](getting-started/subscription/test.md)
         - [Dynamic Subscribers](getting-started/subscription/dynamic.md)
+        - [Concurrency](getting-started/subscription/concurrency.md)
     - [Publishing](getting-started/publishing/index.md)
         - [Broker Publish](getting-started/publishing/broker.md)
         - [Decorator](getting-started/publishing/decorator.md)

--- a/docs/docs/navigation_template.txt
+++ b/docs/docs/navigation_template.txt
@@ -87,6 +87,7 @@ search:
     - [Publishing](rabbit/publishing.md)
     - [RPC](rabbit/rpc.md)
     - [Acknowledgement](rabbit/ack.md)
+    - [Concurrency and Prefetch](rabbit/prefetch.md)
     - [Declare Queue/Exchange](rabbit/declare.md)
     - [Message Information](rabbit/message.md)
     - [Security Configuration](rabbit/security.md)


### PR DESCRIPTION
# Description

Closes #2749.

Adds a dedicated docs page (`docs/docs/en/getting-started/subscription/concurrency.md`) that explains the two independent levers FastStream offers for concurrent processing — `max_workers` and RabbitMQ's `prefetch_count` — and clears up the specific confusion called out in the issue:

> Does `prefetch_count=10` mean ten messages are processed at the same time?
> → No. It means the broker may deliver up to ten before requiring acks; how many are processed in parallel is determined by `max_workers`.

The page covers:

- What each setting does on its own.
- How they combine (with a small table of the four common combinations).
- A note that Kafka/Confluent have no `prefetch_count` and link to the existing "Concurrent processing" notes on the Kafka subscriber docs.
- A note that Redis/NATS/MQTT only have `max_workers`.

Also wires the new page into `docs/docs/navigation_template.txt` after the existing "Dynamic Subscribers" entry.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation (this *is* the docs change)
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix
- [x] Both new and existing unit tests pass successfully on my local environment

No tests added — the change is a new docs page plus a single-line nav entry.
