### PR TITLE
fix(rabbit): default RabbitQueue and RabbitExchange to durable=True

### DIFF
--- a/faststream/rabbit/schemas/exchange.py
+++ b/faststream/rabbit/schemas/exchange.py
@@ -72,7 +72,7 @@ class RabbitExchange(NameRequired):
         self,
         name: str = "",
         type: ExchangeType = ExchangeType.DIRECT,
-        durable: bool = False,
+        durable: bool = True,
         auto_delete: bool = False,
         # custom
         declare: bool = True,

--- a/faststream/rabbit/schemas/queue.py
+++ b/faststream/rabbit/schemas/queue.py
@@ -196,7 +196,7 @@ class RabbitQueue(NameRequired):
                 error_msg = "Quorum and Stream queues must be durable"
                 raise SetupError(error_msg)
         elif durable is EMPTY:
-            durable = False
+            durable = True
 
         super().__init__(name)
 

--- a/tests/asyncapi/rabbit/v2_6_0/test_arguments.py
+++ b/tests/asyncapi/rabbit/v2_6_0/test_arguments.py
@@ -25,7 +25,7 @@ class TestArguments(ArgumentsTestcase):
                 "bindingVersion": "0.2.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "topic",
                     "vhost": "/",
@@ -33,7 +33,7 @@ class TestArguments(ArgumentsTestcase):
                 "is": "routingKey",
                 "queue": {
                     "autoDelete": True,
-                    "durable": False,
+                    "durable": True,
                     "exclusive": False,
                     "name": "test",
                     "vhost": "/",
@@ -58,7 +58,7 @@ class TestArguments(ArgumentsTestcase):
                 "bindingVersion": "0.2.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "fanout",
                     "vhost": "/",
@@ -84,7 +84,7 @@ class TestArguments(ArgumentsTestcase):
                 "bindingVersion": "0.2.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "headers",
                     "vhost": "/",
@@ -110,7 +110,7 @@ class TestArguments(ArgumentsTestcase):
                 "bindingVersion": "0.2.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "x-delayed-message",
                     "vhost": "/",
@@ -136,7 +136,7 @@ class TestArguments(ArgumentsTestcase):
                 "bindingVersion": "0.2.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "x-consistent-hash",
                     "vhost": "/",
@@ -162,7 +162,7 @@ class TestArguments(ArgumentsTestcase):
                 "bindingVersion": "0.2.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "x-modulus-hash",
                     "vhost": "/",

--- a/tests/asyncapi/rabbit/v2_6_0/test_connection.py
+++ b/tests/asyncapi/rabbit/v2_6_0/test_connection.py
@@ -68,7 +68,7 @@ def test_custom() -> None:
                         "is": "routingKey",
                         "queue": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "exclusive": False,
                             "name": "test",
                             "vhost": "/vh",

--- a/tests/asyncapi/rabbit/v2_6_0/test_naming.py
+++ b/tests/asyncapi/rabbit/v2_6_0/test_naming.py
@@ -64,7 +64,7 @@ class TestNaming(NamingTestCase):
                             "bindingVersion": "0.2.0",
                             "queue": {
                                 "name": "test",
-                                "durable": False,
+                                "durable": True,
                                 "exclusive": False,
                                 "autoDelete": False,
                                 "vhost": "/",

--- a/tests/asyncapi/rabbit/v2_6_0/test_publisher.py
+++ b/tests/asyncapi/rabbit/v2_6_0/test_publisher.py
@@ -23,7 +23,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.2.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "direct",
                             "vhost": "/vhost",
@@ -65,7 +65,7 @@ class TestArguments(PublisherTestcase):
                 "bindingVersion": "0.2.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "topic",
                     "vhost": "/",
@@ -73,7 +73,7 @@ class TestArguments(PublisherTestcase):
                 "is": "routingKey",
                 "queue": {
                     "autoDelete": True,
-                    "durable": False,
+                    "durable": True,
                     "exclusive": False,
                     "name": "test",
                     "vhost": "/",
@@ -99,7 +99,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.2.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "fanout",
                             "vhost": "/",
@@ -140,7 +140,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.2.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "direct",
                             "vhost": "/vhost",
@@ -170,7 +170,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.2.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "direct",
                             "vhost": "/vhost",

--- a/tests/asyncapi/rabbit/v2_6_0/test_router.py
+++ b/tests/asyncapi/rabbit/v2_6_0/test_router.py
@@ -45,7 +45,7 @@ class TestRouter(RouterTestcase):
                         "bindingVersion": "0.2.0",
                         "queue": {
                             "name": "test_test",
-                            "durable": False,
+                            "durable": True,
                             "exclusive": False,
                             "autoDelete": False,
                             "vhost": "/",

--- a/tests/asyncapi/rabbit/v3_0_0/test_arguments.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_arguments.py
@@ -26,7 +26,7 @@ class TestArguments(ArgumentsTestcase):
                 "is": "queue",
                 "queue": {
                     "autoDelete": True,
-                    "durable": False,
+                    "durable": True,
                     "exclusive": False,
                     "name": "test",
                     "vhost": "/",
@@ -51,7 +51,7 @@ class TestArguments(ArgumentsTestcase):
                 "bindingVersion": "0.3.0",
                 "queue": {
                     "autoDelete": True,
-                    "durable": False,
+                    "durable": True,
                     "exclusive": False,
                     "name": "test",
                     "vhost": "/",

--- a/tests/asyncapi/rabbit/v3_0_0/test_naming.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_naming.py
@@ -70,7 +70,7 @@ class TestNaming(NamingTestCase):
                             "bindingVersion": "0.3.0",
                             "queue": {
                                 "name": "test",
-                                "durable": False,
+                                "durable": True,
                                 "exclusive": False,
                                 "autoDelete": False,
                                 "vhost": "/",

--- a/tests/asyncapi/rabbit/v3_0_0/test_publisher.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_publisher.py
@@ -24,7 +24,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.3.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "direct",
                             "vhost": "/vhost",
@@ -84,7 +84,7 @@ class TestArguments(PublisherTestcase):
                 "bindingVersion": "0.3.0",
                 "exchange": {
                     "autoDelete": False,
-                    "durable": False,
+                    "durable": True,
                     "name": "test-ex",
                     "type": "topic",
                     "vhost": "/",
@@ -112,7 +112,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.3.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "fanout",
                             "vhost": "/",
@@ -168,7 +168,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.3.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "direct",
                             "vhost": "/vhost",
@@ -194,7 +194,7 @@ class TestArguments(PublisherTestcase):
                         "bindingVersion": "0.3.0",
                         "exchange": {
                             "autoDelete": False,
-                            "durable": False,
+                            "durable": True,
                             "name": "test-ex",
                             "type": "direct",
                             "vhost": "/vhost",

--- a/tests/asyncapi/rabbit/v3_0_0/test_router.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_router.py
@@ -62,7 +62,7 @@ class TestRouter(RouterTestcase):
                             "bindingVersion": "0.3.0",
                             "queue": {
                                 "name": "test_test",
-                                "durable": False,
+                                "durable": True,
                                 "exclusive": False,
                                 "autoDelete": False,
                                 "vhost": "/",

--- a/tests/brokers/rabbit/test_schemas.py
+++ b/tests/brokers/rabbit/test_schemas.py
@@ -3,6 +3,14 @@ import pytest
 from faststream.rabbit import RabbitExchange, RabbitQueue
 
 
+def test_default_queue_is_durable() -> None:
+    assert RabbitQueue("test").durable is True
+
+
+def test_default_exchange_is_durable() -> None:
+    assert RabbitExchange("test").durable is True
+
+
 @pytest.mark.rabbit()
 def test_same_queue() -> None:
     assert (


### PR DESCRIPTION
# Description

RabbitMQ 4.0 deprecated `transient_nonexcl_queues` and 4.3+ disables them by default. The previous classic-queue default (`durable=False`, `exclusive=False`) now fails at connection time with:

```python
aiormq.exceptions.ConnectionInternalError: INTERNAL_ERROR - Feature `transient_nonexcl_queues` is deprecated.
```

This broke the FastAPI integration tutorial example and any user code that relies on the implicit default against modern RabbitMQ. Quorum and Stream queues already defaulted to `durable=True`; this PR brings classic queues — and `RabbitExchange`, for consistency — into line.

Users can still opt out by passing `durable=False` explicitly.

Fixes #2890
Supersedes #2891 (the doc-level workaround is no longer needed once the library default is correct).

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] Breaking change (a fix or feature that would disrupt existing functionality)

**Breaking change note:** users who previously relied on the implicit `durable=False` default AND already have a transient queue/exchange of the same name declared on the broker will hit a `PRECONDITION_FAILED` mismatch on re-declaration until they either delete the existing object or explicitly pass `durable=False`. Worth a callout in the release notes.

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)