### PR TITLE
feat(docs): add json endpoint and fix content-type header

### DIFF
--- a/docs/docs/en/getting-started/asgi.md
+++ b/docs/docs/en/getting-started/asgi.md
@@ -215,5 +215,5 @@ async def start_broker(app):
 app = FastAPI(lifespan=start_broker)
 
 app.mount("/health", make_ping_asgi(broker, timeout=5.0))
-app.mount("/asyncapi", make_asyncapi_asgi(asyncapi, try_it_out=False))
+app.mount("/asyncapi", make_asyncapi_asgi(asyncapi, try_it_out_path=None))
 ```

--- a/docs/docs/en/getting-started/asyncapi/hosting.md
+++ b/docs/docs/en/getting-started/asyncapi/hosting.md
@@ -114,7 +114,7 @@ broker = NatsBroker()
 app = AsgiFastStream(broker, asyncapi_path="/docs/asyncapi")
 ```
 
-To disable the feature, use `AsyncAPIRoute` with `try_it_out=False`:
+To disable the feature, use `AsyncAPIRoute` with `try_it_out_path=None`:
 
 ```python linenums="1" hl_lines="2 8"
 from faststream.nats import NatsBroker
@@ -124,11 +124,11 @@ broker = NatsBroker()
 
 app = AsgiFastStream(
     broker,
-    asyncapi_path=AsyncAPIRoute("/docs/asyncapi", try_it_out=False),
+    asyncapi_path=AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None),
 )
 ```
 
-If you want to point the Try It Out UI to an **external backend** (e.g. a separate service or a production broker URL), pass a custom `try_it_out_url` via `AsyncAPIRoute`:
+If you want to point the Try It Out UI to an **external backend** (e.g. a separate service or a production broker URL), pass a custom `try_it_out_path` via `AsyncAPIRoute`:
 
 ```python linenums="1" hl_lines="2 10"
 from faststream.nats import NatsBroker
@@ -140,13 +140,13 @@ app = AsgiFastStream(
     broker,
     asyncapi_path=AsyncAPIRoute(
         "/docs/asyncapi",
-        try_it_out_url="https://api.example.com/asyncapi/try",
+        try_it_out_path="https://api.example.com/asyncapi/try",
     ),
 )
 ```
 
 !!! note
-    When `try_it_out_url` is set on `AsyncAPIRoute`, it overrides the URL the browser sends requests to. The local `POST {asyncapi_path}/try` endpoint is still registered and reachable regardless of `try_it_out_url`, unless you also pass `try_it_out=False`.
+    `try_it_out_path` controls the URL the browser sends requests to and, when it points at the local app, the path the `POST` endpoint is registered under. Setting `try_it_out_path=None` disables the Try It Out UI and skips registering the local endpoint entirely.
 
 ## Integration with Different HTTP Frameworks (**FastAPI** Example)
 

--- a/docs/docs_src/integrations/fastapi/rabbit/base.py
+++ b/docs/docs_src/integrations/fastapi/rabbit/base.py
@@ -2,6 +2,7 @@ from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 
 from faststream.rabbit.fastapi import RabbitRouter, Logger
+from faststream.rabbit import RabbitQueue
 
 router = RabbitRouter("amqp://guest:guest@localhost:5672/")
 
@@ -11,7 +12,7 @@ class Incoming(BaseModel):
 def call() -> bool:
     return True
 
-@router.subscriber("test")
+@router.subscriber(RabbitQueue("test", durable=True))
 @router.publisher("response")
 async def hello(message: Incoming, logger: Logger, dependency: bool = Depends(call)):
     logger.info("Incoming value: %s, depends value: %s" % (message.m, dependency))

--- a/docs/docs_src/integrations/fastapi/rabbit/base.py
+++ b/docs/docs_src/integrations/fastapi/rabbit/base.py
@@ -2,7 +2,6 @@ from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 
 from faststream.rabbit.fastapi import RabbitRouter, Logger
-from faststream.rabbit import RabbitQueue
 
 router = RabbitRouter("amqp://guest:guest@localhost:5672/")
 

--- a/docs/docs_src/integrations/fastapi/rabbit/base.py
+++ b/docs/docs_src/integrations/fastapi/rabbit/base.py
@@ -12,7 +12,7 @@ class Incoming(BaseModel):
 def call() -> bool:
     return True
 
-@router.subscriber(RabbitQueue("test", durable=True))
+@router.subscriber("test")
 @router.publisher("response")
 async def hello(message: Incoming, logger: Logger, dependency: bool = Depends(call)):
     logger.info("Incoming value: %s, depends value: %s" % (message.m, dependency))

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -392,7 +392,7 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
                     self.schema.to_specification().to_jsonable(),
                     indent=2,
                 ),
