### PR TITLE
fix(confluent): retry on BufferError so a full queue doesn't cancel the whole batch

### DIFF
--- a/faststream/confluent/helpers/client.py
+++ b/faststream/confluent/helpers/client.py
@@ -50,6 +50,11 @@ class _LazyLoggerProxy(logging.Logger):
             real_logger.handle(record)
 
 
+# How long (in seconds) to wait while draining librdkafka's local produce
+# queue before retrying a message that hit ``BufferError`` ("Local: Queue full").
+_BUFFER_FULL_POLL_TIMEOUT = 1.0
+
+
 class AsyncConfluentProducer:
     """An asynchronous Python Kafka client using the "confluent-kafka" package."""
 
@@ -148,7 +153,17 @@ class AsyncConfluentProducer:
             produce_kwargs["partition"] = kwargs["partition"]
         if kwargs.get("timestamp") is not None:
             produce_kwargs["timestamp"] = kwargs["timestamp"]
-        self.producer.produce(topic, **produce_kwargs)
+        while True:
+            try:
+                self.producer.produce(topic, **produce_kwargs)
+                break
+            except BufferError:
+                # librdkafka's local produce queue is full
+                # (queue.buffering.max.messages / queue.buffering.max.kbytes).
+                # Serve delivery reports to drain it and retry this message,
+                # instead of raising and cancelling the whole batch through the
+                # task group in ``send_batch``.
+                await call_or_await(self.producer.poll, _BUFFER_FULL_POLL_TIMEOUT)
 
         if no_confirm:
             return result_future

--- a/tests/brokers/confluent/test_buffer_full.py
+++ b/tests/brokers/confluent/test_buffer_full.py
@@ -1,0 +1,80 @@
+import time
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from faststream._internal.logger.state import LoggerState
+from faststream.confluent.helpers.client import AsyncConfluentProducer
+from faststream.confluent.helpers.config import ConfluentFastConfig
+
+
+class _FakeProducer:
+    """Stand-in for ``confluent_kafka.Producer``.
+
+    ``produce`` raises ``BufferError`` ("Local: Queue full") on the call
+    indices listed in ``fail_calls`` (mimicking librdkafka rejecting a message
+    once its local queue is full), and otherwise immediately fires the delivery
+    callback so the awaiting future resolves.
+    """
+
+    def __init__(self, fail_calls: set[int]) -> None:
+        self._fail_calls = fail_calls
+        self.produce_calls = 0
+        self.produced: list[tuple[str, dict[str, Any]]] = []
+
+    def produce(self, topic: str, *, on_delivery: Any = None, **kwargs: Any) -> None:
+        self.produce_calls += 1
+        if self.produce_calls in self._fail_calls:
+            msg = "Local: Queue full"
+            raise BufferError(msg)
+        self.produced.append((topic, kwargs))
+        if on_delivery is not None:
+            on_delivery(None, None)
+
+    def poll(self, timeout: float = 0) -> int:
+        # Throttle the background poll loop a little so it does not busy-spin.
+        time.sleep(0.01)
+        return 0
+
+    def flush(self, *args: Any, **kwargs: Any) -> int:
+        return 0
+
+
+@pytest.mark.confluent()
+@pytest.mark.asyncio()
+async def test_send_batch_survives_buffer_full() -> None:
+    """A single ``BufferError`` must not cancel the whole batch.
+
+    Regression test for #2836: a message over ``queue.buffering.max.messages``
+    used to raise ``BufferError`` inside one ``send`` task, which cascaded
+    through the ``send_batch`` task group and cancelled every sibling message.
+    The overflowing message should instead be retried after draining the queue.
+    """
+    # The first produce call hits a full queue; the retry must succeed.
+    fake = _FakeProducer(fail_calls={1})
+
+    with patch(
+        "faststream.confluent.helpers.client.Producer",
+        return_value=fake,
+    ):
+        producer = AsyncConfluentProducer(
+            logger=LoggerState(),
+            config=ConfluentFastConfig(),
+        )
+
+    try:
+        batch = producer.create_batch()
+        batch_size = 5
+        for i in range(batch_size):
+            batch.append(value=f"msg-{i}".encode())
+
+        # Must not raise an ExceptionGroup / BufferError.
+        await producer.send_batch(batch, "topic", partition=None)
+
+        # Every message is enqueued, with exactly one extra produce call for the
+        # retry that followed the BufferError.
+        assert len(fake.produced) == batch_size
+        assert fake.produce_calls == batch_size + 1
+    finally:
+        await producer.stop()


### PR DESCRIPTION
# Description

Fixes #2836.

When a batch pushes librdkafka's local produce queue past `queue.buffering.max.messages`, `produce()` raises `BufferError` ("Local: Queue full"). That error was bubbling up out of a single `send` task and cancelling the whole `send_batch` task group, so one overflowing message took down every sibling message in the batch.

This catches `BufferError` in the produce path, serves delivery reports with `poll()` to drain the queue, then retries that same message. It's the usual confluent-kafka backpressure pattern, so the rest of the batch goes through instead of being cancelled.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] I have conducted a self-review of my own code
- [x] I have added tests to validate the effectiveness of my fix

Added `tests/brokers/confluent/test_buffer_full.py`, which fakes a full queue on the first produce call and checks the batch still completes (it fails without the fix). That test and the existing confluent unit tests pass locally.