### PR TITLE
Docs batch example

### DIFF
--- a/docs/docs/en/nats/jetstream/pull.md
+++ b/docs/docs/en/nats/jetstream/pull.md
@@ -37,4 +37,40 @@ The batch size doesn't mean that your `msg` argument is a list of messages, but 
 !!! tip
     If you want to consume list of messages, just set the `batch=True` in `PullSub` class.
 
+```
+from typing import Annotated
+
+from faststream import Context, FastStream, Logger
+from faststream.nats import NatsBroker, PullSub, message
+
+broker = NatsBroker()
+
+@broker.subscriber(
+    "test",
+    stream="test",
+    durable="test",
+    pull_sub=PullSub(batch=True, batch_size=3),
+)
+async def handler(
+    bodies: list[str],
+    logger: Logger,
+    msg: Annotated[message.NatsBatchMessage, Context("message")],
+) -> None:
+    logger.info(bodies)
+    for m in msg.raw_message:
+        await m.ack()
+
+app = FastStream(broker)
+
+@app.after_startup
+async def after_startup() -> None:
+    for i in range(3):
+        await broker.publish(f"Hello, world! {i}", "test", stream="test")
+```
+
+This example demonstrates how to use `batch=True` with a Pull subscriber.
+The message bodies are passed as a list into `bodies`, while the native NATS
+messages are available via `msg.raw_message` (type `NatsBatchMessage`),
+allowing per‑message `ack()` inside a batch.
+
 So, your subject will be processed much faster, without blocking for each message processing. However, if your subject has fewer than `#!python 10` messages, your request to **NATS** will be blocked for `timeout` (5 seconds by default) while trying to collect the required number of messages. Therefore, you should choose `batch_size` and `timeout` accurately to optimize your consumer efficiency.

--- a/docs/docs/en/nats/jetstream/pull.md
+++ b/docs/docs/en/nats/jetstream/pull.md
@@ -37,40 +37,15 @@ The batch size doesn't mean that your `msg` argument is a list of messages, but 
 !!! tip
     If you want to consume list of messages, just set the `batch=True` in `PullSub` class.
 
-```python
-from typing import Annotated
-
-from faststream import Context, FastStream, Logger
-from faststream.nats import NatsBroker, PullSub, message
-
-broker = NatsBroker()
-
-@broker.subscriber(
-    "test",
-    stream="test",
-    durable="test",
-    pull_sub=PullSub(batch=True, batch_size=3),
-)
-async def handler(
-    bodies: list[str],
-    logger: Logger,
-    msg: Annotated[message.NatsBatchMessage, Context("message")],
-) -> None:
-    logger.info(bodies)
-    for m in msg.raw_message:
-        await m.ack()
-
-app = FastStream(broker)
-
-@app.after_startup
-async def after_startup() -> None:
-    for i in range(3):
-        await broker.publish(f"Hello, world! {i}", "test", stream="test")
-```
+### Batch Pull Subscriber Example
 
 This example demonstrates how to use `batch=True` with a Pull subscriber.
 The message bodies are passed as a list into `bodies`, while the native NATS
 messages are available via `msg.raw_message` (type `NatsBatchMessage`),
 allowing per‑message `ack()` inside a batch.
+
+```python linenums="1" hl_lines="10-11"
+{! docs_src/nats/js/pull_sub_batch_example.py !}
+```
 
 So, your subject will be processed much faster, without blocking for each message processing. However, if your subject has fewer than `#!python 10` messages, your request to **NATS** will be blocked for `timeout` (5 seconds by default) while trying to collect the required number of messages. Therefore, you should choose `batch_size` and `timeout` accurately to optimize your consumer efficiency.

--- a/docs/docs/en/nats/jetstream/pull.md
+++ b/docs/docs/en/nats/jetstream/pull.md
@@ -37,7 +37,7 @@ The batch size doesn't mean that your `msg` argument is a list of messages, but 
 !!! tip
     If you want to consume list of messages, just set the `batch=True` in `PullSub` class.
 
-```
+```python
 from typing import Annotated
 
 from faststream import Context, FastStream, Logger

--- a/docs_src/nats/js/pull_sub_batch_example.py
+++ b/docs_src/nats/js/pull_sub_batch_example.py
@@ -1,0 +1,28 @@
+from typing import Annotated
+
+from faststream import Context, FastStream, Logger
+from faststream.nats import NatsBroker, PullSub, message
+
+broker = NatsBroker()
+
+@broker.subscriber(
+    "test",
+    stream="test",
+    durable="test",
+    pull_sub=PullSub(batch=True, batch_size=3),
+)
+async def handler(
+    bodies: list[str],
+    logger: Logger,
+    msg: Annotated[message.NatsBatchMessage, Context("message")],
+) -> None:
+    logger.info(bodies)
+    for m in msg.raw_message:
+        await m.ack()
+
+app = FastStream(broker)
+
+@app.after_startup
+async def after_startup() -> None:
+    for i in range(3):
+        await broker.publish(f"Hello, world! {i}", "test", stream="test")

--- a/tests/docs/nats/js/test_pull_sub_batch_example.py
+++ b/tests/docs/nats/js/test_pull_sub_batch_example.py
@@ -1,0 +1,2 @@
+def test_pull_sub_batch_example_import():
+    import docs_src.nats.js.pull_sub_batch_example as example


### PR DESCRIPTION
# Description

This PR adds a working example of using `batch=True` with `PullSub` in NATS JetStream.
It demonstrates how to access native NATS messages via `msg.raw_message` and perform
per‑message `ack()` inside a batch.

This improves the documentation by providing a real, functional example for batch
processing, which was previously missing.

Fixes: none

## Type of change

- [x] Documentation (code examples or documentation updates)

## Checklist

- [x] I have reviewed my changes
- [x] I have updated the documentation accordingly
- [x] My changes do not introduce any warnings
