### PR TITLE
feat(redis): native async cluster pub/sub on redis-py 8

### DIFF
--- a/docs/docs/en/redis/cluster.md
+++ b/docs/docs/en/redis/cluster.md
@@ -14,6 +14,11 @@ search:
 
 **FastStream** provides a `RedisClusterBroker` for working with [**Redis Cluster**](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/){.external-link target="_blank"}. It is a drop-in replacement for `RedisBroker` with the same constructor API, designed for multi-node cluster deployments.
 
+`RedisClusterBroker` is built on the native asynchronous cluster client (`redis.asyncio.cluster.RedisCluster`) from **redis-py**, which exposes cluster-aware `publish()` and `pubsub()` out of the box. Pub/Sub channels, lists, and streams are all supported through this single async client — no synchronous fallback or background threads are involved.
+
+!!! warning "redis-py version"
+    **Redis Cluster** requires **redis-py >= 8.0.0**, the first release to provide native async `publish`/`pubsub` on the cluster client. The package dependency range is `redis>=5.0.0,<9.0.0`; this higher minimum applies only when you use `RedisClusterBroker`.
+
 ## When to Use
 
 | Use RedisBroker | Use RedisClusterBroker |
@@ -50,7 +55,7 @@ broker = RedisClusterBroker(
 |---|---|---|
 | List | ✅ | ✅ |
 | Stream + XAUTOCLAIM | ✅ | ✅ |
-| Pub/Sub | ✅ | ✅ (via sync cluster) |
+| Pub/Sub | ✅ | ✅ |
 | Pipeline | ✅ | ❌ |
 
 ## Stream Location
@@ -76,9 +81,9 @@ broker = RedisClusterBroker(url="redis://localhost:7000")
 
 ## Limitations
 
-- **Pipeline** is not supported in Redis Cluster.
+- **Pipeline** is not supported in Redis Cluster. `publish` and `publish_batch` emit a `RuntimeWarning` and ignore a `pipeline=` argument if one is passed.
 - **XAUTOCLAIM** with `min_idle_time` requires a consumer group with `group` and `consumer` parameters on `StreamSub`.
-- **Pub/Sub** uses a synchronous `RedisCluster` client (via `ThreadPoolExecutor`) because the async client does not expose `publish`/`pubsub` until `redis-py >= 8.0.0`.
+- **Redis Cluster** requires **redis-py >= 8.0.0** (see the version note above).
 
 ## References
 

--- a/docs/docs/en/redis/index.md
+++ b/docs/docs/en/redis/index.md
@@ -41,7 +41,7 @@ Ultimately, the choice between **Pub/Sub**, **List**, or **Streams** hinges on t
 The **FastStream** `RedisBroker` is a key component of the **FastStream** framework that enables seamless integration with **Redis**. With the `RedisBroker`, developers can easily connect to **Redis** instances, publish messages to **Redis** channels, and subscribe to **Redis** channels within their **FastStream** applications.
 
 !!! tip "Redis Cluster Support"
-    For multi-node **Redis Cluster** deployments FastStream provides `RedisClusterBroker`. It is a drop-in replacement with the same API and supports List, Stream, Sharded Pub/Sub, and XAUTOCLAIM. See the [Cluster documentation](./cluster.md){.internal-link} for details.
+    For multi-node **Redis Cluster** deployments FastStream provides `RedisClusterBroker`. It is a drop-in replacement with the same API and supports List, Stream, Pub/Sub, and XAUTOCLAIM natively through the async cluster client (requires **redis-py >= 8.0.0**). See the [Cluster documentation](./cluster.md){.internal-link} for details.
 
 ### Establishing a Connection
 

--- a/docs/docs/en/redis/pubsub/index.md
+++ b/docs/docs/en/redis/pubsub/index.md
@@ -13,7 +13,7 @@ search:
 [**Redis Pub/Sub Channels**](https://redis.io/docs/latest/develop/pubsub/){.external-link target="_blank"} are a feature of **Redis** that enables messaging between clients through a publish/subscribe (pub/sub) pattern. A **Redis** channel is essentially a medium through which messages are transmitted. Different clients can subscribe to these channels to listen for messages, while other clients can publish messages to these channels.
 
 !!! tip "Cluster Support"
-    `RedisClusterBroker` supports Pub/Sub via a synchronous `RedisCluster` client. See the [Cluster docs](../cluster.md){.internal-link}.
+    `RedisClusterBroker` supports Pub/Sub natively through the async cluster client (`redis.asyncio.cluster.RedisCluster`) on **redis-py >= 8.0.0**. See the [Cluster docs](../cluster.md){.internal-link}.
 
 When a message is published to a **Redis** channel, all subscribers to that channel receive the message instantly. This makes **Redis** channels suitable for a variety of real-time applications such as chat rooms, notifications, live updates, and many more use cases where messages must be broadcast promptly to multiple clients.
 

--- a/docs/docs/en/redis/pubsub/publishing.md
+++ b/docs/docs/en/redis/pubsub/publishing.md
@@ -13,7 +13,7 @@ search:
 The **FastStream** `RedisBroker` supports all standard [publishing use cases](../../getting-started/publishing/index.md){.internal-link} similar to the `KafkaBroker`, allowing you to publish messages to Redis channels with ease.
 
 !!! tip "Redis Cluster"
-    With `RedisClusterBroker`, Pub/Sub works via a synchronous `RedisCluster` client. See the [Cluster docs](../cluster.md){.internal-link}.
+    With `RedisClusterBroker`, publishing to channels uses the native async cluster client (`publish()` on `redis.asyncio.cluster.RedisCluster`, **redis-py >= 8.0.0**). See the [Cluster docs](../cluster.md){.internal-link}.
 
 Below you will find guidance on how to utilize the `RedisBroker` for publishing messages, including creating publisher objects and using decorators for streamlined publishing workflows.
 

--- a/docs/docs/en/redis/pubsub/subscription.md
+++ b/docs/docs/en/redis/pubsub/subscription.md
@@ -15,7 +15,7 @@ search:
 **Redis Pub/Sub** is the default subscriber type in **FastStream**, so you can simply create a regular `#!python @broker.subscriber("channel_name")` with a channel name and it creates a subscriber using **Redis Pub/Sub**.
 
 !!! tip "Redis Cluster"
-    With `RedisClusterBroker`, channel subscribers use a synchronous `RedisCluster` client under the hood. See the [Cluster docs](../cluster.md){.internal-link}.
+    With `RedisClusterBroker`, channel subscribers use the native async cluster client (`pubsub()` on `redis.asyncio.cluster.RedisCluster`, **redis-py >= 8.0.0**). See the [Cluster docs](../cluster.md){.internal-link}.
 
 In this example, we will build a FastStream application that listens to messages from the Redis channel named `#!python "test"`.
 

--- a/faststream/redis/broker/cluster_broker.py
+++ b/faststream/redis/broker/cluster_broker.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 from urllib.parse import urlparse
 
 from fast_depends import dependency_provider
@@ -15,14 +15,11 @@ from faststream.redis.broker import RedisBroker
 from faststream.redis.configs import RedisBrokerConfig
 from faststream.redis.configs.state import RedisClusterConnectionState
 from faststream.redis.parser import BinaryMessageFormatV1
-from faststream.redis.publisher.producer import (
-    RedisClusterFastProducer,
-)
+from faststream.redis.publisher.producer import RedisFastProducer
 from faststream.redis.schemas.types import (
     CLUSTER_INCOMPATIBLE_PARAMS,
     NON_CONNECTION_PARAMS,
 )
-from faststream.redis.subscriber.usecases.basic import LogicSubscriber
 from faststream.specification.schema import BrokerSpec
 
 from .logging import make_redis_logger_state
@@ -33,9 +30,7 @@ if TYPE_CHECKING:
     from redis.asyncio.client import Pipeline
 
     from faststream._internal.basic_types import SendableMessage
-    from faststream.redis.schemas import ListSub, PubSub, StreamSub
     from faststream.redis.schemas.types import RedisClusterParams
-    from faststream.redis.subscriber.usecases import ChannelSubscriber
     from faststream.security import BaseSecurity
 
 
@@ -80,9 +75,8 @@ class RedisClusterBroker(RedisBroker):
             routers=kwargs.get("routers", ()),
             config=RedisBrokerConfig(
                 connection=connection_state,
-                producer=RedisClusterFastProducer(
+                producer=RedisFastProducer(
                     connection=connection_state,
-                    cluster_state=connection_state,
                     parser=kwargs.get("parser"),
                     decoder=kwargs.get("decoder"),
                     message_format=self.message_format,
@@ -121,49 +115,6 @@ class RedisClusterBroker(RedisBroker):
     @property
     def _cluster_state(self) -> RedisClusterConnectionState:
         return cast("RedisClusterConnectionState", self.config.broker_config.connection)
-
-    def subscriber(  # type: ignore[override]
-        self,
-        channel: Union["PubSub", str, None] = None,
-        *,
-        list: Union["ListSub", str, None] = None,
-        stream: Union["StreamSub", str, None] = None,
-        **kwargs: Any,
-    ) -> "LogicSubscriber":
-        if channel is not None:
-            return self._make_channel_subscriber(channel, **kwargs)
-        return super().subscriber(
-            channel=None,
-            list=list,
-            stream=stream,
-            **kwargs,
-        )
-
-    def _make_channel_subscriber(
-        self,
-        channel: Union["PubSub", str],
-        **kwargs: Any,
-    ) -> "ChannelSubscriber":
-        state = self._cluster_state
-
-        sub = cast(
-            "ChannelSubscriber",
-            super().subscriber(channel=channel, list=None, stream=None, **kwargs),
-        )
-
-        async def _patched_start() -> None:
-            if sub.subscription:
-                return
-            psub = state.pubsub()
-            sub.subscription = psub  # type: ignore[assignment]
-            if sub.channel.pattern:
-                await psub.psubscribe(sub.channel.name)
-            else:
-                await psub.subscribe(sub.channel.name)
-            await LogicSubscriber.start(sub, psub)
-
-        sub.start = _patched_start  # type: ignore[method-assign]
-        return sub
 
     async def publish(  # type: ignore[override]
         self,

--- a/faststream/redis/configs/broker.py
+++ b/faststream/redis/configs/broker.py
@@ -10,17 +10,14 @@ if TYPE_CHECKING:
     from redis.asyncio.cluster import RedisCluster
 
     from faststream.redis.parser import MessageFormat
-    from faststream.redis.publisher.producer import (
-        RedisClusterFastProducer,
-        RedisFastProducer,
-    )
+    from faststream.redis.publisher.producer import RedisFastProducer
 
     from .state import ConnectionState
 
 
 @dataclass(kw_only=True)
 class RedisBrokerConfig(BrokerConfig):
-    producer: "RedisFastProducer | RedisClusterFastProducer"
+    producer: "RedisFastProducer"
     connection: "ConnectionState[Redis[bytes]] | ConnectionState[RedisCluster[bytes]]"
 
     message_format: type["MessageFormat"]

--- a/faststream/redis/configs/state.py
+++ b/faststream/redis/configs/state.py
@@ -1,18 +1,11 @@
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
-from functools import partial
 from typing import Any, Generic, TypeVar
 
 from redis.asyncio.client import Redis
 from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.connection import ConnectionPool
-from redis.cluster import (
-    ClusterNode,
-    RedisCluster as SyncRC,
-)
 
 from faststream.__about__ import __version__
-from faststream._internal.utils.functions import run_in_executor
 from faststream.exceptions import IncorrectState
 
 ClientT = TypeVar("ClientT")
@@ -33,6 +26,20 @@ def _client_setinfo_kwargs() -> dict[str, Any]:
     return {"driver_info": DriverInfo().add_upstream_driver("faststream", __version__)}
 
 
+def _ensure_cluster_pubsub_supported() -> None:
+    """Ensure the installed redis-py supports async cluster pub/sub.
+
+    The async ``RedisCluster`` only gained ``publish`` / ``pubsub`` in
+    redis-py 8.0.0; on older versions cluster channels cannot work.
+    """
+    if not hasattr(RedisCluster, "pubsub"):
+        msg = (
+            "Redis Cluster support requires redis-py >= 8.0.0 for native async "
+            "pub/sub. Please upgrade with: pip install 'redis>=8.0.0'."
+        )
+        raise IncorrectState(msg)
+
+
 class ConnectionState(ABC, Generic[ClientT]):
     """Base connection state."""
 
@@ -41,8 +48,6 @@ class ConnectionState(ABC, Generic[ClientT]):
 
         self._connected = False
         self._client: ClientT | None = None
-        self._sync_cluster: Any = None
-        self._thread_pool: Any = None
 
     @property
     def client(self) -> ClientT:
@@ -81,130 +86,25 @@ class RedisConnectionState(ConnectionState["Redis[bytes]"]):
 
 
 class RedisClusterConnectionState(ConnectionState["RedisCluster[bytes]"]):
-    """Manages a Redis Cluster connection lifecycle.
+    """Manages a Redis Cluster connection lifecycle using the async client.
 
-    Uses an **async** ``RedisCluster`` for List/Stream/KV commands and a
-    **sync** ``redis.cluster.RedisCluster`` (wrapped via
-    ``run_in_executor``) for Pub/Sub — the async client doesn't expose
-    ``publish`` / ``pubsub`` until ``redis-py >= 8.0.0``.
+    redis-py >= 8.0.0 is required: the async ``RedisCluster`` exposes native
+    ``publish`` / ``pubsub`` (cluster pub/sub) only from 8.0.0 onwards. The
+    connection defaults to ``legacy_responses=True`` so RESP3 (the redis-8
+    default) still yields RESP2-compatible response shapes.
     """
-
-    def __init__(self, options: dict[str, Any] | None = None) -> None:
-        self._options = options or {}
-
-        self._connected = False
-        self._client: RedisCluster[bytes] | None = None
-        self._sync_cluster: Any = None
-        self._thread_pool: ThreadPoolExecutor | None = None
-
-    @property
-    def client(self) -> "RedisCluster[bytes]":
-        if not self._client:
-            msg = "Connection is not available yet. Please, connect the broker first."
-            raise IncorrectState(msg)
-        return self._client
-
-    def __bool__(self) -> bool:
-        return self._connected
 
     async def connect(self) -> "RedisCluster[bytes]":
         if self._connected:
             return self._client  # type: ignore[return-value]
 
+        _ensure_cluster_pubsub_supported()
+
         opts = {k: v for k, v in self._options.items() if v is not None}
-        opts["lib_name"] = "faststream"
-        opts["lib_version"] = __version__
+        opts.setdefault("legacy_responses", True)
+        opts.update(_client_setinfo_kwargs())
 
         client: RedisCluster[bytes] = RedisCluster(**opts)
         self._client = client
         self._connected = True
         return client
-
-    async def disconnect(self) -> None:
-        if self._thread_pool is not None:
-            self._thread_pool.shutdown(wait=False)
-            self._thread_pool = None
-            self._sync_cluster = None
-        if self._client:
-            await self._client.aclose()  # type: ignore[attr-defined]
-        self._client = None
-        self._connected = False
-
-    async def sync_publish(self, channel: str, body: bytes) -> int:
-        sync = self._get_sync_cluster()
-        return await run_in_executor(self._thread_pool, sync.publish, channel, body)
-
-    def pubsub(self) -> "_SyncPubSubProxy":
-        if self._thread_pool is not None:
-            pool = self._thread_pool
-        elif self._client is not None:
-            # Test mode: store the pool so disconnect() cleans it up
-            pool = self._thread_pool = ThreadPoolExecutor(max_workers=1)
-        else:
-            msg = "Pub/Sub proxy is not available"
-            raise IncorrectState(msg)
-
-        sync = self._get_sync_cluster()
-        return _SyncPubSubProxy(sync, pool)
-
-    def _get_sync_cluster(self) -> Any:
-        if self._sync_cluster is not None:
-            return self._sync_cluster
-
-        # Test mode: _client set by _fake_connect, _connected stays False
-        if not self._connected and self._client is not None:
-            return self._client
-
-        raw = self._options
-        nodes = [ClusterNode(n.host, n.port) for n in raw.get("startup_nodes", [])]
-        if not nodes:
-            host = raw.get("host", "127.0.0.1")
-            port = int(raw.get("port", 6379))
-            nodes.append(ClusterNode(host, port))
-
-        self._sync_cluster = SyncRC(
-            startup_nodes=nodes,
-            password=raw.get("password"),
-            username=raw.get("username"),
-            ssl=raw.get("ssl", False),
-            socket_timeout=raw.get("socket_timeout"),
-            socket_connect_timeout=raw.get("socket_connect_timeout"),
-        )
-        self._thread_pool = ThreadPoolExecutor(max_workers=4)
-        return self._sync_cluster
-
-
-class _SyncPubSubProxy:
-    """Wraps a **sync** ``redis.cluster.RedisCluster.pubsub()`` for async use.
-
-    ``redis-py``'s async ``RedisCluster`` lacks ``publish`` / ``pubsub``
-    until version 8.0.0.  We use the sync client via a
-    ``ThreadPoolExecutor`` (following the same pattern as the Confluent
-    adapter) so Pub/Sub works with ``redis-py >= 7.4.0``.
-    """
-
-    def __init__(self, sync_cluster: Any, pool: ThreadPoolExecutor) -> None:
-        self._pool = pool
-        self._psub = sync_cluster.pubsub()
-
-    async def subscribe(self, channel: str) -> None:
-        await run_in_executor(self._pool, self._psub.subscribe, channel)
-
-    async def psubscribe(self, pattern: str) -> None:
-        await run_in_executor(self._pool, self._psub.psubscribe, pattern)
-
-    async def unsubscribe(self) -> None:
-        await run_in_executor(self._pool, self._psub.unsubscribe)
-
-    async def get_message(
-        self,
-        ignore_subscribe_messages: bool = False,
-        timeout: float | None = 0.0,
-    ) -> Any:
-        return await run_in_executor(
-            self._pool,
-            partial(self._psub.get_message, ignore_subscribe_messages, timeout),
-        )
-
-    async def aclose(self) -> None:
-        await run_in_executor(self._pool, self._psub.close)

--- a/faststream/redis/configs/state.py
+++ b/faststream/redis/configs/state.py
@@ -18,6 +18,21 @@ from faststream.exceptions import IncorrectState
 ClientT = TypeVar("ClientT")
 
 
+def _client_setinfo_kwargs() -> dict[str, Any]:
+    """Return ``CLIENT SETINFO`` kwargs compatible with the installed redis-py.
+
+    redis-py >= 7.4 exposes the ``driver_info`` parameter (and deprecates
+    ``lib_name`` / ``lib_version``); older releases only accept the legacy
+    pair. Importing ``redis.driver_info`` lazily keeps the ``redis>=5.0.0``
+    floor working.
+    """
+    try:
+        from redis.driver_info import DriverInfo
+    except ImportError:  # redis-py < 7.4
+        return {"lib_name": "faststream", "lib_version": __version__}
+    return {"driver_info": DriverInfo().add_upstream_driver("faststream", __version__)}
+
+
 class ConnectionState(ABC, Generic[ClientT]):
     """Base connection state."""
 
@@ -55,8 +70,7 @@ class RedisConnectionState(ConnectionState["Redis[bytes]"]):
     async def connect(self) -> "Redis[bytes]":
         pool = ConnectionPool(
             **self._options,
-            lib_name="faststream",
-            lib_version=__version__,
+            **_client_setinfo_kwargs(),
         )
         client: Redis[bytes] = Redis.from_pool(pool)  # type: ignore[attr-defined]
 

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -8,8 +8,6 @@ from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream._internal.utils.nuid import NUID
-from faststream.redis.configs.state import RedisClusterConnectionState
-from faststream.redis.exceptions import UnreachablePathError
 from faststream.redis.message import DATA_KEY
 from faststream.redis.parser import RedisPubSubParser, SimpleParserConfig
 from faststream.redis.response import DestinationType, RedisPublishCommand
@@ -17,7 +15,6 @@ from faststream.redis.response import DestinationType, RedisPublishCommand
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
     from redis.asyncio.client import Redis
-    from redis.asyncio.cluster import RedisCluster
 
     from faststream._internal.parser import CodecProto
     from faststream._internal.types import CustomCallable
@@ -81,20 +78,23 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         if codec is not None:
             self.codec = codec
 
-    def _build_child(
-        self, **kwargs: Any
-    ) -> "RedisFastProducer | RedisClusterFastProducer":
+    def _build_child(self, **kwargs: Any) -> "RedisFastProducer":
         return self.__class__(**kwargs)  # type: ignore[return-value]
 
 
 class RedisFastProducer(BaseRedisFastProducer):
-    """Producer for a single-node Redis."""
+    """Producer for single-node Redis and Redis Cluster.
+
+    Both the async ``Redis`` and ``RedisCluster`` clients share the same
+    command API (``publish`` / ``rpush`` / ``xadd`` / ``pubsub``), so the
+    cluster broker reuses this producer directly.
+    """
 
     _connection: "ConnectionState[Redis[bytes]]"
 
     def __init__(
         self,
-        connection: "ConnectionState[Redis[bytes]]",
+        connection: "ConnectionState[Any]",
         parser: Optional["CustomCallable"],
         decoder: Optional["CustomCallable"],
         message_format: type["MessageFormat"],
@@ -189,103 +189,3 @@ class RedisFastProducer(BaseRedisFastProducer):
             with suppress(Exception):
                 await psub.unsubscribe()
                 await psub.aclose()  # type: ignore[attr-defined]
-
-
-class RedisClusterFastProducer(BaseRedisFastProducer):
-    """Producer that routes channel operations through the sync cluster."""
-
-    def __init__(
-        self,
-        connection: "ConnectionState[RedisCluster[bytes]]",
-        cluster_state: RedisClusterConnectionState,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(connection=connection, **kwargs)
-        self._cluster_state = cluster_state
-
-    @property
-    def cluster_state(self) -> RedisClusterConnectionState:
-        return self._cluster_state
-
-    @override
-    def _build_child(self, **kwargs: Any) -> "RedisClusterFastProducer":
-        return RedisClusterFastProducer(cluster_state=self._cluster_state, **kwargs)
-
-    @override
-    async def publish(self, cmd: "RedisPublishCommand") -> int | bytes:
-        msg = await cmd.message_format.encode(
-            message=cmd.body,
-            reply_to=cmd.reply_to,
-            headers=cmd.headers,
-            correlation_id=cmd.correlation_id or "",
-            serializer=self.serializer,
-            codec=self.codec,
-        )
-
-        if cmd.destination_type is DestinationType.Channel:
-            return await self._cluster_state.sync_publish(cmd.destination, msg)
-
-        if cmd.destination_type is DestinationType.List:
-            return cast("int", await self._connection.client.rpush(cmd.destination, msg))
-        if cmd.destination_type is DestinationType.Stream:
-            return cast(
-                "bytes",
-                await self._connection.client.xadd(
-                    name=cmd.destination,
-                    fields={DATA_KEY: msg},
-                    maxlen=cmd.maxlen,
-                ),
-            )
-        raise UnreachablePathError
-
-    @override
-    async def request(self, cmd: "RedisPublishCommand") -> "Any":
-        nuid = NUID()
-        reply_to = str(nuid.next(), "utf-8")
-        psub = self._cluster_state.pubsub()
-
-        try:
-            await psub.subscribe(reply_to)
-
-            msg = await cmd.message_format.encode(
-                message=cmd.body,
-                reply_to=reply_to,
-                headers=cmd.headers,
-                correlation_id=cmd.correlation_id or "",
-                serializer=self.serializer,
-                codec=self.codec,
-            )
-
-            if cmd.destination_type is DestinationType.Channel:
-                await self._cluster_state.sync_publish(cmd.destination, msg)
-            elif cmd.destination_type is DestinationType.List:
-                await self._connection.client.rpush(cmd.destination, msg)
-            elif cmd.destination_type is DestinationType.Stream:
-                await self._connection.client.xadd(
-                    name=cmd.destination,
-                    fields={DATA_KEY: msg},
-                    maxlen=cmd.maxlen,
-                )
-            else:
-                raise UnreachablePathError
-
-            with anyio.fail_after(cmd.timeout) as scope:
-                await psub.get_message(
-                    ignore_subscribe_messages=True,
-                    timeout=cmd.timeout or 0.0,
-                )
-
-                response_msg = await psub.get_message(
-                    ignore_subscribe_messages=True,
-                    timeout=cmd.timeout or 0.0,
-                )
-
-            if scope.cancel_called:
-                raise TimeoutError
-
-            return response_msg
-
-        finally:
-            with suppress(Exception):
-                await psub.unsubscribe()
-                await psub.aclose()

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -1,6 +1,5 @@
 import re
 from collections.abc import AsyncGenerator, Iterable, Iterator, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, asynccontextmanager, contextmanager
 from functools import partial
 from typing import (
@@ -146,8 +145,6 @@ class TestRedisBroker(TestBroker[RedisBroker]):
 
         connection_state = broker.config.broker_config.connection
         connection_state._client = connection
-        connection_state._sync_cluster = MagicMock()
-        connection_state._thread_pool = ThreadPoolExecutor(max_workers=1)
         connection_state._connected = True
         return connection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ confluent = [
 
 nats = ["nats-py>=2.12.0,<=3.0.0"]
 
-redis = ["redis>=5.0.0,<8.0.0"]
+redis = ["redis>=5.0.0,<9.0.0"]
 
 mqtt = ["zmqtt>=0.0.4"]
 

--- a/tests/brokers/redis/test_cluster_more_unit.py
+++ b/tests/brokers/redis/test_cluster_more_unit.py
@@ -1,19 +1,16 @@
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any
 from unittest.mock import AsyncMock
 
-import anyio
 import pytest
 
+from faststream.exceptions import IncorrectState
 from faststream.redis import RedisClusterBroker, RedisRouter, TestRedisBroker
-from faststream.redis.configs import ConnectionState, RedisConnectionState
-from faststream.redis.configs.state import RedisClusterConnectionState
-from faststream.redis.exceptions import UnreachablePathError
-from faststream.redis.parser import BinaryMessageFormatV1
-from faststream.redis.publisher.producer import (
-    RedisClusterFastProducer,
-    RedisFastProducer,
+from faststream.redis.configs import (
+    RedisConnectionState,
+    state as state_module,
 )
+from faststream.redis.configs.state import RedisClusterConnectionState
+from faststream.redis.parser import BinaryMessageFormatV1
+from faststream.redis.publisher.producer import RedisFastProducer
 from faststream.redis.response import RedisPublishCommand
 from faststream.response.publish_type import PublishType
 
@@ -35,12 +32,52 @@ class TestRedisClusterConnectionStateUnit:
         state = RedisClusterConnectionState(opts)
         assert state._options == opts
 
-    def test_get_sync_cluster_creates_once(self) -> None:
+    def test_bool_reflects_connected(self) -> None:
+        state = RedisClusterConnectionState()
+        assert not state
+        state._connected = True
+        assert state
+
+
+class TestClusterConnectionStateConnect:
+    """connect() builds the async client with redis-8-safe options."""
+
+    @pytest.mark.asyncio()
+    async def test_connect_sets_legacy_responses_and_driver_info(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeCluster:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+            def pubsub(self) -> None:  # presence satisfies the version guard
+                ...
+
+        monkeypatch.setattr(state_module, "RedisCluster", FakeCluster)
+
         state = RedisClusterConnectionState({"host": "127.0.0.1", "port": 7000})
-        # We can't actually connect, but we can verify the method shape
-        # by checking that _sync_cluster starts as None
-        assert state._sync_cluster is None
-        assert state._thread_pool is None
+        await state.connect()
+
+        assert captured["legacy_responses"] is True
+        assert "driver_info" in captured
+        assert bool(state)
+
+    @pytest.mark.asyncio()
+    async def test_connect_requires_redis8(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class OldCluster:  # no pubsub attr -> simulate redis-py < 8
+            def __init__(self, **kwargs: object) -> None: ...
+
+        monkeypatch.setattr(state_module, "RedisCluster", OldCluster)
+
+        state = RedisClusterConnectionState({"host": "127.0.0.1", "port": 7000})
+        with pytest.raises(IncorrectState, match="requires redis-py"):
+            await state.connect()
 
 
 class TestClusterBrokerWarnings:
@@ -136,269 +173,59 @@ class TestClusterBrokerInheritanceExtra:
         assert len(broker.subscribers) == 1
 
 
-class TestSyncPubSubProxyUnit:
-    """Unit tests for _SyncPubSubProxy."""
+class TestClusterUsesAsyncProducer:
+    """Cluster reuses the standard async RedisFastProducer (no sync proxy)."""
 
-    def test_proxy_stores_pubsub_and_pool(self) -> None:
-        """Verify proxy initialises correctly."""
-        pool = ThreadPoolExecutor(max_workers=1)
-        try:
-            # We need a sync cluster to create pubsub, so just verify
-            # the class structure — actual init tested in integration.
-            pass
-        finally:
-            pool.shutdown(wait=False)
+    def test_producer_is_standard_async(self) -> None:
+        broker = RedisClusterBroker()
+        assert type(broker.config.broker_config.producer) is RedisFastProducer
+
+    @pytest.mark.asyncio()
+    async def test_channel_publish_uses_async_client_publish(self) -> None:
+        client = AsyncMock()
+        client.publish = AsyncMock(return_value=1)
+        conn = RedisConnectionState()
+        conn._client = client
+        conn._connected = True
+
+        producer = RedisFastProducer(
+            connection=conn,
+            parser=None,
+            decoder=None,
+            message_format=BinaryMessageFormatV1,
+            serializer=None,
+        )
+        cmd = RedisPublishCommand(
+            b"hello",
+            channel="ch",
+            _publish_type=PublishType.PUBLISH,
+        )
+        result = await producer.publish(cmd)
+        assert result == 1
+        client.publish.assert_awaited_once()
 
 
 class TestRedisClusterConnectionStateDisconnect:
     """Tests for disconnect lifecycle."""
 
     @pytest.mark.asyncio()
-    async def test_disconnect_cleans_thread_pool(self) -> None:
+    async def test_disconnect_closes_async_client(self) -> None:
         state = RedisClusterConnectionState({"host": "127.0.0.1", "port": 7000})
-        assert state._thread_pool is None
+        client = AsyncMock()
+        state._client = client
+        state._connected = True
+
         await state.disconnect()
-        assert state._thread_pool is None
-        assert state._sync_cluster is None
+
+        client.aclose.assert_awaited_once()
         assert state._client is None
+        assert not bool(state)
 
     @pytest.mark.asyncio()
     async def test_disconnect_before_connect_no_error(self) -> None:
         state = RedisClusterConnectionState({"host": "127.0.0.1", "port": 7000})
         await state.disconnect()  # Should not raise
         assert not bool(state)
-
-    def test_bool_reflects_connected(self) -> None:
-        state = RedisClusterConnectionState()
-        assert not state
-        state._connected = True
-        assert state
-
-
-class TestClusterFastProducerUnit:
-    """Direct unit tests for RedisClusterFastProducer routing logic."""
-
-    @pytest.fixture()
-    def mock_client(self) -> AsyncMock:
-        client = AsyncMock()
-        client.rpush = AsyncMock(return_value=1)
-        client.xadd = AsyncMock(return_value=b"stream-id")
-        return client
-
-    @pytest.fixture()
-    def mock_connection(self, mock_client: AsyncMock) -> ConnectionState[Any]:
-        conn = RedisConnectionState()
-        conn._client = mock_client
-        conn._connected = True
-        return conn
-
-    @pytest.fixture()
-    def mock_cluster_state(self) -> AsyncMock:
-        state = AsyncMock(spec=RedisClusterConnectionState)
-        state.sync_publish = AsyncMock(return_value=1)
-        return state
-
-    @pytest.fixture()
-    def producer(
-        self,
-        mock_connection: ConnectionState,
-        mock_cluster_state: AsyncMock,
-    ) -> RedisFastProducer:
-
-        return RedisClusterFastProducer(
-            connection=mock_connection,
-            cluster_state=mock_cluster_state,
-            parser=None,
-            decoder=None,
-            message_format=BinaryMessageFormatV1,
-            serializer=None,
-        )
-
-    @pytest.mark.asyncio()
-    async def test_publish_channel(
-        self,
-        producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-    ) -> None:
-        cmd = RedisPublishCommand(
-            b"hello",
-            channel="ch",
-            _publish_type=PublishType.PUBLISH,
-        )
-        result = await producer.publish(cmd)
-        assert result == 1
-        mock_cluster_state.sync_publish.assert_awaited_once()
-
-    @pytest.mark.asyncio()
-    async def test_publish_list(
-        self,
-        producer: RedisFastProducer,
-        mock_client: AsyncMock,
-    ) -> None:
-        cmd = RedisPublishCommand(
-            b"hello",
-            list="lst",
-            _publish_type=PublishType.PUBLISH,
-        )
-        result = await producer.publish(cmd)
-        assert result == 1
-        mock_client.rpush.assert_awaited_once_with(
-            "lst", mock_client.rpush.call_args[0][1]
-        )
-
-    @pytest.mark.asyncio()
-    async def test_publish_stream(
-        self,
-        producer: RedisFastProducer,
-        mock_client: AsyncMock,
-    ) -> None:
-        cmd = RedisPublishCommand(
-            b"hello",
-            stream="strm",
-            maxlen=100,
-            _publish_type=PublishType.PUBLISH,
-        )
-        result = await producer.publish(cmd)
-        assert result == b"stream-id"
-        mock_client.xadd.assert_awaited_once()
-
-    @pytest.mark.asyncio()
-    async def test_publish_unreachable(
-        self,
-        producer: RedisFastProducer,
-    ) -> None:
-        """No matching destination_type → UnreachablePathError."""
-        cmd = RedisPublishCommand(
-            b"hello",
-            channel="ch",
-            _publish_type=PublishType.PUBLISH,
-        )
-        cmd.destination_type = None  # type: ignore[assignment]
-        with pytest.raises(UnreachablePathError):
-            await producer.publish(cmd)
-
-    @pytest.mark.asyncio()
-    async def test_request_channel(
-        self,
-        producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-    ) -> None:
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
-
-        cmd = RedisPublishCommand(
-            b"hello",
-            channel="ch",
-            timeout=5.0,
-            _publish_type=PublishType.REQUEST,
-        )
-        result = await producer.request(cmd)
-        assert result == "resp"
-        mock_cluster_state.sync_publish.assert_awaited_once()
-
-    @pytest.mark.asyncio()
-    async def test_request_list(
-        self,
-        producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-        mock_client: AsyncMock,
-    ) -> None:
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
-
-        cmd = RedisPublishCommand(
-            b"hello",
-            list="lst",
-            timeout=5.0,
-            _publish_type=PublishType.REQUEST,
-        )
-        result = await producer.request(cmd)
-        assert result == "resp"
-        mock_client.rpush.assert_awaited_once()
-
-    @pytest.mark.asyncio()
-    async def test_request_stream(
-        self,
-        producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-        mock_client: AsyncMock,
-    ) -> None:
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
-
-        cmd = RedisPublishCommand(
-            b"hello",
-            stream="strm",
-            maxlen=100,
-            timeout=5.0,
-            _publish_type=PublishType.REQUEST,
-        )
-        result = await producer.request(cmd)
-        assert result == "resp"
-        mock_client.xadd.assert_awaited_once()
-
-    @pytest.mark.asyncio()
-    async def test_request_timeout(
-        self,
-        producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-    ) -> None:
-        """Timeout inside fail_after raises TimeoutError."""
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-
-        async def _slow(*args: object, **kwargs: object) -> None:
-            await anyio.sleep(10)
-
-        psub.get_message = _slow
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
-
-        cmd = RedisPublishCommand(
-            b"hello",
-            channel="ch",
-            timeout=0.05,
-            _publish_type=PublishType.REQUEST,
-        )
-        with pytest.raises(TimeoutError):
-            await producer.request(cmd)
-
-    @pytest.mark.asyncio()
-    async def test_request_unreachable(
-        self,
-        producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-    ) -> None:
-        """No matching destination_type → UnreachablePathError."""
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
-
-        cmd = RedisPublishCommand(
-            b"hello",
-            channel="ch",
-            timeout=5.0,
-            _publish_type=PublishType.REQUEST,
-        )
-        cmd.destination_type = None  # type: ignore[assignment]
-        with pytest.raises(UnreachablePathError):
-            await producer.request(cmd)
 
 
 class TestClusterBrokerPing:
@@ -434,5 +261,4 @@ class TestRedisBrokerInit:
 
     def test_specification_url_defaults_to_url(self) -> None:
         broker = RedisClusterBroker(url="redis://127.0.0.1:7001")
-        # specification_url was set from url in __init__
         assert broker._connection is None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -850,7 +850,7 @@ wheels = [
 
 [[package]]
 name = "faststream"
-version = "0.7.0rc1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -1020,7 +1020,7 @@ requires-dist = [
     { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.12.0,<=3.0.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.24.0,<2.0.0" },
     { name = "prometheus-client", marker = "extra == 'prometheus'", specifier = ">=0.20.0,<0.30.0" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<8.0.0" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<9.0.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.9,!=0.12,<=0.21.1" },
     { name = "typing-extensions", specifier = ">=4.12.0" },
     { name = "watchfiles", marker = "extra == 'cli'", specifier = ">=0.15.0,<1.2.0" },
@@ -3080,14 +3080,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.4.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the synchronous Redis Cluster pub/sub workaround (merged in #2854) with **native async cluster pub/sub** from redis-py 8. This eliminates the `ThreadPoolExecutor`, `_SyncPubSubProxy`, and the sync `redis.cluster.RedisCluster` — cluster channels, lists, and streams all go through the single async `redis.asyncio.cluster.RedisCluster` client.

### redis-py 8.x breaking changes resolved

| Breaking change | How it's handled |
|---|---|
| **RESP3 default** (`DEFAULT_RESP_VERSION = 3` in redis-py 8) | Cluster connection sets `legacy_responses=True` (default in redis-py, now explicit) so RESP3 wire still yields RESP2-compatible response shapes. Stream/list/pubsub parsing unchanged. |
| **`lib_name` / `lib_version` deprecated** (`@deprecated_args`, resolved into `driver_info`) | Cluster path uses `DriverInfo().add_upstream_driver("faststream", __version__)` directly. Standalone `RedisConnectionState` uses a version-safe helper that falls back to `lib_name`/`lib_version` on redis-py < 7.4, preserving the `redis>=5.0.0` floor. **0** deprecation warnings on redis 8. |
| **Async cluster `publish()` / `pubsub()`** (new in redis-py 8.0.0) | A runtime guard (`_ensure_cluster_pubsub_supported`) raises a clear error on redis-py < 8, directing users to upgrade. |

### What changed

**Dependency** (`pyproject.toml`)
- Bump `redis>=5.0.0,<8.0.0` → `redis>=5.0.0,<9.0.0`. Non-cluster users are unaffected; cluster requires redis-py ≥ 8.0.0 at runtime.

**`faststream/redis/configs/state.py`**
- Strip sync machinery from `RedisClusterConnectionState`: remove `sync_publish()`, `pubsub()`, `_get_sync_cluster()`, the `_SyncPubSubProxy` class, and the `_sync_cluster`/`_thread_pool` fields (also from base `ConnectionState`).
- `connect()` adds `legacy_responses=True` (RESP3-safe) and `driver_info`.
- Add `_ensure_cluster_pubsub_supported()` guard (raises `IncorrectState` on redis-py < 8).
- Add `_client_setinfo_kwargs()` — version-safe helper for standalone Redis (`driver_info` on ≥ 7.4, `lib_name`/`lib_version` fallback).

**`faststream/redis/publisher/producer.py`**
- **Drop `RedisClusterFastProducer`**. The async `RedisCluster` shares the same command API (`publish`/`rpush`/`xadd`/`pubsub`) as `Redis`, so the cluster broker reuses `RedisFastProducer` directly.
- Broaden `RedisFastProducer.__init__` connection param to `ConnectionState[Any]` so it accepts both standalone and cluster state.

**`faststream/redis/broker/cluster_broker.py`**
- Remove `_make_channel_subscriber()` and the `subscriber()` override: the stock `ChannelSubscriber.start()` calls `self._client.pubsub()`, which now returns a working `ClusterPubSub`.
- Instantiate `RedisFastProducer` (not `RedisClusterFastProducer`) in the broker config.
- Keep pipeline `RuntimeWarning`s and `_resolve_url_options`.

**`faststream/redis/testing.py`**
- Drop `_sync_cluster`/`_thread_pool` seeding from `_fake_connect`; the existing `AsyncMock` pubsub models the async path.

**`faststream/redis/configs/broker.py`**
- Simplify `producer` type hint to `RedisFastProducer` (no union).

**Tests** (`tests/brokers/redis/test_cluster_more_unit.py`)
- Delete sync-proxy / `sync_publish` / `_thread_pool` tests.
- Add: `test_connect_sets_legacy_responses_and_driver_info`, `test_connect_requires_redis8`, `test_producer_is_standard_async`, `test_channel_publish_uses_async_client_publish`, `test_disconnect_closes_async_client`.

**Docs** (`docs/docs/en/redis/`)
- Rewrite `cluster.md`: native async cluster pub/sub, redis-py ≥ 8.0.0 requirement, pipeline unsupported note.
- Update cross-reference tips in `index.md`, `pubsub/index.md`, `pubsub/publishing.md`, `pubsub/subscription.md` — remove sync-workaround caveats.

### Subscription type support

| Type | Min redis-py |
|---|---|
| Streams | `>= 5.0.0` |
| Lists | `>= 5.0.0` |
| Channels (Pub/Sub) | `>= 8.0.0` (native async cluster pub/sub) |

### Out of scope

- FastAPI `RedisClusterRouter` (upstream has none; can be added separately)
- Sharded Pub/Sub (`spublish`/`ssubscribe`) — uses cluster-wide `publish`, kept as-is

### Validation

- `ruff format` ✓ (1217 files)
- `ruff check` ✓
- `codespell` ✓
- `mypy` ✓ (507 source files, 0 errors)
- Full fast test suite (`-m 'not slow and not connected'`) ✓ on redis-py 8.0.0
- 0 `lib_name`/`lib_version` `DeprecationWarning`s on redis 8

### Closes

Builds on #2854 (merged). Supersedes #2886 (closed).

---

[Implementation plan](https://app.warp.dev/drive/notebook/xIX6QNhH4FEUKAnHgduML4) · [Warp conversation](https://app.warp.dev/conversation/889863b3-7f69-42d5-9f50-be0850ae6f00)

Co-Authored-By: Oz <oz-agent@warp.dev>