### PR TITLE
fix(testing): type TestBroker context result via __init__ overloads

### DIFF
--- a/faststream/_internal/testing/ast.py
+++ b/faststream/_internal/testing/ast.py
@@ -7,9 +7,18 @@ from typing import cast
 
 
 def is_contains_context_name(scip_name: str, name: str) -> bool:
-    stack = traceback.extract_stack()[-3]
-    tree = _read_source_ast(stack.filename)
-    node = cast("ast.With | ast.AsyncWith", _find_ast_node(tree, stack.lineno))
+    stack = traceback.extract_stack()
+    # Walk out past this frame and the ``TestBroker.__init__`` chain (the
+    # abstract base plus the concrete subclass override) to the user frame
+    # that opened the ``with`` block, regardless of how many ``__init__``
+    # frames sit in between.
+    idx = len(stack) - 2
+    while idx > 0 and stack[idx].name == "__init__":
+        idx -= 1
+    frame = stack[idx]
+
+    tree = _read_source_ast(frame.filename)
+    node = cast("ast.With | ast.AsyncWith", _find_ast_node(tree, frame.lineno))
     context_calls = _get_withitem_calls(node)
 
     try:

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, TypeVar, cas
 from unittest import mock
 from unittest.mock import MagicMock
 
+from typing_extensions import TypeVar as TypeVar313
+
 from faststream._internal.broker import BrokerUsecase
 from faststream._internal.logger.logger_proxy import RealLoggerObject
 from faststream._internal.testing.app import TestApp
@@ -26,7 +28,7 @@ Broker = TypeVar("Broker", bound=BrokerUsecase[Any, Any])
 
 # ``__aenter__`` return type. Each concrete ``TestBroker`` subclass binds it to a
 # single broker or a ``tuple`` of brokers via its overloaded ``__init__``.
-EnterType = TypeVar("EnterType")
+EnterType = TypeVar313("EnterType", default=Any)
 
 
 class _ProducerContains(Protocol):

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -7,7 +7,7 @@ from contextlib import (
     contextmanager,
 )
 from functools import partial
-from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, TypeVar, cast
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -24,6 +24,10 @@ if TYPE_CHECKING:
 
 Broker = TypeVar("Broker", bound=BrokerUsecase[Any, Any])
 
+# ``__aenter__`` return type. Each concrete ``TestBroker`` subclass binds it to a
+# single broker or a ``tuple`` of brokers via its overloaded ``__init__``.
+EnterType = TypeVar("EnterType")
+
 
 class _ProducerContains(Protocol):
     producer: Any
@@ -39,7 +43,7 @@ def change_producer(
     config.producer = old_producer
 
 
-class TestBroker(Generic[Broker]):
+class TestBroker(Generic[Broker, EnterType]):
     """A class to represent a test broker."""
 
     # This is set so pytest ignores this class
@@ -75,12 +79,12 @@ class TestBroker(Generic[Broker]):
         self.connect_only = connect_only
         self._fake_subscribers: list[SubscriberUsecase[Any]] = []
 
-    async def __aenter__(self) -> Broker | list[Broker]:
+    async def __aenter__(self) -> EnterType:
         self._ctx = self._create_ctx()
         brokers = await self._ctx.__aenter__()
         if len(brokers) == 1:
-            return brokers[0]
-        return brokers
+            return cast("EnterType", brokers[0])
+        return cast("EnterType", brokers)
 
     async def __aexit__(
         self,

--- a/faststream/asgi/factories/asyncapi/try_it_out.py
+++ b/faststream/asgi/factories/asyncapi/try_it_out.py
@@ -1,7 +1,7 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from contextlib import suppress
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, TypedDict, Union
+from typing import TYPE_CHECKING, Any, TypedDict, Union, cast
 
 from faststream.asgi.annotations import Request
 from faststream.asgi.handlers import PostHandler, post
@@ -48,7 +48,9 @@ class TryItOutProcessor:
 
     def __init__(self, *brokers: "BrokerUsecase[Any, Any]") -> None:
         registry = _get_broker_registry()
-        self._entries: list[tuple[BrokerUsecase[Any, Any], type[TestBroker[Any]]]] = []
+        self._entries: list[
+            tuple[BrokerUsecase[Any, Any], type[TestBroker[Any, Any]]]
+        ] = []
         for broker in brokers:
             for br_cls, test_broker_cls in registry.items():
                 if isinstance(broker, br_cls):
@@ -110,7 +112,14 @@ class TryItOutProcessor:
                     if cls is test_broker_cls and b is not broker
                 ),
             )
