### PR TITLE
feat: add Redis Cluster support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,23 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  redis-cluster:
+    image: redis:alpine
+    command: >-
+      sh -c "redis-server
+      --port 7000
+      --cluster-enabled yes
+      --cluster-config-file nodes.conf
+      --cluster-node-timeout 5000
+      --appendonly yes
+      & sleep 2
+      && redis-cli --cluster create 127.0.0.1:7000 --cluster-yes
+      && wait"
+    ports:
+      - 7000:7000
+    security_opt:
+      - no-new-privileges:true
+
   artemis:
     image: apache/activemq-artemis:latest-alpine
     environment:

--- a/docs/docs/en/redis/cluster/index.md
+++ b/docs/docs/en/redis/cluster/index.md
@@ -1,0 +1,126 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 10
+---
+
+# Redis Cluster
+
+[Redis Cluster](https://redis.io/docs/management/scaling/){.external-link target="_blank"} provides automatic sharding across multiple Redis nodes. When keys are distributed across cluster slots, a standalone `RedisBroker` connected to a single node will fail with `MOVED` errors for keys that belong to other shards.
+
+**FastStream** provides `RedisClusterBroker` to handle this transparently. It uses `redis.asyncio.cluster.RedisCluster` under the hood, which automatically routes commands to the correct cluster node.
+
+## Subscription Types
+
+`RedisClusterBroker` supports all three subscription types:
+
+- **Streams** — works with `redis-py >= 5.0.0`
+- **Lists** — works with `redis-py >= 5.0.0`
+- **Channels (Pub/Sub)** — requires `redis-py >= 8.0.0` (async cluster pubsub support)
+
+!!! note
+    As of May 2026, `redis-py 8.0` is in beta. To use channel subscribers on a cluster, install the beta: `pip install 'redis>=8.0.0b1'`
+
+## Basic Usage
+
+Replace `RedisBroker` with `RedisClusterBroker`. Point the URL at any node in the cluster:
+
+```python linenums="1"
+from faststream import FastStream
+from faststream.redis import RedisClusterBroker
+
+broker = RedisClusterBroker("redis://localhost:7000")
+app = FastStream(broker)
+
+@broker.subscriber(stream="orders")
+async def handle_order(order: dict) -> None:
+    print(f"Got order: {order}")
+
+@broker.publisher(stream="confirmations")
+@broker.subscriber(list="tasks")
+async def process_task(task: str) -> str:
+    return f"done: {task}"
+```
+
+## Connection Parameters
+
+`RedisClusterBroker` accepts a subset of the parameters from `RedisBroker` — only those supported by `RedisCluster`:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `url` | `redis://localhost:6379` | Redis Cluster node URL |
+| `host` | — | Override host from URL |
+| `port` | — | Override port from URL |
+| `client_name` | `None` | Client name for `CLIENT SETINFO` |
+| `max_connections` | `None` (defaults to `2^31`) | Max connections per node |
+| `socket_timeout` | `None` | Socket timeout in seconds |
+| `socket_connect_timeout` | `None` | Connection timeout in seconds |
+| `socket_keepalive` | `False` | Enable TCP keepalive |
+| `encoding` | `utf-8` | String encoding |
+| `security` | `None` | Security/TLS options |
+
+Parameters not supported by `RedisCluster` (such as `db`, `socket_read_size`, `retry_on_timeout`, `parser_class`, `encoder_class`) are automatically filtered out.
+
+## FastAPI Integration
+
+Use `RedisClusterRouter` as a drop-in replacement for `RedisRouter`:
+
+```python linenums="1"
+from fastapi import FastAPI
+from faststream.redis.fastapi import RedisClusterRouter
+
+router = RedisClusterRouter("redis://localhost:7000")
+
+@router.subscriber(stream="events")
+async def handle_event(event: dict) -> None:
+    print(event)
+
+app = FastAPI()
+app.include_router(router)
+```
+
+## Testing
+
+Use `TestRedisClusterBroker` to test without a real Redis Cluster:
+
+```python linenums="1"
+import pytest
+from faststream.redis import RedisClusterBroker, TestRedisClusterBroker
+
+broker = RedisClusterBroker()
+
+@broker.subscriber(stream="test")
+async def handler(msg: str) -> None:
+    ...
+
+@pytest.mark.asyncio
+async def test_publish():
+    async with TestRedisClusterBroker(broker) as br:
+        await br.publish("hello", stream="test")
+```
+
+## Docker Compose
+
+A single-node Redis Cluster for local development:
+
+```yaml
+services:
+  redis-cluster:
+    image: redis:alpine
+    command: >-
+      sh -c "redis-server
+      --port 7000
+      --cluster-enabled yes
+      --cluster-config-file nodes.conf
+      --cluster-node-timeout 5000
+      --appendonly yes
+      & sleep 2
+      && redis-cli --cluster create 127.0.0.1:7000 --cluster-yes
+      && wait"
+    ports:
+      - 7000:7000
+```

--- a/docs/docs/en/redis/index.md
+++ b/docs/docs/en/redis/index.md
@@ -58,4 +58,8 @@ Here's a simplified code example demonstrating how to establish a connection to 
 
 This minimal example illustrates how **FastStream** simplifies the process of connecting to **Redis** and performing basic message processing from the *in-channel* to the *out-channel*. Depending on your specific use case and requirements, you can further customize your **Redis** integration with **FastStream** to build efficient and responsive applications.
 
+### Redis Cluster Support
+
+If you are running a **Redis Cluster**, use `RedisClusterBroker` instead of `RedisBroker`. It automatically routes commands to the correct cluster node. See the [Redis Cluster](cluster/index.md){.internal-link} documentation for details.
+
 For more advanced configuration options and detailed usage instructions, please refer to the **FastStream Redis** documentation and the [official Redis documentation](https://redis.io/docs/latest/){.external-link target="_blank"}.

--- a/docs/docs/navigation_template.txt
+++ b/docs/docs/navigation_template.txt
@@ -128,6 +128,7 @@ search:
         - [Batching](redis/streams/batch.md)
         - [Acknowledgement](redis/streams/ack.md)
         - [Claiming](redis/streams/claiming.md)
+    - [Cluster](redis/cluster/index.md)
     - [RPC](redis/rpc.md)
     - [Pipeline](redis/pipeline.md)
     - [Message Information](redis/message.md)

--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -27,7 +27,7 @@ try:
     from .parser import BinaryMessageFormatV1
     from .response import RedisPublishCommand, RedisResponse
     from .schemas import ListSub, PubSub, StreamSub
-    from .testing import TestRedisBroker
+    from .testing import TestRedisBroker, TestRedisClusterBroker
 
 except ImportError as e:
     if "'redis'" not in e.msg:
@@ -59,4 +59,5 @@ __all__ = (
     "StreamSub",
     "TestApp",
     "TestRedisBroker",
+    "TestRedisClusterBroker",
 )

--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -16,7 +16,13 @@ try:
         RedisMessage,
         RedisStreamMessage,
     )
-    from .broker import RedisBroker, RedisPublisher, RedisRoute, RedisRouter
+    from .broker import (
+        RedisBroker,
+        RedisClusterBroker,
+        RedisPublisher,
+        RedisRoute,
+        RedisRouter,
+    )
     from .exceptions import StreamGroupNotFoundError
     from .parser import BinaryMessageFormatV1
     from .response import RedisPublishCommand, RedisResponse
@@ -39,6 +45,7 @@ __all__ = (
     "Redis",
     "RedisBroker",
     "RedisChannelMessage",
+    "RedisClusterBroker",
     "RedisListMessage",
     "RedisMessage",
     "RedisParserType",

--- a/faststream/redis/broker/__init__.py
+++ b/faststream/redis/broker/__init__.py
@@ -1,8 +1,10 @@
 from .broker import RedisBroker
+from .cluster import RedisClusterBroker
 from .router import RedisPublisher, RedisRoute, RedisRouter
 
 __all__ = (
     "RedisBroker",
+    "RedisClusterBroker",
     "RedisPublisher",
     "RedisRoute",
     "RedisRouter",

--- a/faststream/redis/broker/cluster.py
+++ b/faststream/redis/broker/cluster.py
@@ -19,6 +19,7 @@ from faststream.redis.broker.broker import RedisBroker
 from faststream.redis.broker.logging import make_redis_logger_state
 from faststream.redis.broker.registrator import RedisRegistrator
 from faststream.redis.configs import ClusterConnectionState, RedisBrokerConfig
+from faststream.redis.configs.state import _CLUSTER_UNSUPPORTED_KEYS
 from faststream.redis.parser import BinaryMessageFormatV1, MessageFormat
 from faststream.redis.publisher.producer import RedisFastProducer
 from faststream.redis.security import parse_security
@@ -88,6 +89,76 @@ class RedisClusterBroker(RedisBroker):
         provider: Optional["Provider"] = None,
         context: Optional["ContextRepo"] = None,
     ) -> None:
+        """Initialize the RedisClusterBroker.
+
+        Args:
+            url:
+                A Redis Cluster node URL. Defaults to "redis://localhost:6379".
+            host:
+                The Redis host to connect to. If not provided, it will be extracted from the URL.
+            port:
+                The Redis port to connect to. If not provided, it will be extracted from the URL.
+            client_name:
+                The name of the Redis client. Defaults to None.
+            health_check_interval:
+                The interval at which to perform health checks on the broker. Defaults to 0.
+            max_connections:
+                The maximum number of connections per node. Defaults to None (uses RedisCluster default of 2^31).
+            socket_timeout:
+                The timeout for socket operations. Defaults to None.
+            socket_connect_timeout:
+                The timeout for connecting sockets. Defaults to None.
+            socket_keepalive:
+                Whether to enable keep-alive on sockets. Defaults to False.
+            socket_keepalive_options:
+                Options for keep-alive on sockets. Defaults to None.
+            encoding:
+                The encoding used for sending and receiving data. Defaults to "utf-8".
+            encoding_errors:
+                How to handle encoding errors. Defaults to "strict".
+            graceful_timeout:
+                Graceful shutdown timeout. Broker waits for all running subscribers completion before shut down. Defaults to 15.0.
+            ack_policy:
+                Default acknowledgement policy for all subscribers. Individual subscribers can override.
+            decoder:
+                Custom decoder object. Defaults to None.
+            codec:
+                Custom codec object. Defaults to None.
+            parser:
+                Custom parser object. Defaults to None.
+            dependencies:
+                Dependencies to apply to all broker subscribers. Defaults to ().
+            middlewares:
+                Middlewares to apply to all broker publishers/subscribers. Defaults to ().
+            routers:
+                Routers to apply to broker. Defaults to ().
+            message_format:
+                What format to use when parsing messages. Defaults to BinaryMessageFormatV1.
+            security:
+                Security options to connect broker and generate AsyncAPI server security information. Defaults to None.
+            specification_url:
+                AsyncAPI hardcoded server addresses. Use ``servers`` if not specified. Defaults to None.
+            protocol:
+                AsyncAPI server protocol. Defaults to None.
+            protocol_version:
+                AsyncAPI server protocol version. Defaults to "custom".
+            description:
+                AsyncAPI server description. Defaults to None.
+            tags:
+                AsyncAPI server tags. Defaults to ().
+            logger:
+                User specified logger to pass into Context and log service messages. Defaults to EMPTY.
+            log_level:
+                Service messages log level. Defaults to logging.INFO.
+            apply_types:
+                Whether to use FastDepends or not. Defaults to True.
+            serializer:
+                Serializer object. Defaults to EMPTY.
+            provider:
+                Provider for FastDepends library. Defaults to None.
+            context:
+                Context repository for FastDepends library. Defaults to None.
+        """
         self.message_format = message_format
 
         if specification_url is None:
@@ -182,8 +253,6 @@ def _resolve_cluster_url_options(
     # ClusterConnectionState filters these, but we also strip them here to
     # keep the options dict tidy when it is passed as **kwargs to
     # super().__init__().
-    from faststream.redis.configs.state import _CLUSTER_UNSUPPORTED_KEYS
-
     for key in _CLUSTER_UNSUPPORTED_KEYS:
         url_options.pop(key, None)
 

--- a/faststream/redis/broker/cluster.py
+++ b/faststream/redis/broker/cluster.py
@@ -1,0 +1,194 @@
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    Union,
+)
+from urllib.parse import urlparse
+
+from fast_depends import Provider, dependency_provider
+from typing_extensions import override
+
+from faststream._internal.constants import EMPTY
+from faststream._internal.context.repository import ContextRepo
+from faststream._internal.di import FastDependsConfig
+from faststream.middlewares import AckPolicy
+from faststream.redis.broker.broker import RedisBroker
+from faststream.redis.broker.logging import make_redis_logger_state
+from faststream.redis.broker.registrator import RedisRegistrator
+from faststream.redis.configs import ClusterConnectionState, RedisBrokerConfig
+from faststream.redis.parser import BinaryMessageFormatV1, MessageFormat
+from faststream.redis.publisher.producer import RedisFastProducer
+from faststream.redis.security import parse_security
+from faststream.specification.schema import BrokerSpec
+
+if TYPE_CHECKING:
+    from fast_depends.dependencies import Dependant
+    from fast_depends.library.serializer import SerializerProto
+
+    from faststream._internal.basic_types import LoggerProto
+    from faststream._internal.parser import CodecProto
+    from faststream._internal.types import BrokerMiddleware, CustomCallable
+    from faststream.security import BaseSecurity
+    from faststream.specification.schema.extra import Tag, TagDict
+
+
+class RedisClusterBroker(RedisBroker):
+    """Redis Cluster broker.
+
+    Accepts the same subscription types as :class:`RedisBroker` (channels,
+    streams, lists) but connects via ``redis.asyncio.cluster.RedisCluster``
+    instead of ``redis.asyncio.client.Redis``.
+
+    .. note::
+
+        Channel (PubSub) subscribers require ``redis-py >= 8.0.0`` which
+        added async cluster pubsub support.  Streams and lists work with
+        ``redis-py >= 5.0.0``.
+    """
+
+    def __init__(
+        self,
+        url: str = "redis://localhost:6379",
+        *,
+        # Cluster-relevant connection kwargs
+        host: str = EMPTY,
+        port: str | int = EMPTY,
+        client_name: str | None = None,
+        health_check_interval: float = 0,
+        max_connections: int | None = None,
+        socket_timeout: float | None = None,
+        socket_connect_timeout: float | None = None,
+        socket_keepalive: bool = False,
+        socket_keepalive_options: Mapping[int, int | bytes] | None = None,
+        encoding: str = "utf-8",
+        encoding_errors: str = "strict",
+        # Broker args
+        graceful_timeout: float | None = 15.0,
+        ack_policy: AckPolicy = EMPTY,
+        decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
+        parser: Optional["CustomCallable"] = None,
+        dependencies: Iterable["Dependant"] = (),
+        middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
+        routers: Iterable[RedisRegistrator] = (),
+        message_format: type["MessageFormat"] = BinaryMessageFormatV1,
+        security: Optional["BaseSecurity"] = None,
+        specification_url: str | None = None,
+        protocol: str | None = None,
+        protocol_version: str | None = "custom",
+        description: str | None = None,
+        tags: Iterable[Union["Tag", "TagDict"]] = (),
+        logger: Optional["LoggerProto"] = EMPTY,
+        log_level: int = logging.INFO,
+        apply_types: bool = True,
+        serializer: Optional["SerializerProto"] = EMPTY,
+        provider: Optional["Provider"] = None,
+        context: Optional["ContextRepo"] = None,
+    ) -> None:
+        self.message_format = message_format
+
+        if specification_url is None:
+            specification_url = url
+
+        if protocol is None:
+            url_kwargs = urlparse(specification_url)
+            protocol = url_kwargs.scheme
+
+        connection_options = _resolve_cluster_url_options(
+            url,
+            security=security,
+            host=host,
+            port=port,
+            client_name=client_name,
+            health_check_interval=health_check_interval,
+            max_connections=max_connections,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            socket_keepalive=socket_keepalive,
+            socket_keepalive_options=socket_keepalive_options,
+            encoding=encoding,
+            encoding_errors=encoding_errors,
+        )
+
+        connection_state = ClusterConnectionState(connection_options)
+
+        # Skip RedisBroker.__init__ - call its parent directly so we can
+        # inject ClusterConnectionState instead of ConnectionState.
+        super(RedisBroker, self).__init__(
+            **connection_options,
+            routers=routers,
+            config=RedisBrokerConfig(
+                connection=connection_state,
+                producer=RedisFastProducer(
+                    connection=connection_state,
+                    parser=parser,
+                    decoder=decoder,
+                    message_format=self.message_format,
+                    serializer=serializer,
+                ),
+                message_format=self.message_format,
+                # both args
+                broker_middlewares=middlewares,
+                broker_parser=parser,
+                broker_decoder=decoder,
+                broker_codec=codec,
+                logger=make_redis_logger_state(
+                    logger=logger,
+                    log_level=log_level,
+                ),
+                fd_config=FastDependsConfig(
+                    use_fastdepends=apply_types,
+                    serializer=serializer,
+                    provider=provider or dependency_provider,
+                    context=context or ContextRepo(),
+                ),
+                # subscriber args
+                broker_dependencies=dependencies,
+                graceful_timeout=graceful_timeout,
+                ack_policy=ack_policy,
+                extra_context={
+                    "broker": self,
+                },
+            ),
+            specification=BrokerSpec(
+                description=description,
+                url=[specification_url],
+                protocol=protocol,
+                protocol_version=protocol_version,
+                security=security,
+                tags=tags,
+            ),
+        )
+
+    @override
+    async def _connect(self) -> Any:
+        await self.config.connect()
+        return self.config.broker_config.connection.client
+
+
+def _resolve_cluster_url_options(
+    url: str,
+    *,
+    security: Optional["BaseSecurity"],
+    **kwargs: Any,
+) -> dict[str, Any]:
+    from redis.asyncio.connection import parse_url
+
+    url_options: dict[str, Any] = dict(parse_url(url))
+    # parse_url may include keys that RedisCluster doesn't accept (e.g. db).
+    # ClusterConnectionState filters these, but we also strip them here to
+    # keep the options dict tidy when it is passed as **kwargs to
+    # super().__init__().
+    from faststream.redis.configs.state import _CLUSTER_UNSUPPORTED_KEYS
+
+    for key in _CLUSTER_UNSUPPORTED_KEYS:
+        url_options.pop(key, None)
+
+    return {
+        **url_options,
+        **parse_security(security),
+        **{k: v for k, v in kwargs.items() if v is not EMPTY},
+    }

--- a/faststream/redis/configs/__init__.py
+++ b/faststream/redis/configs/__init__.py
@@ -1,7 +1,8 @@
 from .broker import RedisBrokerConfig
-from .state import ConnectionState
+from .state import ClusterConnectionState, ConnectionState
 
 __all__ = (
+    "ClusterConnectionState",
     "ConnectionState",
     "RedisBrokerConfig",
 )

--- a/faststream/redis/configs/state.py
+++ b/faststream/redis/configs/state.py
@@ -2,9 +2,14 @@ from typing import Any
 
 from redis.asyncio.client import Redis
 from redis.asyncio.connection import ConnectionPool
+from redis.driver_info import DriverInfo
 
 from faststream.__about__ import __version__
 from faststream.exceptions import IncorrectState
+
+
+def _make_driver_info() -> DriverInfo:
+    return DriverInfo().add_upstream_driver("faststream", __version__)
 
 
 class ConnectionState:
@@ -28,8 +33,7 @@ class ConnectionState:
     async def connect(self) -> "Redis[bytes]":
         pool = ConnectionPool(
             **self._options,
-            lib_name="faststream",
-            lib_version=__version__,
+            driver_info=_make_driver_info(),
         )
         client: Redis[bytes] = Redis.from_pool(pool)  # type: ignore[attr-defined]
 

--- a/faststream/redis/configs/state.py
+++ b/faststream/redis/configs/state.py
@@ -12,6 +12,34 @@ def _make_driver_info() -> DriverInfo:
     return DriverInfo().add_upstream_driver("faststream", __version__)
 
 
+def _cluster_driver_kwargs() -> dict[str, Any]:
+    """Return driver identification kwargs compatible with the installed redis-py.
+
+    ``RedisCluster`` gained the ``driver_info`` parameter in redis-py 8.x.
+    Older versions (7.x) only accept ``lib_name`` / ``lib_version``.
+    """
+    import inspect
+
+    from redis.asyncio.cluster import RedisCluster
+
+    if "driver_info" in inspect.signature(RedisCluster.__init__).parameters:
+        return {"driver_info": _make_driver_info()}
+    return {"lib_name": "faststream", "lib_version": __version__}
+
+
+# Keys from RedisBroker.__init__ that RedisCluster does not accept.
+_CLUSTER_UNSUPPORTED_KEYS: frozenset[str] = frozenset({
+    "db",
+    "connection_class",
+    "socket_read_size",
+    "socket_type",
+    "retry_on_timeout",
+    "parser_class",
+    "encoder_class",
+    "decode_responses",
+})
+
+
 class ConnectionState:
     def __init__(self, options: dict[str, Any] | None = None) -> None:
         self._options = options or {}
@@ -41,6 +69,42 @@ class ConnectionState:
         self._connected = True
 
         return client
+
+    async def disconnect(self) -> None:
+        if self._client:
+            await self._client.aclose()  # type: ignore[attr-defined]
+
+        self._client = None
+        self._connected = False
+
+
+class ClusterConnectionState(ConnectionState):
+    """Connection state backed by ``redis.asyncio.cluster.RedisCluster``."""
+
+    def __init__(self, options: dict[str, Any] | None = None) -> None:
+        raw = dict(options or {})
+
+        # Strip keys that RedisCluster does not accept.
+        for key in _CLUSTER_UNSUPPORTED_KEYS:
+            raw.pop(key, None)
+
+        # RedisCluster requires max_connections; default mirrors its own default.
+        raw.setdefault("max_connections", 2**31)
+
+        super().__init__(raw)
+
+    async def connect(self) -> "Redis[bytes]":
+        from redis.asyncio.cluster import RedisCluster
+
+        client: RedisCluster[bytes] = RedisCluster(
+            **self._options,
+            **_cluster_driver_kwargs(),
+        )
+
+        self._client = client  # type: ignore[assignment]
+        self._connected = True
+
+        return client  # type: ignore[return-value]
 
     async def disconnect(self) -> None:
         if self._client:

--- a/faststream/redis/fastapi/__init__.py
+++ b/faststream/redis/fastapi/__init__.py
@@ -6,15 +6,16 @@ from faststream._internal.fastapi.context import Context, ContextRepo, Logger
 from faststream.redis.broker.broker import RedisBroker as RB
 from faststream.redis.message import BaseMessage as RM  # noqa: N814
 
+from .cluster import RedisClusterRouter
 from .fastapi import RedisRouter
 
 __all__ = (
-    "Context",
     "ContextRepo",
     "Logger",
     "Redis",
     "RedisBroker",
     "RedisChannelMessage",
+    "RedisClusterRouter",
     "RedisRouter",
 )
 

--- a/faststream/redis/fastapi/__init__.py
+++ b/faststream/redis/fastapi/__init__.py
@@ -10,6 +10,7 @@ from .cluster import RedisClusterRouter
 from .fastapi import RedisRouter
 
 __all__ = (
+    "Context",
     "ContextRepo",
     "Logger",
     "Redis",

--- a/faststream/redis/fastapi/cluster.py
+++ b/faststream/redis/fastapi/cluster.py
@@ -13,7 +13,7 @@ from fastapi.routing import APIRoute
 from fastapi.utils import generate_unique_id
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute
-from typing_extensions import override
+from typing_extensions import overload, override
 
 from faststream.__about__ import SERVICE_NAME
 from faststream._internal.constants import EMPTY
@@ -39,6 +39,16 @@ if TYPE_CHECKING:
     )
     from faststream.redis.publisher.factory import PublisherType
     from faststream.redis.subscriber.factory import SubscriberType
+    from faststream.redis.subscriber.usecases import (
+        ChannelConcurrentSubscriber,
+        ChannelSubscriber,
+        ListBatchSubscriber,
+        ListConcurrentSubscriber,
+        ListSubscriber,
+        StreamBatchSubscriber,
+        StreamConcurrentSubscriber,
+        StreamSubscriber,
+    )
     from faststream.security import BaseSecurity
     from faststream.specification.base import SpecificationFactory
     from faststream.specification.schema.extra import Tag, TagDict
@@ -158,8 +168,208 @@ class RedisClusterRouter(StreamRouter[UnifyRedisDict]):
             generate_unique_id_function=generate_unique_id_function,
         )
 
+    @overload  # type: ignore[override]
+    def subscriber(
+        self,
+        channel: str | PubSub = ...,
+        *,
+        list: None = None,
+        stream: None = None,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: None = None,
+    ) -> "ChannelSubscriber": ...
+
+    @overload
+    def subscriber(
+        self,
+        channel: str | PubSub = ...,
+        *,
+        list: None = None,
+        stream: None = None,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: int = ...,
+    ) -> "ChannelConcurrentSubscriber": ...
+
+    @overload
+    def subscriber(
+        self,
+        channel: None = None,
+        *,
+        list: str = ...,
+        stream: None = None,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: None = None,
+    ) -> "ListSubscriber": ...
+
+    @overload
+    def subscriber(
+        self,
+        channel: None = None,
+        *,
+        list: str | ListSub = ...,
+        stream: None = None,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: None = None,
+    ) -> Union["ListSubscriber", "ListBatchSubscriber"]: ...
+
+    @overload
+    def subscriber(
+        self,
+        channel: None = None,
+        *,
+        list: str | ListSub = ...,
+        stream: None = None,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: int = ...,
+    ) -> "ListConcurrentSubscriber": ...
+
+    @overload
+    def subscriber(
+        self,
+        channel: None = None,
+        *,
+        list: None = None,
+        stream: str = ...,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: None = None,
+    ) -> "StreamSubscriber": ...
+
+    @overload
+    def subscriber(
+        self,
+        channel: None = None,
+        *,
+        list: None = None,
+        stream: str | StreamSub = ...,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: None = None,
+    ) -> Union["StreamSubscriber", "StreamBatchSubscriber"]: ...
+
+    @overload
+    def subscriber(
+        self,
+        channel: None = None,
+        *,
+        list: None = None,
+        stream: str | StreamSub = ...,
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: int = ...,
+    ) -> "StreamConcurrentSubscriber": ...
+
     @override
-    def subscriber(  # type: ignore[override]
+    def subscriber(
         self,
         channel: str | PubSub | None = None,
         *,

--- a/faststream/redis/fastapi/cluster.py
+++ b/faststream/redis/fastapi/cluster.py
@@ -1,0 +1,239 @@
+import logging
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    Union,
+    cast,
+)
+
+from fastapi.datastructures import Default
+from fastapi.routing import APIRoute
+from fastapi.utils import generate_unique_id
+from starlette.responses import JSONResponse
+from starlette.routing import BaseRoute
+from typing_extensions import override
+
+from faststream.__about__ import SERVICE_NAME
+from faststream._internal.constants import EMPTY
+from faststream._internal.context import ContextRepo
+from faststream._internal.fastapi.router import StreamRouter
+from faststream.middlewares import AckPolicy
+from faststream.redis.broker.cluster import RedisClusterBroker
+from faststream.redis.message import UnifyRedisDict
+from faststream.redis.schemas import ListSub, PubSub, StreamSub
+
+if TYPE_CHECKING:
+    from enum import Enum
+
+    from fastapi import params
+    from fastapi.types import IncEx
+    from starlette.responses import Response
+    from starlette.types import ASGIApp, Lifespan
+
+    from faststream._internal.basic_types import LoggerProto
+    from faststream._internal.types import (
+        BrokerMiddleware,
+        CustomCallable,
+    )
+    from faststream.redis.publisher.factory import PublisherType
+    from faststream.redis.subscriber.factory import SubscriberType
+    from faststream.security import BaseSecurity
+    from faststream.specification.base import SpecificationFactory
+    from faststream.specification.schema.extra import Tag, TagDict
+
+
+class RedisClusterRouter(StreamRouter[UnifyRedisDict]):
+    """A FastAPI router backed by :class:`RedisClusterBroker`."""
+
+    broker_class = RedisClusterBroker
+    broker: RedisClusterBroker
+
+    def __init__(
+        self,
+        url: str = "redis://localhost:6379",
+        *,
+        # Cluster-relevant connection kwargs
+        host: str = EMPTY,
+        port: str | int = EMPTY,
+        client_name: str | None = SERVICE_NAME,
+        health_check_interval: float = 0,
+        max_connections: int | None = None,
+        socket_timeout: float | None = None,
+        socket_connect_timeout: float | None = None,
+        socket_keepalive: bool = False,
+        socket_keepalive_options: Mapping[int, int | bytes] | None = None,
+        encoding: str = "utf-8",
+        encoding_errors: str = "strict",
+        # broker base args
+        graceful_timeout: float | None = 15.0,
+        decoder: Optional["CustomCallable"] = None,
+        parser: Optional["CustomCallable"] = None,
+        middlewares: Sequence["BrokerMiddleware[Any, Any]"] = (),
+        # AsyncAPI args
+        security: Optional["BaseSecurity"] = None,
+        specification_url: str | None = None,
+        protocol: str | None = None,
+        protocol_version: str | None = "custom",
+        description: str | None = None,
+        specification: Optional["SpecificationFactory"] = None,
+        specification_tags: Iterable[Union["Tag", "TagDict"]] = (),
+        # logging args
+        logger: Optional["LoggerProto"] = EMPTY,
+        log_level: int = logging.INFO,
+        # StreamRouter options
+        setup_state: bool = True,
+        schema_url: str | None = "/asyncapi",
+        context: ContextRepo | None = None,
+        # FastAPI args
+        prefix: str = "",
+        tags: list[Union[str, "Enum"]] | None = None,
+        dependencies: Sequence["params.Depends"] | None = None,
+        default_response_class: type["Response"] = Default(JSONResponse),
+        responses: dict[int | str, dict[str, Any]] | None = None,
+        callbacks: list[BaseRoute] | None = None,
+        routes: list[BaseRoute] | None = None,
+        redirect_slashes: bool = True,
+        default: Optional["ASGIApp"] = None,
+        dependency_overrides_provider: Any | None = None,
+        route_class: type["APIRoute"] = APIRoute,
+        on_startup: Sequence[Callable[[], Any]] | None = None,
+        on_shutdown: Sequence[Callable[[], Any]] | None = None,
+        lifespan: Optional["Lifespan[Any]"] = None,
+        deprecated: bool | None = None,
+        include_in_schema: bool = True,
+        generate_unique_id_function: Callable[["APIRoute"], str] = Default(
+            generate_unique_id
+        ),
+    ) -> None:
+        super().__init__(
+            url=url,
+            host=host,
+            port=port,
+            health_check_interval=health_check_interval,
+            max_connections=max_connections,
+            socket_timeout=socket_timeout,
+            socket_connect_timeout=socket_connect_timeout,
+            socket_keepalive=socket_keepalive,
+            socket_keepalive_options=socket_keepalive_options,
+            encoding=encoding,
+            encoding_errors=encoding_errors,
+            graceful_timeout=graceful_timeout,
+            decoder=decoder,
+            parser=parser,
+            middlewares=middlewares,
+            client_name=client_name,
+            schema_url=schema_url,
+            setup_state=setup_state,
+            context=context,
+            # logger options
+            logger=logger,
+            log_level=log_level,
+            # AsyncAPI options
+            security=security,
+            protocol=protocol,
+            description=description,
+            protocol_version=protocol_version,
+            specification_tags=specification_tags,
+            specification_url=specification_url,
+            specification=specification,
+            # FastAPI kwargs
+            prefix=prefix,
+            tags=tags,
+            dependencies=dependencies,
+            default_response_class=default_response_class,
+            responses=responses,
+            callbacks=callbacks,
+            routes=routes,
+            redirect_slashes=redirect_slashes,
+            default=default,
+            dependency_overrides_provider=dependency_overrides_provider,
+            route_class=route_class,
+            on_startup=on_startup,
+            on_shutdown=on_shutdown,
+            deprecated=deprecated,
+            include_in_schema=include_in_schema,
+            lifespan=lifespan,
+            generate_unique_id_function=generate_unique_id_function,
+        )
+
+    @override
+    def subscriber(  # type: ignore[override]
+        self,
+        channel: str | PubSub | None = None,
+        *,
+        list: str | ListSub | None = None,
+        stream: str | StreamSub | None = None,
+        # broker arguments
+        dependencies: Iterable["params.Depends"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        # AsyncAPI information
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+        # FastAPI args
+        response_model: Any = Default(None),
+        response_model_include: Optional["IncEx"] = None,
+        response_model_exclude: Optional["IncEx"] = None,
+        response_model_by_alias: bool = True,
+        response_model_exclude_unset: bool = False,
+        response_model_exclude_defaults: bool = False,
+        response_model_exclude_none: bool = False,
+        max_workers: int | None = None,
+    ) -> "SubscriberType":
+        return cast(
+            "SubscriberType",
+            super().subscriber(
+                channel=channel,
+                max_workers=max_workers or 1,
+                list=list,
+                stream=stream,
+                dependencies=dependencies,
+                parser=parser,
+                decoder=decoder,
+                ack_policy=ack_policy,
+                no_reply=no_reply,
+                title=title,
+                description=description,
+                include_in_schema=include_in_schema,
+                # FastAPI args
+                response_model=response_model,
+                response_model_include=response_model_include,
+                response_model_exclude=response_model_exclude,
+                response_model_by_alias=response_model_by_alias,
+                response_model_exclude_unset=response_model_exclude_unset,
+                response_model_exclude_defaults=response_model_exclude_defaults,
+                response_model_exclude_none=response_model_exclude_none,
+            ),
+        )
+
+    @override
+    def publisher(
+        self,
+        channel: str | PubSub | None = None,
+        list: str | ListSub | None = None,
+        stream: str | StreamSub | None = None,
+        headers: dict[str, Any] | None = None,
+        reply_to: str = "",
+        # AsyncAPI information
+        title: str | None = None,
+        description: str | None = None,
+        schema: Any | None = None,
+        include_in_schema: bool = True,
+    ) -> "PublisherType":
+        return self.broker.publisher(
+            channel,
+            list=list,
+            stream=stream,
+            headers=headers,
+            reply_to=reply_to,
+            # AsyncAPI options
+            title=title,
+            description=description,
+            schema=schema,
+            include_in_schema=include_in_schema,
+        )

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -19,6 +19,7 @@ from faststream._internal.testing.broker import TestBroker, change_producer
 from faststream.exceptions import SetupError, SubscriberNotFound
 from faststream.message import gen_cor_id
 from faststream.redis.broker.broker import RedisBroker
+from faststream.redis.broker.cluster import RedisClusterBroker
 from faststream.redis.message import (
     BatchListMessage,
     BatchStreamMessage,
@@ -42,11 +43,38 @@ if TYPE_CHECKING:
     from faststream.redis.publisher.usecase import LogicPublisher
     from faststream.redis.subscriber.usecases.basic import LogicSubscriber
 
-__all__ = ("TestRedisBroker",)
+__all__ = (
+    "TestRedisBroker",
+    "TestRedisClusterBroker",
+)
 
 
 class TestRedisBroker(TestBroker[RedisBroker]):
     """A class to test Redis brokers."""
+
+    @staticmethod
+    async def _fake_connect(  # type: ignore[override]
+        broker: RedisBroker,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncMock:
+        connection = MagicMock()
+
+        pub_sub = AsyncMock()
+
+        async def get_msg(*args: Any, timeout: float, **kwargs: Any) -> None:
+            await anyio.sleep(timeout)
+
+        pub_sub.get_message = get_msg
+
+        connection.pubsub.side_effect = lambda: pub_sub
+        connection.aclose = AsyncMock()
+
+        connection.xack = AsyncMock()
+        connection.xdel = AsyncMock()
+
+        broker.config.broker_config.connection._client = connection
+        return connection
 
     @contextmanager
     def _patch_producer(self, broker: RedisBroker) -> Iterator[None]:
@@ -89,30 +117,6 @@ class TestRedisBroker(TestBroker[RedisBroker]):
             is_real = True
 
         return sub, is_real
-
-    @staticmethod
-    async def _fake_connect(  # type: ignore[override]
-        broker: RedisBroker,
-        *args: Any,
-        **kwargs: Any,
-    ) -> AsyncMock:
-        connection = MagicMock()
-
-        pub_sub = AsyncMock()
-
-        async def get_msg(*args: Any, timeout: float, **kwargs: Any) -> None:
-            await anyio.sleep(timeout)
-
-        pub_sub.get_message = get_msg
-
-        connection.pubsub.side_effect = lambda: pub_sub
-        connection.aclose = AsyncMock()
-
-        connection.xack = AsyncMock()
-        connection.xdel = AsyncMock()
-
-        broker.config.broker_config.connection._client = connection
-        return connection
 
 
 class FakeProducer(RedisFastProducer):
@@ -404,3 +408,57 @@ def _make_destination_kwargs(cmd: RedisPublishCommand) -> _DestinationKwargs:
         raise SetupError(INCORRECT_SETUP_MSG)
 
     return destination
+
+
+class TestRedisClusterBroker(TestBroker[RedisClusterBroker]):
+    """A class to test Redis Cluster brokers."""
+
+    @contextmanager
+    def _patch_producer(
+        self,
+        broker: RedisClusterBroker,
+    ) -> Iterator[None]:
+        with ExitStack() as es:
+            es.enter_context(
+                change_producer(
+                    broker.config.broker_config, FakeProducer(broker, broker.config)
+                ),
+            )
+
+            for publisher in cast("list[LogicPublisher]", broker.publishers):
+                es.enter_context(
+                    change_producer(publisher, FakeProducer(broker, publisher.config)),
+                )
+
+            yield
+
+    @staticmethod
+    def create_publisher_fake_subscriber(
+        broker: RedisClusterBroker,
+        publisher: "LogicPublisher",
+    ) -> tuple["LogicSubscriber", bool]:
+        return TestRedisBroker.create_publisher_fake_subscriber(broker, publisher)
+
+    @staticmethod
+    async def _fake_connect(  # type: ignore[override]
+        broker: RedisClusterBroker,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncMock:
+        connection = MagicMock()
+
+        pub_sub = AsyncMock()
+
+        async def get_msg(*args: Any, timeout: float, **kwargs: Any) -> None:
+            await anyio.sleep(timeout)
+
+        pub_sub.get_message = get_msg
+
+        connection.pubsub.side_effect = lambda: pub_sub
+        connection.aclose = AsyncMock()
+
+        connection.xack = AsyncMock()
+        connection.xdel = AsyncMock()
+
+        broker.config.broker_config.connection._client = connection
+        return connection

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -52,30 +52,6 @@ __all__ = (
 class TestRedisBroker(TestBroker[RedisBroker]):
     """A class to test Redis brokers."""
 
-    @staticmethod
-    async def _fake_connect(  # type: ignore[override]
-        broker: RedisBroker,
-        *args: Any,
-        **kwargs: Any,
-    ) -> AsyncMock:
-        connection = MagicMock()
-
-        pub_sub = AsyncMock()
-
-        async def get_msg(*args: Any, timeout: float, **kwargs: Any) -> None:
-            await anyio.sleep(timeout)
-
-        pub_sub.get_message = get_msg
-
-        connection.pubsub.side_effect = lambda: pub_sub
-        connection.aclose = AsyncMock()
-
-        connection.xack = AsyncMock()
-        connection.xdel = AsyncMock()
-
-        broker.config.broker_config.connection._client = connection
-        return connection
-
     @contextmanager
     def _patch_producer(self, broker: RedisBroker) -> Iterator[None]:
         with ExitStack() as es:
@@ -117,6 +93,30 @@ class TestRedisBroker(TestBroker[RedisBroker]):
             is_real = True
 
         return sub, is_real
+
+    @staticmethod
+    async def _fake_connect(  # type: ignore[override]
+        broker: RedisBroker,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncMock:
+        connection = MagicMock()
+
+        pub_sub = AsyncMock()
+
+        async def get_msg(*args: Any, timeout: float, **kwargs: Any) -> None:
+            await anyio.sleep(timeout)
+
+        pub_sub.get_message = get_msg
+
+        connection.pubsub.side_effect = lambda: pub_sub
+        connection.aclose = AsyncMock()
+
+        connection.xack = AsyncMock()
+        connection.xdel = AsyncMock()
+
+        broker.config.broker_config.connection._client = connection
+        return connection
 
 
 class FakeProducer(RedisFastProducer):
@@ -445,20 +445,4 @@ class TestRedisClusterBroker(TestBroker[RedisClusterBroker]):
         *args: Any,
         **kwargs: Any,
     ) -> AsyncMock:
-        connection = MagicMock()
-
-        pub_sub = AsyncMock()
-
-        async def get_msg(*args: Any, timeout: float, **kwargs: Any) -> None:
-            await anyio.sleep(timeout)
-
-        pub_sub.get_message = get_msg
-
-        connection.pubsub.side_effect = lambda: pub_sub
-        connection.aclose = AsyncMock()
-
-        connection.xack = AsyncMock()
-        connection.xdel = AsyncMock()
-
-        broker.config.broker_config.connection._client = connection
-        return connection
+        return await TestRedisBroker._fake_connect(broker, *args, **kwargs)

--- a/justfile
+++ b/justfile
@@ -258,6 +258,23 @@ test-redis-all +param="tests/":
   docker compose exec faststream uv run pytest {{param}} -m "redis or (redis and slow)" -n auto
 
 
+# Redis Cluster
+[doc("Run redis-cluster container")]
+[group("redis")]
+redis-cluster-up:
+  docker compose up -d redis-cluster
+
+[doc("Stop redis-cluster container")]
+[group("redis")]
+redis-cluster-stop:
+  docker compose stop redis-cluster
+
+[doc("Show redis-cluster logs")]
+[group("redis")]
+redis-cluster-logs:
+  docker compose logs -f redis-cluster
+
+
 # Nats
 [doc("Run nats container")]
 [group("nats")]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ confluent = [
 
 nats = ["nats-py>=2.12.0,<=3.0.0"]
 
-redis = ["redis>=5.0.0,<8.0.0"]
+redis = ["redis>=5.0.0,<9.0.0"]
 
 mqtt = ["zmqtt>=0.0.4"]
 

--- a/tests/brokers/redis/test_cluster.py
+++ b/tests/brokers/redis/test_cluster.py
@@ -1,0 +1,155 @@
+"""Unit tests for RedisClusterBroker and ClusterConnectionState."""
+
+import pytest
+
+from faststream.redis import RedisClusterBroker, TestRedisClusterBroker
+from faststream.redis.configs.state import (
+    _CLUSTER_UNSUPPORTED_KEYS,
+    ClusterConnectionState,
+)
+
+# --- ClusterConnectionState ---
+
+
+@pytest.mark.redis()
+def test_cluster_state_filters_unsupported_keys() -> None:
+    options = {
+        "host": "localhost",
+        "port": 6379,
+        "db": 1,
+        "socket_read_size": 65536,
+        "socket_type": 0,
+        "retry_on_timeout": True,
+        "parser_class": object,
+        "encoder_class": object,
+        "connection_class": object,
+        "decode_responses": True,
+        "encoding": "utf-8",
+    }
+    state = ClusterConnectionState(options)
+    for key in _CLUSTER_UNSUPPORTED_KEYS:
+        assert key not in state._options
+    # Valid keys should be preserved
+    assert state._options["host"] == "localhost"
+    assert state._options["port"] == 6379
+    assert state._options["encoding"] == "utf-8"
+
+
+@pytest.mark.redis()
+def test_cluster_state_defaults_max_connections() -> None:
+    state = ClusterConnectionState({})
+    assert state._options["max_connections"] == 2**31
+
+
+@pytest.mark.redis()
+def test_cluster_state_preserves_max_connections() -> None:
+    state = ClusterConnectionState({"max_connections": 100})
+    assert state._options["max_connections"] == 100
+
+
+@pytest.mark.redis()
+def test_cluster_state_not_connected_initially() -> None:
+    state = ClusterConnectionState()
+    assert not state
+
+
+@pytest.mark.redis()
+def test_cluster_state_client_raises_when_not_connected() -> None:
+    state = ClusterConnectionState()
+    with pytest.raises(Exception, match="Connection is not available"):
+        _ = state.client
+
+
+# --- RedisClusterBroker ---
+
+
+@pytest.mark.redis()
+def test_cluster_broker_instantiates() -> None:
+    broker = RedisClusterBroker("redis://localhost:6379")
+    assert broker is not None
+
+
+@pytest.mark.redis()
+def test_cluster_broker_uses_cluster_connection_state() -> None:
+    broker = RedisClusterBroker("redis://localhost:7000")
+    connection = broker.config.broker_config.connection
+    assert isinstance(connection, ClusterConnectionState)
+
+
+@pytest.mark.redis()
+def test_cluster_broker_filters_db_from_url() -> None:
+    """Even if the URL has /1, the cluster state should strip db."""
+    broker = RedisClusterBroker("redis://localhost:7000/1")
+    connection = broker.config.broker_config.connection
+    assert "db" not in connection._options
+
+
+@pytest.mark.redis()
+def test_cluster_broker_subscriber_registration() -> None:
+    """Subscribers can be registered on the cluster broker."""
+    broker = RedisClusterBroker()
+
+    @broker.subscriber(stream="test-stream")
+    async def handler(msg: str) -> None:
+        pass
+
+    assert len(list(broker.subscribers)) == 1
+
+
+@pytest.mark.redis()
+def test_cluster_broker_publisher_registration() -> None:
+    """Publishers can be registered on the cluster broker."""
+    broker = RedisClusterBroker()
+    pub = broker.publisher(stream="test-stream")
+    assert pub is not None
+
+
+# --- TestRedisClusterBroker ---
+
+
+@pytest.mark.redis()
+@pytest.mark.asyncio()
+async def test_test_cluster_broker_publishes() -> None:
+    broker = RedisClusterBroker()
+    received = []
+
+    @broker.subscriber(list="test-list")
+    async def handler(msg: str) -> None:
+        received.append(msg)
+
+    async with TestRedisClusterBroker(broker) as br:
+        await br.publish("hello", list="test-list")
+
+    assert received == ["hello"]
+
+
+@pytest.mark.redis()
+@pytest.mark.asyncio()
+async def test_test_cluster_broker_stream() -> None:
+    broker = RedisClusterBroker()
+    received = []
+
+    @broker.subscriber(stream="test-stream")
+    async def handler(msg: str) -> None:
+        received.append(msg)
+
+    async with TestRedisClusterBroker(broker) as br:
+        await br.publish("world", stream="test-stream")
+
+    assert received == ["world"]
+
+
+@pytest.mark.redis()
+@pytest.mark.asyncio()
+async def test_test_cluster_broker_channel() -> None:
+    broker = RedisClusterBroker()
+    received = []
+
+    @broker.subscriber(channel="test-channel")
+    async def handler(msg: str) -> None:
+        received.append(msg)
+
+    async with TestRedisClusterBroker(broker) as br:
+        await br.publish("hi", channel="test-channel")
+
+    assert received == ["hi"]

--- a/tests/brokers/redis/test_cluster_connect.py
+++ b/tests/brokers/redis/test_cluster_connect.py
@@ -1,0 +1,116 @@
+"""Integration tests for RedisClusterBroker.
+
+These tests require a running Redis Cluster on localhost:7000.
+Start one with: docker compose up -d redis-cluster
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from faststream.redis import RedisClusterBroker, StreamSub
+from tests.brokers.base.connection import BrokerConnectionTestcase
+
+
+@pytest.mark.connected()
+@pytest.mark.redis()
+class TestClusterConnection(BrokerConnectionTestcase):
+    broker = RedisClusterBroker
+
+    def get_broker_args(self, settings: Any) -> dict[str, Any]:
+        return {"url": "redis://localhost:7000"}
+
+    @pytest.mark.asyncio()
+    async def test_cluster_connect(self) -> None:
+        async with RedisClusterBroker("redis://localhost:7000") as broker:
+            assert await broker.ping(timeout=5.0)
+
+
+@pytest.mark.connected()
+@pytest.mark.redis()
+@pytest.mark.asyncio()
+class TestClusterConsume:
+    async def test_cluster_stream_publish_consume(
+        self,
+        queue: str,
+    ) -> None:
+        mock = MagicMock()
+        event = asyncio.Event()
+
+        broker = RedisClusterBroker("redis://localhost:7000")
+
+        @broker.subscriber(stream=queue)
+        async def handler(msg: str) -> None:
+            mock(msg)
+            event.set()
+
+        async with broker:
+            await broker.start()
+
+            await asyncio.wait(
+                (
+                    asyncio.create_task(broker.publish("hello", stream=queue)),
+                    asyncio.create_task(event.wait()),
+                ),
+                timeout=10,
+            )
+
+        mock.assert_called_once_with("hello")
+
+    async def test_cluster_list_publish_consume(
+        self,
+        queue: str,
+    ) -> None:
+        mock = MagicMock()
+        event = asyncio.Event()
+
+        broker = RedisClusterBroker("redis://localhost:7000")
+
+        @broker.subscriber(list=queue)
+        async def handler(msg: str) -> None:
+            mock(msg)
+            event.set()
+
+        async with broker:
+            await broker.start()
+
+            await asyncio.wait(
+                (
+                    asyncio.create_task(broker.publish("world", list=queue)),
+                    asyncio.create_task(event.wait()),
+                ),
+                timeout=10,
+            )
+
+        mock.assert_called_once_with("world")
+
+    async def test_cluster_stream_with_group(
+        self,
+        queue: str,
+    ) -> None:
+        mock = MagicMock()
+        event = asyncio.Event()
+
+        broker = RedisClusterBroker("redis://localhost:7000")
+
+        @broker.subscriber(
+            stream=StreamSub(queue, group="test-group", consumer="c1"),
+        )
+        async def handler(msg: str) -> None:
+            mock(msg)
+            event.set()
+
+        async with broker:
+            await broker.start()
+
+            await asyncio.wait(
+                (
+                    asyncio.create_task(broker.publish("grouped", stream=queue)),
+                    asyncio.create_task(event.wait()),
+                ),
+                timeout=10,
+            )
+
+        mock.assert_called_once_with("grouped")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1012,7 +1012,7 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "aio-pika", marker = "extra == 'rabbit'", specifier = ">=9,<10" },
-    { name = "aiokafka", marker = "extra == 'kafka'", specifier = ">=0.9,<0.14" },
+    { name = "aiokafka", marker = "extra == 'kafka'", specifier = ">=0.9,<0.15" },
     { name = "anyio", specifier = ">=4.0,<5" },
     { name = "confluent-kafka", marker = "python_full_version >= '3.13' and extra == 'confluent'", specifier = ">=2.6,!=2.8.1,<3" },
     { name = "confluent-kafka", marker = "python_full_version < '3.13' and extra == 'confluent'", specifier = ">=2,!=2.8.1,<3" },
@@ -1020,7 +1020,7 @@ requires-dist = [
     { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.12.0,<=3.0.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.24.0,<2.0.0" },
     { name = "prometheus-client", marker = "extra == 'prometheus'", specifier = ">=0.20.0,<0.30.0" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<8.0.0" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<9.0.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.9,!=0.12,<=0.21.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "watchfiles", marker = "extra == 'cli'", specifier = ">=0.15.0,<1.2.0" },


### PR DESCRIPTION
## Summary

Add `RedisClusterBroker` for Redis Cluster deployments, resolving #1170.

Uses `redis.asyncio.cluster.RedisCluster` under the hood so commands are
automatically routed to the correct cluster node — no more `MOVED` errors.

### What's included

- **`RedisClusterBroker`** — drop-in replacement for `RedisBroker` with cluster-compatible parameters
- **`ClusterConnectionState`** — connection lifecycle using `RedisCluster` directly (not `ConnectionPool`)
- **`TestRedisClusterBroker`** — mock-connection testing utility
- **`RedisClusterRouter`** — FastAPI integration with full `@overload` subscriber signatures
- **`driver_info` migration** — existing `ConnectionState` migrated from deprecated `lib_name`/`lib_version` to `DriverInfo` API
- **Docker Compose** — single-node Redis Cluster service on port 7000
- **Tests** — 13 unit tests + 6 integration tests (streams, lists, consumer groups)
- **Documentation** — cluster usage guide with examples, nav entry

### Subscription type support

| Type | Min redis-py |
|---|---|
| Streams | `>= 5.0.0` |
| Lists | `>= 5.0.0` |
| Channels (PubSub) | `>= 8.0.0` (async cluster pubsub, currently beta) |

### redis-py 8.x compatibility

Analysed the breaking changes in redis-py 8.0.0b1/b2. Default `legacy_responses=True`
preserves RESP2-compatible response shapes — no impact on faststream's stream/list/channel
parsing. The `redis` dependency upper bound is bumped from `<8.0.0` to `<9.0.0`.

### Closes

Closes #1170

---

[Warp conversation](https://app.warp.dev/conversation/889863b3-7f69-42d5-9f50-be0850ae6f00) · [Implementation plan](https://app.warp.dev/drive/notebook/vIrb4kaf5ihsth1IMPkG1x)

Co-Authored-By: Oz <oz-agent@warp.dev>