-                headers={"Content-Type": "application/octet-stream"},
+                headers={"Content-Type": "application/json"},
             )
 
         def download_app_yaml_schema() -> Response:

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -425,7 +425,7 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
                     schemas=schemas,
                     errors=errors,
                     expand_message_examples=expandMessageExamples,
-                    try_it_out_url=f"{schema_url}/try",
+                    try_it_out_path=f"{schema_url}/try",
                 ),
             )
 

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -132,7 +132,7 @@ class AsgiFastStream(Application):
             if asyncapi_route.asyncapi_json_path:
 
                 @get(include_in_schema=asyncapi_route.include_in_schema)
-                async def json_handler(scope: "Scope") -> None:
+                async def json_handler(scope: "Scope") -> AsgiResponse:
                     return JSONResponse(self.schema.to_specification().to_jsonable())
 
                 self.routes.append((asyncapi_route.asyncapi_json_path, json_handler))

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -19,8 +19,8 @@ from faststream._internal.logger import logger
 from faststream.exceptions import INSTALL_UVICORN, StartupValidationError
 
 from .factories import AsyncAPIRoute, make_try_it_out_handler
-from .handlers import HttpHandler
-from .response import AsgiResponse
+from .handlers import HttpHandler, get
+from .response import AsgiResponse, JSONResponse
 from .websocket import WebSocketClose
 
 if TYPE_CHECKING:
@@ -129,19 +129,13 @@ class AsgiFastStream(Application):
             handler.set_logger(logger)
             self.routes.append((asyncapi_route.path, handler))
 
-            json_path = getattr(asyncapi_route, "asyncapi_json_path", None)
-            if json_path:
-                from .response import JSONResponse
+            if asyncapi_route.asyncapi_json_path:
 
-                raw_json_schema = self.schema.to_specification().to_jsonable()
+                @get(include_in_schema=asyncapi_route.include_in_schema)
+                async def json_handler(scope: "Scope") -> None:
+                    return JSONResponse(self.schema.to_specification().to_jsonable())
 
