### PR TITLE
fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity

### DIFF
--- a/faststream/redis/broker/cluster_broker.py
+++ b/faststream/redis/broker/cluster_broker.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 from fast_depends import dependency_provider
 from redis.asyncio.cluster import ClusterNode
+from redis.asyncio.connection import SSLConnection
 from typing_extensions import Unpack
 
 from faststream._internal.constants import EMPTY
@@ -275,6 +276,29 @@ class RedisClusterBroker(RedisBroker):
         for h, p in startup_nodes:
             nodes.append(ClusterNode(h, int(p)))
 
-        return {
+        # TLS is conveyed via `connection_class` (from `parse_security()` or a
+        # `rediss://` URL), but RedisCluster doesn't accept it — translate to
+        # its native `ssl` flag before the filter drops it.
+        connection_class = options.get("connection_class")
+        use_ssl = (security is not None and security.use_ssl) or (
+            isinstance(connection_class, type)
+            and issubclass(connection_class, SSLConnection)
+        )
+
+        result = {
             k: v for k, v in options.items() if k not in CLUSTER_INCOMPATIBLE_PARAMS
         } | {"startup_nodes": nodes}
+
+        if use_ssl:
+            result.setdefault("ssl", True)
+
+            if security is not None and security.ssl_context is not None:
+                warnings.warn(
+                    "RedisCluster does not support a custom `ssl_context`, so it"
+                    " will be ignored. Use `ssl_ca_certs`, `ssl_certfile`,"
+                    " `ssl_keyfile` and other `ssl_*` connection options instead.",
+                    category=RuntimeWarning,
+                    stacklevel=3,
+                )
+
+        return result

--- a/faststream/redis/security.py
+++ b/faststream/redis/security.py
@@ -34,7 +34,7 @@ def _parse_base_security(security: BaseSecurity) -> dict[str, Any]:
             def _connection_arguments(self) -> Any:
                 return {
                     **super()._connection_arguments(),  # type: ignore[misc]
-                    "ssl": self._security.ssl_context,
+                    "ssl": self._security.ssl_context or True,
                 }
 
         return {"connection_class": SSLConnection}

--- a/tests/brokers/redis/test_cluster.py
+++ b/tests/brokers/redis/test_cluster.py
@@ -1,6 +1,10 @@
+import ssl
+import warnings
+
 import pytest
 
 from faststream.redis import RedisClusterBroker, RedisRouter
+from faststream.security import BaseSecurity, SASLPlaintext
 
 pytestmark = pytest.mark.redis_cluster
 
@@ -284,6 +288,64 @@ def test_different_parameter_forms(kwargs) -> None:
     broker = RedisClusterBroker(**kwargs)
     s = broker.config.broker_config.connection
     assert len(s._options["startup_nodes"]) == 1
+
+
+class TestClusterSecurity:
+    """TLS options from BaseSecurity must survive the incompatible-params filter."""
+
+    def test_base_security_ssl_enabled(self) -> None:
+        broker = RedisClusterBroker(security=BaseSecurity(use_ssl=True))
+        opts = broker.config.broker_config.connection._options
+        assert opts.get("ssl") is True
+        assert "connection_class" not in opts
+
+    def test_base_security_no_ssl(self) -> None:
+        broker = RedisClusterBroker(security=BaseSecurity(use_ssl=False))
+        opts = broker.config.broker_config.connection._options
+        assert "ssl" not in opts
+
+    def test_no_security_no_ssl(self) -> None:
+        broker = RedisClusterBroker()
+        opts = broker.config.broker_config.connection._options
+        assert "ssl" not in opts
+
+    def test_ssl_context_not_supported_warns(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            ssl_context = ssl.create_default_context()
+
+        with pytest.warns(RuntimeWarning, match="ssl_context"):
+            broker = RedisClusterBroker(
+                security=BaseSecurity(ssl_context=ssl_context),
+            )
+
+        opts = broker.config.broker_config.connection._options
+        assert opts.get("ssl") is True
+        assert "ssl_context" not in opts
+
+    def test_rediss_url_enables_ssl(self) -> None:
+        broker = RedisClusterBroker(url="rediss://localhost:6379")
+        opts = broker.config.broker_config.connection._options
+        assert opts.get("ssl") is True
+        assert "connection_class" not in opts
+
+    def test_explicit_ssl_kwarg_preserved(self) -> None:
+        broker = RedisClusterBroker(
+            security=BaseSecurity(use_ssl=True),
+            ssl_ca_certs="/path/to/ca.pem",
+        )
+        opts = broker.config.broker_config.connection._options
+        assert opts.get("ssl") is True
+        assert opts.get("ssl_ca_certs") == "/path/to/ca.pem"
+
+    def test_sasl_plaintext_with_ssl(self) -> None:
+        broker = RedisClusterBroker(
+            security=SASLPlaintext(username="user", password="pass", use_ssl=True),
+        )
+        opts = broker.config.broker_config.connection._options
+        assert opts.get("ssl") is True
+        assert opts.get("username") == "user"
+        assert opts.get("password") == "pass"
 
 
 def test_exported_from_redis_package() -> None:

--- a/tests/brokers/redis/test_security.py
+++ b/tests/brokers/redis/test_security.py
@@ -1,0 +1,40 @@
+import ssl
+import warnings
+
+import pytest
+
+from faststream.redis.security import parse_security
+from faststream.security import BaseSecurity, SASLPlaintext
+
+pytestmark = pytest.mark.redis
+
+
+def test_no_security() -> None:
+    assert parse_security(None) == {}
+
+
+def test_base_security_without_context_enables_tls() -> None:
+    opts = parse_security(BaseSecurity(use_ssl=True))
+    connection = opts["connection_class"]()
+    assert connection._connection_arguments()["ssl"] is True
+
+
+def test_base_security_with_context_uses_it() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        ssl_context = ssl.create_default_context()
+
+    opts = parse_security(BaseSecurity(ssl_context=ssl_context))
+    connection = opts["connection_class"]()
+    assert connection._connection_arguments()["ssl"] is ssl_context
+
+
+def test_base_security_no_ssl() -> None:
+    assert parse_security(BaseSecurity(use_ssl=False)) == {}
+
+
+def test_sasl_plaintext() -> None:
+    opts = parse_security(
+        SASLPlaintext(username="user", password="pass", use_ssl=False),
+    )
+    assert opts == {"username": "user", "password": "pass"}


### PR DESCRIPTION
# Description

`RedisClusterBroker` silently dropped TLS when configured with `BaseSecurity(use_ssl=True)`: `parse_security()` conveys TLS via `connection_class: SSLConnection`, but `CLUSTER_INCOMPATIBLE_PARAMS` filters `connection_class` out in `_resolve_url_options()`, so `RedisCluster(**opts)` received zero SSL config and connected over plaintext (timing out against TLS-only clusters such as AWS MemoryDB). Introduced in #2854.

Fixes #2909

## What changed

- **`RedisClusterBroker._resolve_url_options`** now translates TLS intent into `RedisCluster`'s native `ssl=True` flag after the incompatible-params filter. This covers both `BaseSecurity(use_ssl=True)` and `rediss://` URLs (which hit the same silent-drop path via `parse_url`'s `connection_class`). `setdefault` is used so explicit user `ssl`/`ssl_*` kwargs are preserved, and the injected `ssl` option also flows into the sync Pub/Sub cluster client, which already reads it.
- **Custom `ssl_context` on cluster:** the async `RedisCluster` constructor has no `ssl_context`/`connection_class` parameter (verified against redis-py 7.4), so the fix proposed in the issue would raise `TypeError` at connect time. Instead a `RuntimeWarning` is emitted telling the user to use the `ssl_ca_certs`/`ssl_certfile`/`ssl_keyfile`/`ssl_*` options, while `ssl=True` is still applied — no more silent plaintext.
- **`_parse_base_security`** (plain `RedisBroker`): the generated `SSLConnection._connection_arguments` passed `ssl: None` when no explicit `ssl_context` was given, which disables TLS in `asyncio.open_connection` — the same bug in the non-cluster broker. It now falls back to `ssl: True` (default SSL context).

Verified end-to-end that the options produced by the broker construct a `RedisCluster` whose `connection_kwargs["connection_class"]` is redis-py's own `SSLConnection`, and that the issue's repro assertions are resolved.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)