-            async with test_broker_cls(*same_type_brokers):
+            # ``test_broker_cls`` is typed as the abstract ``TestBroker`` base, whose
+            # overloaded ``__init__`` would make mypy try to instantiate the abstract
+            # class. At runtime it is always a concrete subclass; the enter result is
+            # unused here, so call it through a plain factory type.
+            test_broker_factory = cast(
+                "Callable[..., TestBroker[Any, Any]]", test_broker_cls
+            )
+            async with test_broker_factory(*same_type_brokers):
                 data = await broker.request(payload, destination, timeout=30)
                 decoded = None
                 with suppress(Exception):
@@ -187,9 +196,9 @@ def _iter_broker_channels(broker: "BrokerUsecase[Any, Any]") -> set[str]:
 @lru_cache(maxsize=1)
 def _get_broker_registry() -> dict[
     type["BrokerUsecase[Any, Any]"],
-    type["TestBroker[Any]"],
+    type["TestBroker[Any, Any]"],
 ]:
-    registry: dict[type[BrokerUsecase[Any, Any]], type[TestBroker[Any]]] = {}
+    registry: dict[type[BrokerUsecase[Any, Any]], type[TestBroker[Any, Any]]] = {}
 
     with suppress(ImportError):
         from faststream.confluent import (

--- a/faststream/confluent/testing.py
+++ b/faststream/confluent/testing.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast, overload
 from unittest.mock import AsyncMock, MagicMock
 
 import anyio
@@ -9,7 +9,11 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import BatchCodecProto, DefaultCodec
-from faststream._internal.testing.broker import TestBroker, change_producer
+from faststream._internal.testing.broker import (
+    EnterType,
+    TestBroker,
+    change_producer,
+)
 from faststream.confluent.broker import KafkaBroker
 from faststream.confluent.parser import AsyncConfluentParser
 from faststream.confluent.publisher.producer import AsyncConfluentFastProducer
@@ -32,8 +36,38 @@ if TYPE_CHECKING:
 __all__ = ("TestKafkaBroker",)
 
 
-class TestKafkaBroker(TestBroker[KafkaBroker]):
+class TestKafkaBroker(TestBroker[KafkaBroker, EnterType]):
     """A class to test Kafka brokers."""
+
+    @overload
+    def __init__(
+        self: "TestKafkaBroker[KafkaBroker]",
+        broker: KafkaBroker,
+        /,
+        *,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "TestKafkaBroker[tuple[KafkaBroker, ...]]",
+        *brokers: KafkaBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *brokers: KafkaBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None:
+        super().__init__(
+            *brokers,
+            with_real=with_real,
+            connect_only=connect_only,
+        )
 
     @contextmanager
     def _patch_producer(self, broker: KafkaBroker) -> Iterator[None]:

--- a/faststream/kafka/testing.py
+++ b/faststream/kafka/testing.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast, overload
 from unittest.mock import AsyncMock, MagicMock
 
 import anyio
@@ -11,7 +11,11 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import BatchCodecProto, DefaultCodec
-from faststream._internal.testing.broker import TestBroker, change_producer
+from faststream._internal.testing.broker import (
+    EnterType,
+    TestBroker,
+    change_producer,
+)
 from faststream.exceptions import SubscriberNotFound
 from faststream.kafka import TopicPartition
 from faststream.kafka.broker import KafkaBroker
@@ -34,8 +38,38 @@ if TYPE_CHECKING:
 __all__ = ("TestKafkaBroker",)
 
 
-class TestKafkaBroker(TestBroker[KafkaBroker]):
+class TestKafkaBroker(TestBroker[KafkaBroker, EnterType]):
     """A class to test Kafka brokers."""
+
+    @overload
+    def __init__(
+        self: "TestKafkaBroker[KafkaBroker]",
+        broker: KafkaBroker,
+        /,
+        *,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "TestKafkaBroker[tuple[KafkaBroker, ...]]",
+        *brokers: KafkaBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *brokers: KafkaBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None:
+        super().__init__(
+            *brokers,
+            with_real=with_real,
+            connect_only=connect_only,
+        )
 
     @contextmanager
     def _patch_producer(self, broker: KafkaBroker) -> Iterator[None]:

--- a/faststream/mqtt/testing.py
+++ b/faststream/mqtt/testing.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast, overload
 from unittest.mock import MagicMock
 
 import anyio
@@ -11,7 +11,11 @@ from zmqtt._internal.protocol import _shared_filter_to_actual, _topic_matches
 
 from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
-from faststream._internal.testing.broker import TestBroker, change_producer
+from faststream._internal.testing.broker import (
+    EnterType,
+    TestBroker,
+    change_producer,
+)
 from faststream.exceptions import SubscriberNotFound
 from faststream.mqtt.broker.broker import MQTTBroker
 from faststream.mqtt.parser import MQTTParserV5, MQTTParserV311
@@ -66,7 +70,7 @@ def _parser_for_version(
     return MQTTParserV311() if version == "3.1.1" else MQTTParserV5()
 
 
-class TestMQTTBroker(TestBroker[MQTTBroker]):
+class TestMQTTBroker(TestBroker[MQTTBroker, EnterType]):
     """In-memory test double for MQTTBroker.
 
     Routes published messages to matching subscribers without a real
@@ -80,6 +84,36 @@ class TestMQTTBroker(TestBroker[MQTTBroker]):
             await br.publish("hello", "sensors/temp")
             handler.mock.assert_called_once_with("hello")
     """
+
+    @overload
+    def __init__(
+        self: "TestMQTTBroker[MQTTBroker]",
+        broker: MQTTBroker,
+        /,
+        *,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "TestMQTTBroker[tuple[MQTTBroker, ...]]",
+        *brokers: MQTTBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *brokers: MQTTBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None:
+        super().__init__(
+            *brokers,
+            with_real=with_real,
+            connect_only=connect_only,
+        )
 
     def create_publisher_fake_subscriber(
         self,

--- a/faststream/nats/testing.py
+++ b/faststream/nats/testing.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator, Iterable, Iterator, Sequence
 from contextlib import ExitStack, contextmanager
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast, overload
 from unittest.mock import AsyncMock
 
 import anyio
@@ -9,7 +9,7 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
-from faststream._internal.testing.broker import TestBroker
+from faststream._internal.testing.broker import EnterType, TestBroker
 from faststream.exceptions import SubscriberNotFound
 from faststream.message import gen_cor_id
 from faststream.nats.broker import NatsBroker
@@ -49,8 +49,38 @@ def change_producer(
     config.broker_config.js_producer = old_js_producer
 
 
-class TestNatsBroker(TestBroker[NatsBroker]):
+class TestNatsBroker(TestBroker[NatsBroker, EnterType]):
     """A class to test NATS brokers."""
+
+    @overload
+    def __init__(
+        self: "TestNatsBroker[NatsBroker]",
+        broker: NatsBroker,
+        /,
+        *,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "TestNatsBroker[tuple[NatsBroker, ...]]",
+        *brokers: NatsBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *brokers: NatsBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None:
+        super().__init__(
+            *brokers,
+            with_real=with_real,
+            connect_only=connect_only,
+        )
 
     def create_publisher_fake_subscriber(
         self,

--- a/faststream/rabbit/testing.py
+++ b/faststream/rabbit/testing.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast, overload
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -13,7 +13,11 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
-from faststream._internal.testing.broker import TestBroker, change_producer
+from faststream._internal.testing.broker import (
+    EnterType,
+    TestBroker,
+    change_producer,
+)
 from faststream.exceptions import SubscriberNotFound
 from faststream.message import gen_cor_id
 from faststream.rabbit.broker.broker import RabbitBroker
@@ -39,8 +43,38 @@ if TYPE_CHECKING:
 __all__ = ("TestRabbitBroker",)
 
 
-class TestRabbitBroker(TestBroker[RabbitBroker]):
+class TestRabbitBroker(TestBroker[RabbitBroker, EnterType]):
     """A class to test RabbitMQ brokers."""
+
+    @overload
+    def __init__(
+        self: "TestRabbitBroker[RabbitBroker]",
+        broker: RabbitBroker,
+        /,
+        *,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "TestRabbitBroker[tuple[RabbitBroker, ...]]",
+        *brokers: RabbitBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *brokers: RabbitBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None:
+        super().__init__(
+            *brokers,
+            with_real=with_real,
+            connect_only=connect_only,
+        )
 
     @contextmanager
     def _patch_broker(self, broker: "RabbitBroker") -> Generator[None, None, None]:

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -10,6 +10,7 @@ from typing import (
     Protocol,
     Union,
     cast,
+    overload,
 )
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
@@ -19,7 +20,11 @@ from typing_extensions import TypedDict, override
 
 from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
-from faststream._internal.testing.broker import TestBroker, change_producer
+from faststream._internal.testing.broker import (
+    EnterType,
+    TestBroker,
+    change_producer,
+)
 from faststream.exceptions import SetupError, SubscriberNotFound
 from faststream.message import gen_cor_id
 from faststream.redis.broker.broker import RedisBroker
@@ -51,8 +56,38 @@ if TYPE_CHECKING:
 __all__ = ("TestRedisBroker",)
 
 
-class TestRedisBroker(TestBroker[RedisBroker]):
+class TestRedisBroker(TestBroker[RedisBroker, EnterType]):
     """A class to test Redis brokers."""
+
+    @overload
+    def __init__(
+        self: "TestRedisBroker[RedisBroker]",
+        broker: RedisBroker,
+        /,
+        *,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self: "TestRedisBroker[tuple[RedisBroker, ...]]",
+        *brokers: RedisBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        *brokers: RedisBroker,
+        with_real: bool = False,
+        connect_only: bool | None = None,
+    ) -> None:
+        super().__init__(
+            *brokers,
+            with_real=with_real,
+            connect_only=connect_only,
+        )
 
     @asynccontextmanager
     async def _create_ctx(self) -> AsyncGenerator[list[RedisBroker], None]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 
 requires-python = ">=3.10"
-version = "0.7.0"
+version = "0.7.1"
 
 keywords = [
     "rabbitmq",

--- a/tests/integrations/msgspec/test_serialization.py
+++ b/tests/integrations/msgspec/test_serialization.py
@@ -78,7 +78,7 @@ async def test_msgspec_serialize(
     expected_message: Any,
     mock: MagicMock,
     broker_cls: type[BrokerUsecase[Any, Any]],
-    test_cls: type[TestBroker[Any]],
+    test_cls: type[TestBroker[Any, Any]],
 ) -> None:
     broker = broker_cls(serializer=MsgSpecSerializer())
 

--- a/tests/mypy/confluent.py
+++ b/tests/mypy/confluent.py
@@ -3,7 +3,7 @@ import asyncio
 from confluent_kafka import Message
 from typing_extensions import assert_type
 
-from faststream.confluent import KafkaBroker, KafkaMessage, KafkaRouter
+from faststream.confluent import KafkaBroker, KafkaMessage, KafkaRouter, TestKafkaBroker
 from faststream.confluent.fastapi import KafkaRouter as FastAPIRouter
 from faststream.confluent.publisher.usecase import (
     BatchPublisher,
@@ -14,6 +14,18 @@ from faststream.confluent.subscriber.usecase import (
     ConcurrentDefaultSubscriber,
     DefaultSubscriber,
 )
+
+
+async def check_multiple_test_brokers() -> None:
+    async with TestKafkaBroker(KafkaBroker()) as br1:
+        await br1.publish(None, "test")
+
+    async with TestKafkaBroker(
+        KafkaBroker(),
+        KafkaBroker(),
+    ) as (br1, br2):
+        await br1.publish(None, "test")
+        await br2.publish(None, "test")
 
 
 async def check_response_type() -> None:

--- a/tests/mypy/kafka.py
+++ b/tests/mypy/kafka.py
@@ -12,6 +12,7 @@ from faststream.kafka import (
     KafkaRoute,
     KafkaRouter,
     RecordMetadata,
+    TestKafkaBroker,
 )
 from faststream.kafka.fastapi import KafkaRouter as FastAPIRouter
 from faststream.kafka.opentelemetry import KafkaTelemetryMiddleware
@@ -23,6 +24,18 @@ from faststream.kafka.subscriber.usecase import (
     ConcurrentDefaultSubscriber,
     DefaultSubscriber,
 )
+
+
+async def check_multiple_test_brokers() -> None:
+    async with TestKafkaBroker(KafkaBroker()) as br1:
+        await br1.publish(None, "test")
+
+    async with TestKafkaBroker(
+        KafkaBroker(),
+        KafkaBroker(),
+    ) as (br1, br2):
+        await br1.publish(None, "test")
+        await br2.publish(None, "test")
 
 
 def sync_decoder(msg: KafkaMessage) -> DecodedMessage:

--- a/tests/mypy/mqtt.py
+++ b/tests/mypy/mqtt.py
@@ -1,0 +1,13 @@
+from faststream.mqtt import MQTTBroker, TestMQTTBroker
+
+
+async def check_multiple_test_brokers() -> None:
+    async with TestMQTTBroker(MQTTBroker()) as br1:
+        await br1.publish(None, "test")
+
+    async with TestMQTTBroker(
+        MQTTBroker(),
+        MQTTBroker(),
+    ) as (br1, br2):
+        await br1.publish(None, "test")
+        await br2.publish(None, "test")

--- a/tests/mypy/nats.py
+++ b/tests/mypy/nats.py
@@ -5,7 +5,14 @@ from nats.aio.msg import Msg
 from typing_extensions import assert_type
 
 from faststream._internal.basic_types import DecodedMessage
-from faststream.nats import NatsBroker, NatsMessage, NatsRoute, NatsRouter, PubAck
+from faststream.nats import (
+    NatsBroker,
+    NatsMessage,
+    NatsRoute,
+    NatsRouter,
+    PubAck,
+    TestNatsBroker,
+)
 from faststream.nats.fastapi import NatsRouter as FastAPIRouter
 from faststream.nats.message import NatsKvMessage, NatsObjMessage
 from faststream.nats.opentelemetry import NatsTelemetryMiddleware
@@ -23,6 +30,18 @@ from faststream.nats.subscriber.usecases import (
     PullStreamSubscriber,
     PushStreamSubscriber,
 )
+
+
+async def check_multiple_test_brokers() -> None:
+    async with TestNatsBroker(NatsBroker()) as br1:
+        await br1.publish(None, "test")
+
+    async with TestNatsBroker(
+        NatsBroker(),
+        NatsBroker(),
+    ) as (br1, br2):
+        await br1.publish(None, "test")
+        await br2.publish(None, "test")
 
 
 def sync_decoder(msg: NatsMessage) -> DecodedMessage:

--- a/tests/mypy/rabbit.py
+++ b/tests/mypy/rabbit.py
@@ -6,12 +6,30 @@ from aiormq.abc import ConfirmationFrameType
 from typing_extensions import assert_type
 
 from faststream._internal.basic_types import DecodedMessage
-from faststream.rabbit import RabbitBroker, RabbitMessage, RabbitRoute, RabbitRouter
+from faststream.rabbit import (
+    RabbitBroker,
+    RabbitMessage,
+    RabbitRoute,
+    RabbitRouter,
+    TestRabbitBroker,
+)
 from faststream.rabbit.fastapi import RabbitRouter as FastAPIRouter
 from faststream.rabbit.opentelemetry import RabbitTelemetryMiddleware
 from faststream.rabbit.prometheus import RabbitPrometheusMiddleware
 from faststream.rabbit.publisher.usecase import RabbitPublisher
 from faststream.rabbit.subscriber.usecase import RabbitSubscriber
+
+
+async def check_multiple_test_brokers() -> None:
+    async with TestRabbitBroker(RabbitBroker()) as br1:
+        await br1.publish(None, "test")
+
+    async with TestRabbitBroker(
+        RabbitBroker(),
+        RabbitBroker(),
+    ) as (br1, br2):
+        await br1.publish(None, "test")
+        await br2.publish(None, "test")
 
 
 def sync_decoder(msg: RabbitMessage) -> DecodedMessage:

--- a/tests/mypy/redis.py
+++ b/tests/mypy/redis.py
@@ -14,6 +14,7 @@ from faststream.redis import (
     RedisRouter,
     RedisStreamMessage,
     StreamSub,
+    TestRedisBroker,
 )
 from faststream.redis.fastapi import RedisRouter as FastAPIRouter
 from faststream.redis.message import RedisMessage as Msg
@@ -35,6 +36,18 @@ from faststream.redis.subscriber.usecases import (
     StreamConcurrentSubscriber,
     StreamSubscriber,
 )
+
+
+async def check_multiple_test_brokers() -> None:
+    async with TestRedisBroker(RedisBroker()) as br1:
+        await br1.publish(None, "test")
+
+    async with TestRedisBroker(
+        RedisBroker(),
+        RedisBroker(),
+    ) as (br1, br2):
+        await br1.publish(None, "test")
+        await br2.publish(None, "test")
 
 
 def sync_decoder(msg: Message) -> DecodedMessage:

--- a/tests/utils/test_ast.py
+++ b/tests/utils/test_ast.py
@@ -30,6 +30,16 @@ class B(Context):
         pass
 
 
+class SubA(A):
+    """Mirrors a concrete ``TestBroker`` subclass that delegates to ``super``.
+
+    The extra ``__init__`` frame must not break context-name detection.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
 def test_base() -> None:
     with A() as a, B():
         assert a.contains
@@ -73,6 +83,22 @@ def test_base_invalid() -> None:
 
 def test_nested_invalid() -> None:
     with B(), A() as a:
+        assert not a.contains
+
+
+def test_subclass_init_chain() -> None:
+    with SubA() as a, B():
+        assert a.contains
+
+
+@pytest.mark.asyncio()
+async def test_subclass_init_chain_async() -> None:
+    async with SubA() as a, B():
+        assert a.contains
+
+
+def test_subclass_init_chain_invalid() -> None:
+    with B(), SubA() as a:
         assert not a.contains
 
 


### PR DESCRIPTION
# Description

`TestBroker.__aenter__` was typed to return `Broker | list[Broker]`. That union is wrong for both usage shapes: mypy rejects `.publish()` on the single-broker result (the `list` arm has no such method) and rejects unpacking the multi-broker result (the `Broker` arm is not iterable).

```python
# Before — both lines fail under `just static-analysis`:
async with TestKafkaBroker(KafkaBroker()) as br:
    await br.publish(None, "test")
    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]

async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
    # error: "KafkaBroker" object is not iterable  [misc]
    ...
```

## Solution

`TestBroker` is now generic over a second type parameter `EnterType` (the `__aenter__` result), and each concrete test broker declares explicit `__init__` overloads that bind it:

- one positional broker → the broker type
- `*brokers` → `tuple[Broker, ...]`

```python
class TestKafkaBroker(TestBroker[KafkaBroker, EnterType]):
    @overload
    def __init__(self: "TestKafkaBroker[KafkaBroker]", broker: KafkaBroker, /, *, ...) -> None: ...
    @overload
    def __init__(self: "TestKafkaBroker[tuple[KafkaBroker, ...]]", *brokers: KafkaBroker, ...) -> None: ...
    def __init__(self, *brokers: KafkaBroker, ...) -> None:
        super().__init__(*brokers, ...)
```

```python
# After — mypy infers the precise type:
async with TestKafkaBroker(KafkaBroker()) as br:
    reveal_type(br)            # KafkaBroker
    await br.publish(None, "test")

async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
    await br1.publish(None, "test")
    await br2.publish(None, "test")
```

> The overloads live on each concrete subclass rather than the abstract base: self-typed overloads on the base fail to bind `EnterType` once a subclass fixes the broker type (mypy leaves it `Never`), so the inference must be expressed per concrete broker.

This is applied to all brokers — Kafka, Confluent, Redis, NATS, RabbitMQ and MQTT — and `tests/mypy/*` now contains a `check_multiple_test_brokers` regression test for each (new `tests/mypy/mqtt.py`).

Fixes # (issue number)

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
