### PR TITLE
fix(docs): export *ParserType aliases at runtime

### DIFF
--- a/faststream/confluent/__init__.py
+++ b/faststream/confluent/__init__.py
@@ -1,11 +1,7 @@
-from typing import TYPE_CHECKING
-
+from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-if TYPE_CHECKING:
-    from faststream._internal.parser import ParserProto
-
-    ConfluentParserType = ParserProto["Message"]  # type: ignore[name-defined]
+ConfluentParserType = ParserProto["Message"]  # type: ignore[name-defined]
 
 try:
     from .annotations import KafkaMessage

--- a/faststream/kafka/__init__.py
+++ b/faststream/kafka/__init__.py
@@ -1,13 +1,12 @@
 from typing import TYPE_CHECKING
 
+from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
 if TYPE_CHECKING:
     from aiokafka import ConsumerRecord
 
-    from faststream._internal.parser import ParserProto
-
-    KafkaParserType = ParserProto["ConsumerRecord"]
+KafkaParserType = ParserProto["ConsumerRecord"]
 
 try:
     from aiokafka import ConsumerRecord, TopicPartition

--- a/faststream/nats/__init__.py
+++ b/faststream/nats/__init__.py
@@ -1,11 +1,7 @@
-from typing import TYPE_CHECKING
-
+from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-if TYPE_CHECKING:
-    from faststream._internal.parser import ParserProto
-
-    NatsParserType = ParserProto["Msg"]  # type: ignore[name-defined]
+NatsParserType = ParserProto["Msg"]  # type: ignore[name-defined]
 
 try:
     from nats.js.api import (

--- a/faststream/rabbit/__init__.py
+++ b/faststream/rabbit/__init__.py
@@ -1,11 +1,7 @@
-from typing import TYPE_CHECKING
-
+from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-if TYPE_CHECKING:
-    from faststream._internal.parser import ParserProto
-
-    RabbitParserType = ParserProto["IncomingMessage"]  # type: ignore[name-defined]
+RabbitParserType = ParserProto["IncomingMessage"]  # type: ignore[name-defined]
 
 try:
     from .annotations import RabbitMessage

--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -1,11 +1,7 @@
-from typing import TYPE_CHECKING
-
+from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-if TYPE_CHECKING:
-    from faststream._internal.parser import ParserProto
-
-    RedisParserType = ParserProto["Mapping[str, Any]"]  # type: ignore[name-defined]
+RedisParserType = ParserProto["Mapping[str, Any]"]  # type: ignore[name-defined]
 
 try:
     from .annotations import (


### PR DESCRIPTION
## Problem

The `deploy_docs` → **Build API Reference** job fails with:

```python
AttributeError: module 'faststream.confluent' has no attribute 'ConfluentParserType'
```

([example failing run](https://github.com/ag2ai/faststream/actions/runs/26781885304/job/78948007549))

The API-reference builder (`docs/create_api_docs.py`) walks each module's `__all__` and calls `getattr(m, name)` at **runtime**. Every broker `__init__.py` lists its `*ParserType` alias in `__all__` but defined it only under `TYPE_CHECKING`, so at runtime the attribute does not exist and `getattr` raises. `confluent` fails first only because it's alphabetically earliest.

Introduced in #2841 ("codec wiring unification"); affects all five brokers (confluent, kafka, nats, rabbit, redis).

## Fix

Move each `*ParserType` alias definition (and the `ParserProto` import) out of the `TYPE_CHECKING` block so they exist as real runtime attributes. They resolve to `ParserProto[ForwardRef(...)]` generic aliases, which the docs builder skips (not a function/class) without crashing.

## Verification

- `cd docs && python docs.py build-api-docs` now completes without the traceback.
- All five aliases resolve at runtime via `getattr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)