### PR TITLE
fix: declare nats-py[nkeys] extra so NKEY auth works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ confluent = [
     "confluent-kafka>=2.6,!=2.8.1,<3; python_version >= '3.13'",
 ]
 
-nats = ["nats-py>=2.12.0,<=3.0.0"]
+nats = ["nats-py[nkeys]>=2.12.0,<=3.0.0"]
 
 redis = ["redis>=5.0.0,<8.0.0"]
 

--- a/tests/brokers/nats/test_nkeys_dependency.py
+++ b/tests/brokers/nats/test_nkeys_dependency.py
@@ -1,0 +1,35 @@
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _read_pyproject() -> str:
+    for parent in Path(__file__).resolve().parents:
+        pyproject = parent / "pyproject.toml"
+        if pyproject.exists():
+            return pyproject.read_text(encoding="utf-8")
+    msg = "pyproject.toml not found"
+    raise FileNotFoundError(msg)
+
+
+@pytest.mark.nats()
+def test_nats_extra_requires_nkeys() -> None:
+    """The ``nats`` extra must install ``nats-py`` with its ``nkeys`` extra.
+
+    Without it, NKEY authentication (e.g. the ``nkeys_seed`` argument) fails at
+    runtime with ``ModuleNotFoundError: No module named 'nkeys'`` (issue #2673).
+    """
+    content = _read_pyproject()
+
+    match = re.search(
+        r"^\s*nats\s*=\s*(?P<deps>\[.*\])\s*$",
+        content,
+        re.MULTILINE,
+    )
+    assert match, "no 'nats' optional-dependency declaration found in pyproject.toml"
+
+    assert re.search(r"nats-py\s*\[[^\]]*\bnkeys\b[^\]]*\]", match.group("deps")), (
+        "the 'nats' extra must require 'nats-py[nkeys]' so NKEY auth works; "
+        f"got: {match.group('deps').strip()}"
+    )


### PR DESCRIPTION
# Description

The `nats` optional-dependency only pulls in `nats-py`, so NKEY authentication (e.g. passing `nkeys_seed`) fails at runtime with `ModuleNotFoundError: No module named 'nkeys'`. nats-py ships its NKEY support behind an `nkeys` extra, so this declares `nats-py[nkeys]` in the `nats` extra to pull it in.

Fixes #2673

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] I have conducted a self-review of my own code
- [x] I have added a test to validate the fix (the new test in `tests/brokers/nats/test_nkeys_dependency.py` asserts the `nats` extra requires `nats-py[nkeys]`, and it passes locally)