### PR TITLE
fix FastAPI RabbitMQ tutorial example compatibility with RabbitMQ 4.x

### DIFF
--- a/docs/docs_src/integrations/fastapi/rabbit/base.py
+++ b/docs/docs_src/integrations/fastapi/rabbit/base.py
@@ -2,6 +2,7 @@ from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 
 from faststream.rabbit.fastapi import RabbitRouter, Logger
+from faststream.rabbit import RabbitQueue
 
 router = RabbitRouter("amqp://guest:guest@localhost:5672/")
 
@@ -11,7 +12,7 @@ class Incoming(BaseModel):
 def call() -> bool:
     return True
 
-@router.subscriber("test")
+@router.subscriber(RabbitQueue("test", durable=True))
 @router.publisher("response")
 async def hello(message: Incoming, logger: Logger, dependency: bool = Depends(call)):
     logger.info("Incoming value: %s, depends value: %s" % (message.m, dependency))


### PR DESCRIPTION
# Description

This PR fixes a compatibility issue in the FastAPI integration tutorial for RabbitMQ (`docs/docs/en/docs_src/integrations/fastapi/rabbit/base.py`). 

Currently, the example uses @router.subscriber("test"). By default, passing a string name implicitly creates a queue with `durable=False` and `exclusive=False`. 

Starting from RabbitMQ 4.0, the combination of non-durable and non-exclusive queues (`transient_nonexcl_queues`) has been deprecated, and it is disabled by default as of RabbitMQ 4.3.0. Running the current tutorial example against the latest `rabbitmq:management` Docker image results in a fatal connection error: `aiormq.exceptions.ConnectionInternalError: INTERNAL_ERROR - Feature transient_nonexcl_queues is deprecated`.

Fixes #2890

## Type of change
- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`