-                async def json_handler(
-                    scope: "Scope", receive: "Receive", send: "Send"
-                ) -> None:
-                    response = JSONResponse(raw_json_schema)
-                    await response(scope, receive, send)
-
-                self.routes.append((json_path, json_handler))
+                self.routes.append((asyncapi_route.asyncapi_json_path, json_handler))
 
             if asyncapi_route.try_it_out and self.brokers:
                 try_it_out_route = make_try_it_out_handler(

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -129,6 +129,20 @@ class AsgiFastStream(Application):
             handler.set_logger(logger)
             self.routes.append((asyncapi_route.path, handler))
 
+            json_path = getattr(asyncapi_route, "asyncapi_json_path", None)
+            if json_path:
+                from .response import JSONResponse
+
+                raw_json_schema = self.schema.to_specification().to_jsonable()
+
+                async def json_handler(
+                    scope: "Scope", receive: "Receive", send: "Send"
+                ) -> None:
+                    response = JSONResponse(raw_json_schema)
+                    await response(scope, receive, send)
+
+                self.routes.append((json_path, json_handler))
+
             if asyncapi_route.try_it_out and self.brokers:
                 try_it_out_route = make_try_it_out_handler(
                     self.brokers,

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -137,7 +137,7 @@ class AsgiFastStream(Application):
 
                 self.routes.append((asyncapi_route.asyncapi_json_path, json_handler))
 
-            if asyncapi_route.try_it_out and self.brokers:
+            if asyncapi_route.try_it_out_path is not None and self.brokers:
                 try_it_out_route = make_try_it_out_handler(
                     self.brokers,
                     include_in_schema=asyncapi_route.include_in_schema,
@@ -146,7 +146,7 @@ class AsgiFastStream(Application):
                 try_it_out_route.set_logger(logger)
 
                 self.routes.append((
-                    asyncapi_route.try_it_out_url,
+                    asyncapi_route.try_it_out_path,
                     try_it_out_route,
                 ))
 

--- a/faststream/asgi/factories/asyncapi/docs.py
+++ b/faststream/asgi/factories/asyncapi/docs.py
@@ -34,8 +34,7 @@ def make_asyncapi_asgi(
     asyncapi_js_url: str = ASYNCAPI_JS_DEFAULT_URL,
     asyncapi_css_url: str = ASYNCAPI_CSS_DEFAULT_URL,
     try_it_out_plugin_url: str = ASYNCAPI_TRY_IT_PLUGIN_URL,
-    try_it_out: bool = True,
-    try_it_out_url: str = "asyncapi/try",
+    try_it_out_path: str | None = "asyncapi/try",
 ) -> "GetHandler":
     """Create AsyncAPI documentation ASGI handler."""
     cached_docs: str | None = None
@@ -62,8 +61,7 @@ def make_asyncapi_asgi(
                 asyncapi_js_url=asyncapi_js_url,
                 asyncapi_css_url=asyncapi_css_url,
                 try_it_out_plugin_url=try_it_out_plugin_url,
-                try_it_out=try_it_out,
-                try_it_out_url=try_it_out_url,
+                try_it_out_path=try_it_out_path,
             )
 
         return AsgiResponse(

--- a/faststream/asgi/factories/asyncapi/route.py
+++ b/faststream/asgi/factories/asyncapi/route.py
@@ -20,6 +20,7 @@ class AsyncAPIRoute:
     def __init__(
         self,
         path: str,
+        asyncapi_json_path: str | None = "/asyncapi.json",
         description: str | None = None,
         tags: Sequence[Union["Tag", "TagDict", dict[str, Any]]] | None = None,
         unique_id: str | None = None,
@@ -40,6 +41,7 @@ class AsyncAPIRoute:
         try_it_out_url: str | None = None,
     ) -> None:
         self.path = path
+        self.asyncapi_json_path = asyncapi_json_path
 
         self.description = description
         self.tags = tags

--- a/faststream/asgi/factories/asyncapi/route.py
+++ b/faststream/asgi/factories/asyncapi/route.py
@@ -21,12 +21,13 @@ class AsyncAPIRoute:
     def __init__(
         self,
         path: str,
-        asyncapi_json_path: str | None = EMPTY,
         description: str | None = None,
         tags: Sequence[Union["Tag", "TagDict", dict[str, Any]]] | None = None,
         unique_id: str | None = None,
         include_in_schema: bool = False,
+        asyncapi_json_path: str | None = EMPTY,
         *,
+        try_it_out_path: str | None = EMPTY,
         sidebar: bool = True,
         info: bool = True,
         servers: bool = True,
@@ -38,8 +39,6 @@ class AsyncAPIRoute:
         asyncapi_js_url: str = ASYNCAPI_JS_DEFAULT_URL,
         asyncapi_css_url: str = ASYNCAPI_CSS_DEFAULT_URL,
         try_it_out_plugin_url: str = ASYNCAPI_TRY_IT_PLUGIN_URL,
-        try_it_out: bool = True,
-        try_it_out_url: str | None = None,
     ) -> None:
         self.path = path
 
@@ -47,9 +46,9 @@ class AsyncAPIRoute:
             asyncapi_json_path = path.rstrip("/") + ".json"
         self.asyncapi_json_path = asyncapi_json_path
 
-        if not try_it_out_url:
-            try_it_out_url = path.rstrip("/") + "/try"
-        self.try_it_out_url = try_it_out_url
+        if try_it_out_path is EMPTY:
+            try_it_out_path = path.rstrip("/") + "/try"
+        self.try_it_out_path = try_it_out_path
 
         self.description = description
         self.tags = tags
@@ -67,7 +66,6 @@ class AsyncAPIRoute:
         self.asyncapi_js_url = asyncapi_js_url
         self.asyncapi_css_url = asyncapi_css_url
         self.try_it_out_plugin_url = try_it_out_plugin_url
-        self.try_it_out = try_it_out
 
     @classmethod
     def ensure_route(cls, path: Union[str, "AsyncAPIRoute"]) -> "AsyncAPIRoute":
@@ -93,6 +91,5 @@ class AsyncAPIRoute:
             asyncapi_js_url=self.asyncapi_js_url,
             asyncapi_css_url=self.asyncapi_css_url,
             try_it_out_plugin_url=self.try_it_out_plugin_url,
-            try_it_out=self.try_it_out,
-            try_it_out_url=self.try_it_out_url,
+            try_it_out_path=self.try_it_out_path,
         )

--- a/faststream/asgi/factories/asyncapi/route.py
+++ b/faststream/asgi/factories/asyncapi/route.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Union
 
+from faststream._internal.constants import EMPTY
 from faststream.asgi.factories.asyncapi.docs import make_asyncapi_asgi
 from faststream.specification.asyncapi.site import (
     ASYNCAPI_CSS_DEFAULT_URL,
@@ -20,7 +21,7 @@ class AsyncAPIRoute:
     def __init__(
         self,
         path: str,
-        asyncapi_json_path: str | None = "/asyncapi.json",
+        asyncapi_json_path: str | None = EMPTY,
         description: str | None = None,
         tags: Sequence[Union["Tag", "TagDict", dict[str, Any]]] | None = None,
         unique_id: str | None = None,
@@ -41,7 +42,14 @@ class AsyncAPIRoute:
         try_it_out_url: str | None = None,
     ) -> None:
         self.path = path
+
+        if asyncapi_json_path is EMPTY:
+            asyncapi_json_path = path.rstrip("/") + ".json"
         self.asyncapi_json_path = asyncapi_json_path
+
+        if not try_it_out_url:
+            try_it_out_url = path.rstrip("/") + "/try"
+        self.try_it_out_url = try_it_out_url
 
         self.description = description
         self.tags = tags
@@ -60,9 +68,6 @@ class AsyncAPIRoute:
         self.asyncapi_css_url = asyncapi_css_url
         self.try_it_out_plugin_url = try_it_out_plugin_url
         self.try_it_out = try_it_out
-        if not try_it_out_url:
-            try_it_out_url = path.rstrip("/") + "/try"
-        self.try_it_out_url = try_it_out_url
 
     @classmethod
     def ensure_route(cls, path: Union[str, "AsyncAPIRoute"]) -> "AsyncAPIRoute":

--- a/faststream/specification/asyncapi/site.py
+++ b/faststream/specification/asyncapi/site.py
@@ -34,8 +34,7 @@ def get_asyncapi_html(
     asyncapi_js_url: str = ASYNCAPI_JS_DEFAULT_URL,
     asyncapi_css_url: str = ASYNCAPI_CSS_DEFAULT_URL,
     try_it_out_plugin_url: str = ASYNCAPI_TRY_IT_PLUGIN_URL,
-    try_it_out: bool = True,
-    try_it_out_url: str = "asyncapi/try",
+    try_it_out_path: str | None = "asyncapi/try",
 ) -> str:
     """Generate HTML for displaying an AsyncAPI document."""
     config = {
@@ -57,14 +56,14 @@ def get_asyncapi_html(
         },
     }
 
-    if try_it_out:
+    if try_it_out_path is not None:
         plugins_js = f"""
         <script src="{asyncapi_js_url}"></script>
         <script src="{try_it_out_plugin_url}"></script>
         <script>
             const schema = {schema.to_json()};
             const config = {json_dumps(config).decode()};
-            const endpoint = {try_it_out_url!r};
+            const endpoint = {try_it_out_path!r};
             const plugin = window.AsyncApiTryItPlugin.createTryItOutPlugin({{
                 endpointBase: endpoint.replace(/^\\//, ""),
                 resolveEndpoint: () => endpoint,
@@ -163,7 +162,7 @@ class _Handler(server.BaseHTTPRequestHandler):
             schemas=query_dict.get("schemas", True),
             errors=query_dict.get("errors", True),
             expand_message_examples=query_dict.get("expandMessageExamples", True),
-            try_it_out=False,  # CLI serve has no broker — use AsgiFastStream for try-it
+            try_it_out_path=None,  # CLI serve has no broker — use AsgiFastStream for try-it
         )
         body = html.encode(encoding=encoding)
 

--- a/tests/asgi/multibroker/test_try_it_out.py
+++ b/tests/asgi/multibroker/test_try_it_out.py
@@ -169,9 +169,7 @@ class TestMultiBrokerDispatch:
         async def h(msg: Any) -> None:
             mock(msg)
 
-        app = AsgiFastStream(
-            kafka, asyncapi_path=AsyncAPIRoute("/asyncapi")
-        )
+        app = AsgiFastStream(kafka, asyncapi_path=AsyncAPIRoute("/asyncapi"))
 
         async with TestKafkaBroker(kafka):
             with TestClient(app) as client:

--- a/tests/asgi/multibroker/test_try_it_out.py
+++ b/tests/asgi/multibroker/test_try_it_out.py
@@ -69,7 +69,7 @@ class TestMultiBrokerDispatch:
         app = AsgiFastStream(
             kafka_1,
             kafka_2,
-            asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out=True),
+            asyncapi_path=AsyncAPIRoute("/asyncapi"),
         )
 
         async with TestKafkaBroker(kafka_1, kafka_2):
@@ -102,7 +102,7 @@ class TestMultiBrokerDispatch:
         app = AsgiFastStream(
             kafka_1,
             kafka_2,
-            asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out=True),
+            asyncapi_path=AsyncAPIRoute("/asyncapi"),
         )
 
         async with TestKafkaBroker(kafka_1, kafka_2):
@@ -132,7 +132,7 @@ class TestMultiBrokerDispatch:
         app = AsgiFastStream(
             kafka_1,
             kafka_2,
-            asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out=True),
+            asyncapi_path=AsyncAPIRoute("/asyncapi"),
         )
 
         async with TestKafkaBroker(kafka_1, kafka_2):
@@ -151,7 +151,7 @@ class TestMultiBrokerDispatch:
         app = AsgiFastStream(
             kafka_1,
             kafka_2,
-            asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out=True),
+            asyncapi_path=AsyncAPIRoute("/asyncapi"),
         )
 
         async with TestKafkaBroker(kafka_1, kafka_2):
@@ -170,7 +170,7 @@ class TestMultiBrokerDispatch:
             mock(msg)
 
         app = AsgiFastStream(
-            kafka, asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out=True)
+            kafka, asyncapi_path=AsyncAPIRoute("/asyncapi")
         )
 
         async with TestKafkaBroker(kafka):

--- a/tests/asgi/test_app.py
+++ b/tests/asgi/test_app.py
@@ -1,0 +1,188 @@
+"""ASGI-specific logic that does not depend on a concrete broker.
+
+These tests exercise routing, the AsyncAPI docs/JSON endpoints, the ASGI
+handler decorators and dependency injection directly — no broker is required,
+so they run once instead of being inherited by every broker test case. Broker
+behaviour (message delivery, healthchecks, try-it-out dispatch) lives in
+``AsgiTestcase`` and is still parametrized per broker.
+"""
+
+from collections.abc import Callable
+
+import pytest
+from fast_depends import Depends
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from faststream._internal.context import Context
+from faststream.annotations import FastStream, Logger
+from faststream.asgi import (
+    AsgiFastStream,
+    AsgiResponse,
+    AsyncAPIRoute,
+    Request,
+    get,
+    post,
+)
+from faststream.asgi.params import Header, Query
+from faststream.asgi.types import ASGIApp, Scope
+from faststream.specification import AsyncAPI
+
+
+def test_not_found() -> None:
+    client = TestClient(AsgiFastStream())
+    response = client.get("/")
+    assert response.status_code == 404
+
+
+def test_ws_not_found() -> None:
+    client = TestClient(AsgiFastStream())
+    with (
+        pytest.raises(WebSocketDisconnect),
+        client.websocket_connect("/ws"),
+    ):  # raises error
+        pass
+
+
+def test_asyncapi_asgi() -> None:
+    app = AsgiFastStream(specification=AsyncAPI(), asyncapi_path="/docs")
+
+    client = TestClient(app)
+    response = client.get("/docs")
+    assert response.status_code == 200, response
+    assert response.text
+
+
+def test_asyncapi_json_default_path() -> None:
+    app = AsgiFastStream(specification=AsyncAPI(), asyncapi_path="/docs")
+
+    client = TestClient(app)
+    response = client.get("/docs.json")
+    assert response.status_code == 200, response
+    assert response.headers["content-type"] == "application/json"
+    assert response.json() == app.schema.to_specification().to_jsonable()
+
+
+def test_asyncapi_json_path_strips_trailing_slash() -> None:
+    app = AsgiFastStream(specification=AsyncAPI(), asyncapi_path="/docs/")
+
+    client = TestClient(app)
+    assert client.get("/docs.json").status_code == 200
+
+
+def test_asyncapi_json_custom_path() -> None:
+    app = AsgiFastStream(
+        specification=AsyncAPI(),
+        asyncapi_path=AsyncAPIRoute("/docs", asyncapi_json_path="/openapi.json"),
+    )
+
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200, response
+    assert response.json() == app.schema.to_specification().to_jsonable()
+
+    # the default derived path is not registered when overridden
+    assert client.get("/docs.json").status_code == 404
+
+
+def test_asyncapi_json_disabled() -> None:
+    app = AsgiFastStream(
+        specification=AsyncAPI(),
+        asyncapi_path=AsyncAPIRoute("/docs", asyncapi_json_path=None),
+    )
+
+    client = TestClient(app)
+    # docs HTML is still served
+    assert client.get("/docs").status_code == 200
+    # but the JSON endpoint is not registered
+    assert client.get("/docs.json").status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("decorator", "client_method"),
+    (
+        pytest.param(get, "get", id="get"),
+        pytest.param(post, "post", id="post"),
+    ),
+)
+def test_decorators(decorator: Callable[..., ASGIApp], client_method: str) -> None:
+    @decorator
+    async def some_handler(scope: Scope) -> AsgiResponse:
+        return AsgiResponse(body=b"test", status_code=200)
+
+    app = AsgiFastStream(asgi_routes=[("/test", some_handler)])
+
+    client = TestClient(app)
+    response = getattr(client, client_method)("/test")
+    assert response.status_code == 200
+    assert response.text == "test"
+
+
+@pytest.mark.parametrize(
+    ("decorator", "client_method"),
+    (
+        pytest.param(get, "get", id="get"),
+        pytest.param(post, "post", id="post"),
+    ),
+)
+def test_context_injected(decorator: Callable[..., ASGIApp], client_method: str) -> None:
+    @decorator
+    async def some_handler(
+        request: Request, logger: Logger, app: FastStream
+    ) -> AsgiResponse:
+        return AsgiResponse(
+            body=f"{request.__class__.__name__} {logger.__class__.__name__} {app.__class__.__name__}".encode(),
+            status_code=200,
+        )
+
+    app = AsgiFastStream(asgi_routes=[("/test", some_handler)])
+
+    client = TestClient(app)
+    response = getattr(client, client_method)("/test")
+    assert response.status_code == 200
+    assert response.text == "AsgiRequest Logger AsgiFastStream"
+
+
+@pytest.mark.parametrize(
+    ("decorator", "client_method"),
+    (
+        pytest.param(get, "get", id="get"),
+        pytest.param(post, "post", id="post"),
+    ),
+)
+def test_fast_depends_injected(
+    decorator: Callable[..., ASGIApp], client_method: str
+) -> None:
+    def get_string() -> str:
+        return "test"
+
+    @decorator
+    async def some_handler(string=Depends(get_string)) -> AsgiResponse:  # noqa: B008
+        return AsgiResponse(body=string.encode(), status_code=200)
+
+    app = AsgiFastStream(asgi_routes=[("/test", some_handler)])
+
+    client = TestClient(app)
+    response = getattr(client, client_method)("/test")
+    assert response.status_code == 200
+    assert response.text == "test"
+
+
+@pytest.mark.parametrize(
+    "dependency",
+    (
+        pytest.param(Query(), id="query"),
+        pytest.param(Header(), id="header"),
+    ),
+)
+def test_validation_error_handled(dependency: Context) -> None:
+    @get
+    async def some_handler(dep=dependency) -> AsgiResponse:
+        return AsgiResponse(status_code=200)
+
+    app = AsgiFastStream(asgi_routes=[("/test", some_handler)])
+
+    client = TestClient(app)
+    response = client.get("/test")
+    assert response.status_code == 422
+    assert response.text == "Validation error"

--- a/tests/asgi/testcase.py
+++ b/tests/asgi/testcase.py
@@ -54,10 +54,12 @@ class AsgiTestcase:
         app = AsgiFastStream(broker)
 
         async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                with pytest.raises(WebSocketDisconnect):
-                    with client.websocket_connect("/ws"):  # raises error
-                        pass
+            with (
+                TestClient(app) as client,
+                pytest.raises(WebSocketDisconnect),
+                client.websocket_connect("/ws"),
+            ):  # raises error
+                pass
 
     @pytest.mark.asyncio()
     async def test_asgi_ping_healthy(self) -> None:

--- a/tests/asgi/testcase.py
+++ b/tests/asgi/testcase.py
@@ -125,6 +125,74 @@ class AsgiTestcase:
                 assert response.text
 
     @pytest.mark.asyncio()
+    async def test_asyncapi_json_default_path(self) -> None:
+        broker = self.get_broker()
+
+        app = AsgiFastStream(
+            broker,
+            specification=AsyncAPI(),
+            asyncapi_path="/docs",
+        )
+
+        async with self.get_test_broker(broker):
+            with TestClient(app) as client:
+                response = client.get("/docs.json")
+                assert response.status_code == 200, response
+                assert response.headers["content-type"] == "application/json"
+                assert response.json() == app.schema.to_specification().to_jsonable()
+
+    @pytest.mark.asyncio()
+    async def test_asyncapi_json_path_strips_trailing_slash(self) -> None:
+        broker = self.get_broker()
+
+        app = AsgiFastStream(
+            broker,
+            specification=AsyncAPI(),
+            asyncapi_path="/docs/",
+        )
+
+        async with self.get_test_broker(broker):
+            with TestClient(app) as client:
+                response = client.get("/docs.json")
+                assert response.status_code == 200, response
+
+    @pytest.mark.asyncio()
+    async def test_asyncapi_json_custom_path(self) -> None:
+        broker = self.get_broker()
+
+        app = AsgiFastStream(
+            broker,
+            specification=AsyncAPI(),
+            asyncapi_path=AsyncAPIRoute("/docs", asyncapi_json_path="/openapi.json"),
+        )
+
+        async with self.get_test_broker(broker):
+            with TestClient(app) as client:
+                response = client.get("/openapi.json")
+                assert response.status_code == 200, response
+                assert response.json() == app.schema.to_specification().to_jsonable()
+
+                # the default derived path is not registered when overridden
+                assert client.get("/docs.json").status_code == 404
+
+    @pytest.mark.asyncio()
+    async def test_asyncapi_json_disabled(self) -> None:
+        broker = self.get_broker()
+
+        app = AsgiFastStream(
+            broker,
+            specification=AsyncAPI(),
+            asyncapi_path=AsyncAPIRoute("/docs", asyncapi_json_path=None),
+        )
+
+        async with self.get_test_broker(broker):
+            with TestClient(app) as client:
+                # docs HTML is still served
+                assert client.get("/docs").status_code == 200
+                # but the JSON endpoint is not registered
+                assert client.get("/docs.json").status_code == 404
+
+    @pytest.mark.asyncio()
     @pytest.mark.parametrize(
         ("decorator", "client_method"),
         (

--- a/tests/asgi/testcase.py
+++ b/tests/asgi/testcase.py
@@ -249,7 +249,7 @@ class AsgiTestcase:
 
         app = AsgiFastStream(
             broker,
-            asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out=True),
+            asyncapi_path=AsyncAPIRoute("/asyncapi"),
         )
 
         async with self.get_test_broker(broker):
@@ -482,7 +482,7 @@ class AsgiTestcase:
 
         app = AsgiFastStream(
             broker,
-            asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out=False),
+            asyncapi_path=AsyncAPIRoute("/asyncapi", try_it_out_path=None),
         )
 
         async with self.get_test_broker(broker):
@@ -639,7 +639,7 @@ class AsgiTestcase:
             broker,
             asyncapi_path=AsyncAPIRoute(
                 "/docs",
-                try_it_out_url="https://api.example.com/try",
+                try_it_out_path="https://api.example.com/try",
             ),
         )
 

--- a/tests/asgi/testcase.py
+++ b/tests/asgi/testcase.py
@@ -1,32 +1,21 @@
 import asyncio
 import math
-from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from dirty_equals import Contains, IsFloat, IsList, IsPartialDict, IsStr
-from fast_depends import Depends
 from freezegun import freeze_time
 from starlette.applications import Starlette
 from starlette.routing import Mount
 from starlette.testclient import TestClient
-from starlette.websockets import WebSocketDisconnect
 
-from faststream._internal.context import Context
-from faststream.annotations import FastStream, Logger
 from faststream.asgi import (
     AsgiFastStream,
-    AsgiResponse,
     AsyncAPIRoute,
-    Request,
-    get,
     make_asyncapi_asgi,
     make_ping_asgi,
-    post,
 )
-from faststream.asgi.params import Header, Query
-from faststream.asgi.types import ASGIApp, Scope
 from faststream.specification import AsyncAPI
 
 
@@ -36,30 +25,6 @@ class AsgiTestcase:
 
     def get_test_broker(self, broker: Any) -> Any:
         raise NotImplementedError
-
-    @pytest.mark.asyncio()
-    async def test_not_found(self) -> None:
-        broker = self.get_broker()
-        app = AsgiFastStream(broker)
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = client.get("/")
-                assert response.status_code == 404
-
-    @pytest.mark.asyncio()
-    async def test_ws_not_found(self) -> None:
-        broker = self.get_broker()
-
-        app = AsgiFastStream(broker)
-
-        async with self.get_test_broker(broker):
-            with (
-                TestClient(app) as client,
-                pytest.raises(WebSocketDisconnect),
-                client.websocket_connect("/ws"),
-            ):  # raises error
-                pass
 
     @pytest.mark.asyncio()
     async def test_asgi_ping_healthy(self) -> None:
@@ -94,22 +59,6 @@ class AsgiTestcase:
                 assert response.status_code == 500
 
     @pytest.mark.asyncio()
-    async def test_asyncapi_asgi(self) -> None:
-        broker = self.get_broker()
-
-        app = AsgiFastStream(
-            broker,
-            specification=AsyncAPI(),
-            asyncapi_path="/docs",
-        )
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = client.get("/docs")
-                assert response.status_code == 200, response
-                assert response.text
-
-    @pytest.mark.asyncio()
     async def test_asyncapi_asgi_if_broker_set_by_method(self) -> None:
         broker = self.get_broker()
 
@@ -125,176 +74,6 @@ class AsgiTestcase:
                 response = client.get("/docs")
                 assert response.status_code == 200, response
                 assert response.text
-
-    @pytest.mark.asyncio()
-    async def test_asyncapi_json_default_path(self) -> None:
-        broker = self.get_broker()
-
-        app = AsgiFastStream(
-            broker,
-            specification=AsyncAPI(),
-            asyncapi_path="/docs",
-        )
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = client.get("/docs.json")
-                assert response.status_code == 200, response
-                assert response.headers["content-type"] == "application/json"
-                assert response.json() == app.schema.to_specification().to_jsonable()
-
-    @pytest.mark.asyncio()
-    async def test_asyncapi_json_path_strips_trailing_slash(self) -> None:
-        broker = self.get_broker()
-
-        app = AsgiFastStream(
-            broker,
-            specification=AsyncAPI(),
-            asyncapi_path="/docs/",
-        )
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = client.get("/docs.json")
-                assert response.status_code == 200, response
-
-    @pytest.mark.asyncio()
-    async def test_asyncapi_json_custom_path(self) -> None:
-        broker = self.get_broker()
-
-        app = AsgiFastStream(
-            broker,
-            specification=AsyncAPI(),
-            asyncapi_path=AsyncAPIRoute("/docs", asyncapi_json_path="/openapi.json"),
-        )
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = client.get("/openapi.json")
-                assert response.status_code == 200, response
-                assert response.json() == app.schema.to_specification().to_jsonable()
-
-                # the default derived path is not registered when overridden
-                assert client.get("/docs.json").status_code == 404
-
-    @pytest.mark.asyncio()
-    async def test_asyncapi_json_disabled(self) -> None:
-        broker = self.get_broker()
-
-        app = AsgiFastStream(
-            broker,
-            specification=AsyncAPI(),
-            asyncapi_path=AsyncAPIRoute("/docs", asyncapi_json_path=None),
-        )
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                # docs HTML is still served
-                assert client.get("/docs").status_code == 200
-                # but the JSON endpoint is not registered
-                assert client.get("/docs.json").status_code == 404
-
-    @pytest.mark.asyncio()
-    @pytest.mark.parametrize(
-        ("decorator", "client_method"),
-        (
-            pytest.param(get, "get", id="get"),
-            pytest.param(post, "post", id="post"),
-        ),
-    )
-    async def test_decorators(
-        self, decorator: Callable[..., ASGIApp], client_method: str
-    ) -> None:
-        @decorator
-        async def some_handler(scope: Scope) -> AsgiResponse:
-            return AsgiResponse(body=b"test", status_code=200)
-
-        broker = self.get_broker()
-        app = AsgiFastStream(broker, asgi_routes=[("/test", some_handler)])
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = getattr(client, client_method)("/test")
-                assert response.status_code == 200
-                assert response.text == "test"
-
-    @pytest.mark.asyncio()
-    @pytest.mark.parametrize(
-        ("decorator", "client_method"),
-        (
-            pytest.param(get, "get", id="get"),
-            pytest.param(post, "post", id="post"),
-        ),
-    )
-    async def test_context_injected(
-        self, decorator: Callable[..., ASGIApp], client_method: str
-    ) -> None:
-        @decorator
-        async def some_handler(
-            request: Request, logger: Logger, app: FastStream
-        ) -> AsgiResponse:
-            return AsgiResponse(
-                body=f"{request.__class__.__name__} {logger.__class__.__name__} {app.__class__.__name__}".encode(),
-                status_code=200,
-            )
-
-        broker = self.get_broker()
-        app = AsgiFastStream(broker, asgi_routes=[("/test", some_handler)])
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = getattr(client, client_method)("/test")
-                assert response.status_code == 200
-                assert response.text == "AsgiRequest Logger AsgiFastStream"
-
-    @pytest.mark.asyncio()
-    @pytest.mark.parametrize(
-        ("decorator", "client_method"),
-        (
-            pytest.param(get, "get", id="get"),
-            pytest.param(post, "post", id="post"),
-        ),
-    )
-    async def test_fast_depends_injected(
-        self, decorator: Callable[..., ASGIApp], client_method: str
-    ) -> None:
-        def get_string() -> str:
-            return "test"
-
-        @decorator
-        async def some_handler(string=Depends(get_string)) -> AsgiResponse:  # noqa: B008
-            return AsgiResponse(body=string.encode(), status_code=200)
-
-        broker = self.get_broker()
-        app = AsgiFastStream(broker, asgi_routes=[("/test", some_handler)])
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = getattr(client, client_method)("/test")
-                assert response.status_code == 200
-                assert response.text == "test"
-
-    @pytest.mark.asyncio()
-    @pytest.mark.parametrize(
-        "dependency",
-        (
-            pytest.param(Query(), id="query"),
-            pytest.param(Header(), id="header"),
-        ),
-    )
-    async def test_validation_error_handled(self, dependency: Context) -> None:
-        @get
-        async def some_handler(dep=dependency) -> AsgiResponse:
-            return AsgiResponse(status_code=200)
-
-        broker = self.get_broker()
-        app = AsgiFastStream(broker, asgi_routes=[("/test", some_handler)])
-
-        async with self.get_test_broker(broker):
-            with TestClient(app) as client:
-                response = client.get("/test")
-                assert response.status_code == 422
-                assert response.text == "Validation error"
 
     def test_asyncapi_pure_asgi(self) -> None:
         broker = self.get_broker()


### PR DESCRIPTION
# Description

Create new endpoint which  sends raw json documentation. Fix fastapi integration endpoint header "content-type: application/json"

Fixes #2803
## Type of change

- [x] New feature (a non-breaking change that adds functionality)
## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`

