### PR TITLE
chore(rabbit): allow aio-pika 10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-rabbit = ["aio-pika>=9,<10"]
+rabbit = ["aio-pika>=9,<11"]
 
 kafka = ["aiokafka>=0.9,<0.15"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1013,7 +1013,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-pika", marker = "extra == 'rabbit'", specifier = ">=9,<10" },
+    { name = "aio-pika", marker = "extra == 'rabbit'", specifier = ">=9,<11" },
     { name = "aiokafka", marker = "extra == 'kafka'", specifier = ">=0.9,<0.15" },
     { name = "anyio", specifier = ">=4.0,<5" },
     { name = "confluent-kafka", marker = "python_full_version >= '3.13' and extra == 'confluent'", specifier = ">=2.6,!=2.8.1,<3" },


### PR DESCRIPTION
## Description

Widens the `rabbit` extra constraint from `aio-pika>=9,<10` to `aio-pika>=9,<11`.

A hard `>=10` bump isn't possible yet: aio-pika 10 declares `requires-python >=3.11` (its new dependency chain aiormq 7 → pamqp 4 dropped older Pythons), while FastStream still supports Python 3.10. With the widened range, pip resolves 9.x on Python 3.10 and can pick 10.x on 3.11+. A strict `>=10` pin can follow once Python 3.10 support is dropped (EOL October 2026).

## Compatibility verification (aio-pika 10.0.1 / aiormq 7.0.0 / pamqp 4.0.1, Python 3.11)

- All in-memory rabbit tests pass (`tests/brokers/rabbit -m "not connected"`, 203 tests)
- All connected tests pass against a real RabbitMQ container (181 tests)
- `mypy faststream/rabbit` clean, including the `connect_robust` TypeVar changes in 10.0.1

The `aiormq.abc` / `pamqp.commands` / `pamqp.header.ContentHeader` APIs FastStream uses are unchanged in the new major versions.

Note: `uv.lock` still resolves aio-pika 9.6.2 because the lock covers all supported Pythons and the 3.10 floor forces 9.x — so CI exercises 9.x; 10.0.1 was verified locally as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)