### PR TITLE
fix(testing): TestKafkaBroker should mock a real tombstone too

### DIFF
--- a/faststream/confluent/testing.py
+++ b/faststream/confluent/testing.py
@@ -279,7 +279,7 @@ class FakeProducer(AsyncConfluentFastProducer):
 class MockConfluentMessage:
     def __init__(
         self,
-        raw_msg: bytes,
+        raw_msg: bytes | None,
         topic: str,
         key: bytes | str,
         headers: list[tuple[str, bytes]],
@@ -304,7 +304,7 @@ class MockConfluentMessage:
         self._timestamp = (timestamp_type, timestamp_ms)
 
     def len(self) -> int:
-        return len(self._raw_msg)
+        return 0 if self._raw_msg is None else len(self._raw_msg)
 
     def error(self) -> str | None:
         return self._error
@@ -327,7 +327,7 @@ class MockConfluentMessage:
     def topic(self) -> str:
         return self._topic
 
-    def value(self) -> bytes:
+    def value(self) -> bytes | None:
         return self._raw_msg
 
 
@@ -345,8 +345,12 @@ async def build_message(
     codec: Optional["CodecProto"] = None,
 ) -> MockConfluentMessage:
     """Build a mock confluent_kafka.Message for a sendable message."""
-    codec_instance = codec or DefaultCodec()
-    msg, content_type = await codec_instance.encode(message, serializer)
+    if message is None:
+        # keep a real tombstone (message.value() is None) distinct from b""
+        msg, content_type = None, None
+    else:
+        codec_instance = codec or DefaultCodec()
+        msg, content_type = await codec_instance.encode(message, serializer)
     k = key or b""
     headers = {
         "content-type": content_type or "",

--- a/faststream/kafka/testing.py
+++ b/faststream/kafka/testing.py
@@ -309,7 +309,12 @@ async def build_message(
     codec: Optional["CodecProto"] = None,
 ) -> "ConsumerRecord":
     """Build a Kafka ConsumerRecord for a sendable message."""
-    msg, content_type = await (codec or DefaultCodec()).encode(message, serializer)
+    if message is None and key is not None:
+        # keyed None is a real tombstone, matching publish()'s own rule
+        # (aiokafka needs a key or value, a keyless None still goes b"")
+        msg, content_type = None, None
+    else:
+        msg, content_type = await (codec or DefaultCodec()).encode(message, serializer)
 
     k = key or b""
 
@@ -328,8 +333,8 @@ async def build_message(
         partition=partition or 0,
         key=k,
         serialized_key_size=len(k),
-        serialized_value_size=len(msg),
-        checksum=sum(msg),
+        serialized_value_size=0 if msg is None else len(msg),
+        checksum=0 if msg is None else sum(msg),
         offset=0,
         headers=[(i, j.encode()) for i, j in headers.items()],
         timestamp_type=1,

--- a/tests/brokers/confluent/test_test_client.py
+++ b/tests/brokers/confluent/test_test_client.py
@@ -1,9 +1,10 @@
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from faststream import AckPolicy, BaseMiddleware
+from faststream import AckPolicy, BaseMiddleware, Context
 from faststream.confluent.annotations import KafkaMessage
 from faststream.confluent.message import FAKE_CONSUMER
 from faststream.confluent.testing import FakeProducer
@@ -16,6 +17,22 @@ from .basic import ConfluentMemoryTestcaseConfig
 @pytest.mark.confluent()
 @pytest.mark.asyncio()
 class TestTestclient(ConfluentMemoryTestcaseConfig, BrokerTestclientTestcase):
+    async def test_publish_none_tombstone(self, queue: str) -> None:
+        broker = self.get_broker(apply_types=True)
+
+        values: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+        @broker.subscriber(queue)
+        async def handler(raw: Any = Context("message")) -> None:
+            await values.put(raw.raw_message.value())
+
+        async with self.patch_broker(broker) as br:
+            await br.publish(None, queue, key=b"tombstone-key")
+
+            value = await asyncio.wait_for(values.get(), timeout=3)
+
+        assert value is None
+
     async def test_message_nack_seek(self, queue: str) -> None:
         broker = self.get_broker(apply_types=True)
 

--- a/tests/brokers/confluent/test_test_client.py
+++ b/tests/brokers/confluent/test_test_client.py
@@ -1,6 +1,5 @@
 import asyncio
-from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,21 +16,21 @@ from .basic import ConfluentMemoryTestcaseConfig
 @pytest.mark.confluent()
 @pytest.mark.asyncio()
 class TestTestclient(ConfluentMemoryTestcaseConfig, BrokerTestclientTestcase):
-    async def test_publish_none_tombstone(self, queue: str) -> None:
+    async def test_publish_none_tombstone(
+        self,
+        queue: str,
+        mock: MagicMock,
+    ) -> None:
         broker = self.get_broker(apply_types=True)
 
-        values: asyncio.Queue[bytes | None] = asyncio.Queue()
-
         @broker.subscriber(queue)
-        async def handler(raw: Any = Context("message")) -> None:
-            await values.put(raw.raw_message.value())
+        async def handler(msg=Context("message")) -> None:
+            mock(msg.raw_message.value())
 
         async with self.patch_broker(broker) as br:
             await br.publish(None, queue, key=b"tombstone-key")
 
-            value = await asyncio.wait_for(values.get(), timeout=3)
-
-        assert value is None
+        mock.assert_called_once_with(None)
 
     async def test_message_nack_seek(self, queue: str) -> None:
         broker = self.get_broker(apply_types=True)

--- a/tests/brokers/kafka/test_test_client.py
+++ b/tests/brokers/kafka/test_test_client.py
@@ -1,6 +1,5 @@
 import asyncio
-from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,21 +17,21 @@ from .basic import KafkaMemoryTestcaseConfig
 @pytest.mark.kafka()
 @pytest.mark.asyncio()
 class TestTestclient(KafkaMemoryTestcaseConfig, BrokerTestclientTestcase):
-    async def test_publish_none_tombstone(self, queue: str) -> None:
+    async def test_publish_none_tombstone(
+        self,
+        queue: str,
+        mock: MagicMock,
+    ) -> None:
         broker = self.get_broker(apply_types=True)
 
-        values: asyncio.Queue[bytes | None] = asyncio.Queue()
-
         @broker.subscriber(queue)
-        async def handler(raw: Any = Context("message")) -> None:
-            await values.put(raw.raw_message.value)
+        async def handler(msg=Context("message")) -> None:
+            mock(msg.raw_message.value)
 
         async with self.patch_broker(broker) as br:
             await br.publish(None, queue, key=b"tombstone-key")
 
-            value = await asyncio.wait_for(values.get(), timeout=3)
-
-        assert value is None
+        mock.assert_called_once_with(None)
 
     async def test_partition_match(
         self,

--- a/tests/brokers/kafka/test_test_client.py
+++ b/tests/brokers/kafka/test_test_client.py
@@ -1,9 +1,10 @@
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from faststream import AckPolicy, BaseMiddleware
+from faststream import AckPolicy, BaseMiddleware, Context
 from faststream.kafka import TopicPartition
 from faststream.kafka.annotations import KafkaMessage
 from faststream.kafka.message import FAKE_CONSUMER
@@ -17,6 +18,22 @@ from .basic import KafkaMemoryTestcaseConfig
 @pytest.mark.kafka()
 @pytest.mark.asyncio()
 class TestTestclient(KafkaMemoryTestcaseConfig, BrokerTestclientTestcase):
+    async def test_publish_none_tombstone(self, queue: str) -> None:
+        broker = self.get_broker(apply_types=True)
+
+        values: asyncio.Queue[bytes | None] = asyncio.Queue()
+
+        @broker.subscriber(queue)
+        async def handler(raw: Any = Context("message")) -> None:
+            await values.put(raw.raw_message.value)
+
+        async with self.patch_broker(broker) as br:
+            await br.publish(None, queue, key=b"tombstone-key")
+
+            value = await asyncio.wait_for(values.get(), timeout=3)
+
+        assert value is None
+
     async def test_partition_match(
         self,
         queue: str,


### PR DESCRIPTION
publish(None, topic, key=...) is supposed to simulate a real Kafka tombstone. Under TestKafkaBroker it never did. build_message ran None through the codec and got back b"", so message.value() was always bytes, never a true None.

This meant the tombstone path (message.value() is None) could never be exercised through the test broker at all, for confluent or kafka.

Fixed build_message in both faststream/confluent/testing.py and faststream/kafka/testing.py to skip the codec when message is None, same as the producer fix in #2932. Added a test for each driver confirming the mocked message now carries a real None value.

Follow up to #2932 and #2933.