### PR TITLE
bug(kafka): [#2943] Added sinchronization for key's indexes

### DIFF
--- a/faststream/confluent/response.py
+++ b/faststream/confluent/response.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Union
 
 from typing_extensions import override
@@ -139,6 +140,26 @@ class KafkaPublishCommand(BatchPublishCommand):
             headers["reply_to"] = self.reply_to
 
         return headers | self.headers
+
+    @BatchPublishCommand.batch_bodies.setter  # type: ignore[attr-defined, untyped-decorator]
+    def batch_bodies(self, value: Sequence["Any"]) -> None:
+        if len(value) == 0:
+            self.body = None
+            self.extra_bodies = ()
+        else:
+            self._align_keys(value)
+            self.body = value[0]
+            self.extra_bodies = tuple(value[1:])
+
+    def _align_keys(self, value: Sequence["Any"]) -> None:
+        """Align the per-message keys with the batch_bodies."""
+        if len(self.batch_bodies) == 0:
+            return
+        if isinstance(self.batch_bodies[0], KafkaResponse):
+            return
+
+        new_indexes = tuple(self.batch_bodies.index(body) for body in value)
+        self._per_message_keys = tuple(self._per_message_keys[i] for i in new_indexes)
 
 
 # Semantic alias for publish operations

--- a/faststream/confluent/response.py
+++ b/faststream/confluent/response.py
@@ -171,7 +171,7 @@ class KafkaPublishCommand(BatchPublishCommand):
 
     def _update_bodies(self, bodies_seen: dict[int, Any], index: int, body: Any) -> None:
         """Update the bodies_seen dictionary with the given index and body."""
-        if bodies_seen.get(index) is None and self.batch_bodies[index] == body:
+        if self.batch_bodies[index] == body and bodies_seen.get(index) is None:
             bodies_seen.update({index: body})
         else:
             index += 1

--- a/faststream/confluent/response.py
+++ b/faststream/confluent/response.py
@@ -157,9 +157,25 @@ class KafkaPublishCommand(BatchPublishCommand):
             return
         if isinstance(self.batch_bodies[0], KafkaResponse):
             return
-
-        new_indexes = tuple(self.batch_bodies.index(body) for body in value)
+        new_indexes = self._form_indexes(value)
         self._per_message_keys = tuple(self._per_message_keys[i] for i in new_indexes)
+
+    def _form_indexes(self, value: Sequence["Any"]) -> tuple[int, ...]:
+        """Form a list of indexes for the given value sequence based on batch_bodies."""
+        bodies_seen: dict[int, Any] = {}
+        for body in value:
+            index = self.batch_bodies.index(body)
+            self._update_bodies(bodies_seen, index, body)
+
+        return tuple(i for i in bodies_seen)
+
+    def _update_bodies(self, bodies_seen: dict[int, Any], index: int, body: Any) -> None:
+        """Update the bodies_seen dictionary with the given index and body."""
+        if bodies_seen.get(index) is None and self.batch_bodies[index] == body:
+            bodies_seen.update({index: body})
+        else:
+            index += 1
+            self._update_bodies(bodies_seen, index, body)
 
 
 # Semantic alias for publish operations

--- a/faststream/kafka/response.py
+++ b/faststream/kafka/response.py
@@ -158,8 +158,25 @@ class KafkaPublishCommand(BatchPublishCommand):
         if isinstance(self.batch_bodies[0], KafkaResponse):
             return
 
-        new_indexes = tuple(self.batch_bodies.index(body) for body in value)
+        new_indexes = self._form_indexes(value)
         self._per_message_keys = tuple(self._per_message_keys[i] for i in new_indexes)
+
+    def _form_indexes(self, value: Sequence["Any"]) -> tuple[int, ...]:
+        """Form a list of indexes for the given value sequence based on batch_bodies."""
+        bodies_seen: dict[int, Any] = {}
+        for body in value:
+            index = self.batch_bodies.index(body)
+            self._update_bodies(bodies_seen, index, body)
+
+        return tuple(i for i in bodies_seen)
+
+    def _update_bodies(self, bodies_seen: dict[int, Any], index: int, body: Any) -> None:
+        """Update the bodies_seen dictionary with the given index and body."""
+        if bodies_seen.get(index) is None and self.batch_bodies[index] == body:
+            bodies_seen.update({index: body})
+        else:
+            index += 1
+            self._update_bodies(bodies_seen, index, body)
 
 
 # Semantic alias for publish operations

--- a/faststream/kafka/response.py
+++ b/faststream/kafka/response.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Union
 
 from typing_extensions import override
@@ -139,6 +140,26 @@ class KafkaPublishCommand(BatchPublishCommand):
             headers["reply_to"] = self.reply_to
 
         return headers | self.headers
+
+    @BatchPublishCommand.batch_bodies.setter  # type: ignore[attr-defined, untyped-decorator]
+    def batch_bodies(self, value: Sequence["Any"]) -> None:
+        if len(value) == 0:
+            self.body = None
+            self.extra_bodies = ()
+        else:
+            self._align_keys(value)
+            self.body = value[0]
+            self.extra_bodies = tuple(value[1:])
+
+    def _align_keys(self, value: Sequence["Any"]) -> None:
+        """Align the per-message keys with the batch_bodies."""
+        if len(self.batch_bodies) == 0:
+            return
+        if isinstance(self.batch_bodies[0], KafkaResponse):
+            return
+
+        new_indexes = tuple(self.batch_bodies.index(body) for body in value)
+        self._per_message_keys = tuple(self._per_message_keys[i] for i in new_indexes)
 
 
 # Semantic alias for publish operations

--- a/faststream/kafka/response.py
+++ b/faststream/kafka/response.py
@@ -172,7 +172,7 @@ class KafkaPublishCommand(BatchPublishCommand):
 
     def _update_bodies(self, bodies_seen: dict[int, Any], index: int, body: Any) -> None:
         """Update the bodies_seen dictionary with the given index and body."""
-        if bodies_seen.get(index) is None and self.batch_bodies[index] == body:
+        if self.batch_bodies[index] == body and bodies_seen.get(index) is None:
             bodies_seen.update({index: body})
         else:
             index += 1

--- a/tests/brokers/confluent/test_batch_body.py
+++ b/tests/brokers/confluent/test_batch_body.py
@@ -8,14 +8,66 @@ def delivered(cmd):
     return [(body, cmd.key_for(i)) for i, body in enumerate(cmd.batch_bodies)]
 
 
+def reverse_bodies(batch_bodies):
+    return tuple(reversed(batch_bodies))
+
+
+def remove_body(batch_bodies):
+    return tuple(batch_bodies[1:])
+
+
+def do_nothing(batch_bodies):
+    return batch_bodies
+
+
 @pytest.mark.kafka()
-def test_keys_order() -> None:
+@pytest.mark.parametrize(
+    ("kafka_messages", "changing_pattern", "expected"),
+    (
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-C", key=b"key-C"),
+            ],
+            remove_body,
+            [("body-B", b"key-B"), ("body-C", b"key-C")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            do_nothing,
+            [("body-A", b"key-A"), ("body-B", b"key-B"), ("body-B", b"key-B")],
+        ),
+    ),
+)
+def test_keys_order(kafka_messages, changing_pattern, expected) -> None:
+
     cmd = KafkaPublishCommand(
-        KafkaPublishMessage("body-A", key=b"key-A"),
-        KafkaPublishMessage("body-B", key=b"key-B"),
+        *kafka_messages,
         topic="topic",
         _publish_type=PublishType.PUBLISH,
     )
-    cmd.batch_bodies = tuple(reversed(cmd.batch_bodies))
+    cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
     delivered_cmd = delivered(cmd)
-    assert delivered_cmd == [("body-B", b"key-B"), ("body-A", b"key-A")]
+    assert delivered_cmd == expected

--- a/tests/brokers/confluent/test_batch_body.py
+++ b/tests/brokers/confluent/test_batch_body.py
@@ -3,6 +3,10 @@ import pytest
 from faststream.kafka.response import KafkaPublishCommand, KafkaPublishMessage
 from faststream.response.publish_type import PublishType
 
+body_a = "body-A"
+body_b = "body-B"
+body_c = "body-C"
+
 
 def delivered(cmd):
     return [(body, cmd.key_for(i)) for i, body in enumerate(cmd.batch_bodies)]
@@ -59,6 +63,29 @@ def do_nothing(batch_bodies):
             do_nothing,
             [("body-A", b"key-A"), ("body-B", b"key-B"), ("body-B", b"key-B")],
         ),
+        (
+            [
+                KafkaPublishMessage(body_a, key=b"key-1"),
+                KafkaPublishMessage(body_c, key=b"key-2"),
+                KafkaPublishMessage(body_b, key=b"key-3"),
+                KafkaPublishMessage(body_a, key=b"key-4"),
+                KafkaPublishMessage(body_b, key=b"key-5"),
+                KafkaPublishMessage(body_a, key=b"key-6"),
+                KafkaPublishMessage(body_a, key=b"key-7"),
+                KafkaPublishMessage(body_b, key=b"key-8"),
+            ],
+            do_nothing,
+            [
+                ("body-A", b"key-1"),
+                ("body-C", b"key-2"),
+                ("body-B", b"key-3"),
+                ("body-A", b"key-4"),
+                ("body-B", b"key-5"),
+                ("body-A", b"key-6"),
+                ("body-A", b"key-7"),
+                ("body-B", b"key-8"),
+            ],
+        ),
     ),
 )
 def test_keys_order(kafka_messages, changing_pattern, expected) -> None:
@@ -71,3 +98,70 @@ def test_keys_order(kafka_messages, changing_pattern, expected) -> None:
     cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
     delivered_cmd = delivered(cmd)
     assert delivered_cmd == expected
+
+
+@pytest.mark.kafka()
+@pytest.mark.parametrize(
+    ("kafka_messages", "changing_pattern", "expected"),
+    (
+        (
+            [
+                KafkaPublishMessage(body_a, key=b"key-1"),
+                KafkaPublishMessage(body_c, key=b"key-2"),
+                KafkaPublishMessage(body_b, key=b"key-3"),
+                KafkaPublishMessage(body_a, key=b"key-4"),
+                KafkaPublishMessage(body_b, key=b"key-5"),
+                KafkaPublishMessage(body_a, key=b"key-6"),
+                KafkaPublishMessage(body_a, key=b"key-7"),
+                KafkaPublishMessage(body_b, key=b"key-8"),
+            ],
+            reverse_bodies,
+            [
+                ("body-A", b"key-1"),
+                ("body-C", b"key-2"),
+                ("body-B", b"key-3"),
+                ("body-A", b"key-4"),
+                ("body-B", b"key-5"),
+                ("body-A", b"key-6"),
+                ("body-A", b"key-7"),
+                ("body-B", b"key-8"),
+            ],
+        ),
+        pytest.param(
+            [
+                KafkaPublishMessage(body_a, key=b"key-1"),
+                KafkaPublishMessage(body_c, key=b"key-2"),
+                KafkaPublishMessage(body_b, key=b"key-3"),
+                KafkaPublishMessage(body_a, key=b"key-4"),
+                KafkaPublishMessage(body_b, key=b"key-5"),
+                KafkaPublishMessage(body_a, key=b"key-6"),
+                KafkaPublishMessage(body_a, key=b"key-7"),
+                KafkaPublishMessage(body_b, key=b"key-8"),
+            ],
+            remove_body,
+            [
+                ("body-C", b"key-2"),
+                ("body-B", b"key-3"),
+                ("body-A", b"key-4"),
+                ("body-B", b"key-5"),
+                ("body-A", b"key-6"),
+                ("body-A", b"key-7"),
+                ("body-B", b"key-8"),
+            ],
+            marks=pytest.mark.xfail(
+                reason="It is not possible to track the relationship between identical bodies and keys after removing bodies, as the keys are not unique."
+            ),
+        ),
+    ),
+)
+def test_random_bodies(kafka_messages, changing_pattern, expected) -> None:
+
+    cmd = KafkaPublishCommand(
+        *kafka_messages,
+        topic="topic",
+        _publish_type=PublishType.PUBLISH,
+    )
+    cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
+    delivered_cmd = delivered(cmd)
+    for body in expected:
+        assert body in delivered_cmd

--- a/tests/brokers/confluent/test_batch_body.py
+++ b/tests/brokers/confluent/test_batch_body.py
@@ -1,5 +1,11 @@
 import pytest
 
+from faststream import BaseMiddleware, Context
+from faststream.confluent import KafkaBroker, TestKafkaBroker
+from faststream.confluent.response import (
+    KafkaPublishCommand as ConfluentPublishCommand,
+    KafkaPublishMessage as ConfluentPublishMessage,
+)
 from faststream.kafka.response import KafkaPublishCommand, KafkaPublishMessage
 from faststream.response.publish_type import PublishType
 
@@ -22,6 +28,16 @@ def remove_body(batch_bodies):
 
 def do_nothing(batch_bodies):
     return batch_bodies
+
+
+def dedup_bodies(batch_bodies):
+    seen = set()
+    deduped = []
+    for body in batch_bodies:
+        if body not in seen:
+            seen.add(body)
+            deduped.append(body)
+    return tuple(deduped)
 
 
 @pytest.mark.kafka()
@@ -165,3 +181,72 @@ def test_random_bodies(kafka_messages, changing_pattern, expected) -> None:
     delivered_cmd = delivered(cmd)
     for body in expected:
         assert body in delivered_cmd
+
+
+@pytest.mark.confluent()
+@pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    ("kafka_messages", "changing_pattern", "expected"),
+    (
+        (
+            [
+                ConfluentPublishMessage("body-A", key=b"key-A"),
+                ConfluentPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                ConfluentPublishMessage("body-A", key=b"key-A"),
+                ConfluentPublishMessage("body-B", key=b"key-B"),
+                ConfluentPublishMessage("body-C", key=b"key-C"),
+            ],
+            remove_body,
+            [("body-B", b"key-B"), ("body-C", b"key-C")],
+        ),
+        (
+            [
+                ConfluentPublishMessage("body-A", key=b"key-A"),
+                ConfluentPublishMessage("body-B", key=b"key-B"),
+                ConfluentPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                ConfluentPublishMessage("body-A", key=b"key-1"),
+                ConfluentPublishMessage("body-A", key=b"key-2"),
+                ConfluentPublishMessage("body-B", key=b"key-3"),
+            ],
+            dedup_bodies,
+            [("body-A", b"key-1"), ("body-B", b"key-3")],
+        ),
+    ),
+)
+async def test_publish_middleware_keeps_keys_aligned(
+    queue: str,
+    kafka_messages,
+    changing_pattern,
+    expected,
+) -> None:
+    received = []
+
+    class MutatingMiddleware(BaseMiddleware):
+        async def publish_scope(self, call_next, cmd):
+            if isinstance(cmd, ConfluentPublishCommand):
+                cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
+            return await call_next(cmd)
+
+    broker = KafkaBroker(apply_types=True, middlewares=(MutatingMiddleware,))
+
+    @broker.subscriber(queue, batch=True)
+    async def handler(msgs, raw=Context("message")) -> None:
+        received.extend(zip(msgs, (m.key() for m in raw.raw_message), strict=True))
+
+    async with TestKafkaBroker(broker) as br:
+        await br.start()
+        await br.publish_batch(*kafka_messages, topic=queue)
+
+    assert received == expected

--- a/tests/brokers/confluent/test_batch_body.py
+++ b/tests/brokers/confluent/test_batch_body.py
@@ -1,0 +1,21 @@
+import pytest
+
+from faststream.kafka.response import KafkaPublishCommand, KafkaPublishMessage
+from faststream.response.publish_type import PublishType
+
+
+def delivered(cmd):
+    return [(body, cmd.key_for(i)) for i, body in enumerate(cmd.batch_bodies)]
+
+
+@pytest.mark.kafka()
+def test_keys_order() -> None:
+    cmd = KafkaPublishCommand(
+        KafkaPublishMessage("body-A", key=b"key-A"),
+        KafkaPublishMessage("body-B", key=b"key-B"),
+        topic="topic",
+        _publish_type=PublishType.PUBLISH,
+    )
+    cmd.batch_bodies = tuple(reversed(cmd.batch_bodies))
+    delivered_cmd = delivered(cmd)
+    assert delivered_cmd == [("body-B", b"key-B"), ("body-A", b"key-A")]

--- a/tests/brokers/kafka/test_batch_body.py
+++ b/tests/brokers/kafka/test_batch_body.py
@@ -8,14 +8,66 @@ def delivered(cmd):
     return [(body, cmd.key_for(i)) for i, body in enumerate(cmd.batch_bodies)]
 
 
+def reverse_bodies(batch_bodies):
+    return tuple(reversed(batch_bodies))
+
+
+def remove_body(batch_bodies):
+    return tuple(batch_bodies[1:])
+
+
+def do_nothing(batch_bodies):
+    return batch_bodies
+
+
 @pytest.mark.kafka()
-def test_keys_order() -> None:
+@pytest.mark.parametrize(
+    ("kafka_messages", "changing_pattern", "expected"),
+    (
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-C", key=b"key-C"),
+            ],
+            remove_body,
+            [("body-B", b"key-B"), ("body-C", b"key-C")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            do_nothing,
+            [("body-A", b"key-A"), ("body-B", b"key-B"), ("body-B", b"key-B")],
+        ),
+    ),
+)
+def test_keys_order(kafka_messages, changing_pattern, expected) -> None:
+
     cmd = KafkaPublishCommand(
-        KafkaPublishMessage("body-A", key=b"key-A"),
-        KafkaPublishMessage("body-B", key=b"key-B"),
+        *kafka_messages,
         topic="topic",
         _publish_type=PublishType.PUBLISH,
     )
-    cmd.batch_bodies = tuple(reversed(cmd.batch_bodies))
+    cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
     delivered_cmd = delivered(cmd)
-    assert delivered_cmd == [("body-B", b"key-B"), ("body-A", b"key-A")]
+    assert delivered_cmd == expected

--- a/tests/brokers/kafka/test_batch_body.py
+++ b/tests/brokers/kafka/test_batch_body.py
@@ -3,6 +3,10 @@ import pytest
 from faststream.kafka.response import KafkaPublishCommand, KafkaPublishMessage
 from faststream.response.publish_type import PublishType
 
+body_a = "body-A"
+body_b = "body-B"
+body_c = "body-C"
+
 
 def delivered(cmd):
     return [(body, cmd.key_for(i)) for i, body in enumerate(cmd.batch_bodies)]
@@ -59,6 +63,29 @@ def do_nothing(batch_bodies):
             do_nothing,
             [("body-A", b"key-A"), ("body-B", b"key-B"), ("body-B", b"key-B")],
         ),
+        (
+            [
+                KafkaPublishMessage(body_a, key=b"key-1"),
+                KafkaPublishMessage(body_c, key=b"key-2"),
+                KafkaPublishMessage(body_b, key=b"key-3"),
+                KafkaPublishMessage(body_a, key=b"key-4"),
+                KafkaPublishMessage(body_b, key=b"key-5"),
+                KafkaPublishMessage(body_a, key=b"key-6"),
+                KafkaPublishMessage(body_a, key=b"key-7"),
+                KafkaPublishMessage(body_b, key=b"key-8"),
+            ],
+            do_nothing,
+            [
+                ("body-A", b"key-1"),
+                ("body-C", b"key-2"),
+                ("body-B", b"key-3"),
+                ("body-A", b"key-4"),
+                ("body-B", b"key-5"),
+                ("body-A", b"key-6"),
+                ("body-A", b"key-7"),
+                ("body-B", b"key-8"),
+            ],
+        ),
     ),
 )
 def test_keys_order(kafka_messages, changing_pattern, expected) -> None:
@@ -71,3 +98,70 @@ def test_keys_order(kafka_messages, changing_pattern, expected) -> None:
     cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
     delivered_cmd = delivered(cmd)
     assert delivered_cmd == expected
+
+
+@pytest.mark.kafka()
+@pytest.mark.parametrize(
+    ("kafka_messages", "changing_pattern", "expected"),
+    (
+        (
+            [
+                KafkaPublishMessage(body_a, key=b"key-1"),
+                KafkaPublishMessage(body_c, key=b"key-2"),
+                KafkaPublishMessage(body_b, key=b"key-3"),
+                KafkaPublishMessage(body_a, key=b"key-4"),
+                KafkaPublishMessage(body_b, key=b"key-5"),
+                KafkaPublishMessage(body_a, key=b"key-6"),
+                KafkaPublishMessage(body_a, key=b"key-7"),
+                KafkaPublishMessage(body_b, key=b"key-8"),
+            ],
+            reverse_bodies,
+            [
+                ("body-A", b"key-1"),
+                ("body-C", b"key-2"),
+                ("body-B", b"key-3"),
+                ("body-A", b"key-4"),
+                ("body-B", b"key-5"),
+                ("body-A", b"key-6"),
+                ("body-A", b"key-7"),
+                ("body-B", b"key-8"),
+            ],
+        ),
+        pytest.param(
+            [
+                KafkaPublishMessage(body_a, key=b"key-1"),
+                KafkaPublishMessage(body_c, key=b"key-2"),
+                KafkaPublishMessage(body_b, key=b"key-3"),
+                KafkaPublishMessage(body_a, key=b"key-4"),
+                KafkaPublishMessage(body_b, key=b"key-5"),
+                KafkaPublishMessage(body_a, key=b"key-6"),
+                KafkaPublishMessage(body_a, key=b"key-7"),
+                KafkaPublishMessage(body_b, key=b"key-8"),
+            ],
+            remove_body,
+            [
+                ("body-C", b"key-2"),
+                ("body-B", b"key-3"),
+                ("body-A", b"key-4"),
+                ("body-B", b"key-5"),
+                ("body-A", b"key-6"),
+                ("body-A", b"key-7"),
+                ("body-B", b"key-8"),
+            ],
+            marks=pytest.mark.xfail(
+                reason="It is not possible to track the relationship between identical bodies and keys after removing bodies, as the keys are not unique."
+            ),
+        ),
+    ),
+)
+def test_random_bodies(kafka_messages, changing_pattern, expected) -> None:
+
+    cmd = KafkaPublishCommand(
+        *kafka_messages,
+        topic="topic",
+        _publish_type=PublishType.PUBLISH,
+    )
+    cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
+    delivered_cmd = delivered(cmd)
+    for body in expected:
+        assert body in delivered_cmd

--- a/tests/brokers/kafka/test_batch_body.py
+++ b/tests/brokers/kafka/test_batch_body.py
@@ -1,5 +1,7 @@
 import pytest
 
+from faststream import BaseMiddleware, Context
+from faststream.kafka import KafkaBroker, TestKafkaBroker
 from faststream.kafka.response import KafkaPublishCommand, KafkaPublishMessage
 from faststream.response.publish_type import PublishType
 
@@ -22,6 +24,16 @@ def remove_body(batch_bodies):
 
 def do_nothing(batch_bodies):
     return batch_bodies
+
+
+def dedup_bodies(batch_bodies):
+    seen = set()
+    deduped = []
+    for body in batch_bodies:
+        if body not in seen:
+            seen.add(body)
+            deduped.append(body)
+    return tuple(deduped)
 
 
 @pytest.mark.kafka()
@@ -165,3 +177,72 @@ def test_random_bodies(kafka_messages, changing_pattern, expected) -> None:
     delivered_cmd = delivered(cmd)
     for body in expected:
         assert body in delivered_cmd
+
+
+@pytest.mark.kafka()
+@pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    ("kafka_messages", "changing_pattern", "expected"),
+    (
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-C", key=b"key-C"),
+            ],
+            remove_body,
+            [("body-B", b"key-B"), ("body-C", b"key-C")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-A"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+                KafkaPublishMessage("body-B", key=b"key-B"),
+            ],
+            reverse_bodies,
+            [("body-B", b"key-B"), ("body-B", b"key-B"), ("body-A", b"key-A")],
+        ),
+        (
+            [
+                KafkaPublishMessage("body-A", key=b"key-1"),
+                KafkaPublishMessage("body-A", key=b"key-2"),
+                KafkaPublishMessage("body-B", key=b"key-3"),
+            ],
+            dedup_bodies,
+            [("body-A", b"key-1"), ("body-B", b"key-3")],
+        ),
+    ),
+)
+async def test_publish_middleware_keeps_keys_aligned(
+    queue: str,
+    kafka_messages,
+    changing_pattern,
+    expected,
+) -> None:
+    received = []
+
+    class MutatingMiddleware(BaseMiddleware):
+        async def publish_scope(self, call_next, cmd):
+            if isinstance(cmd, KafkaPublishCommand):
+                cmd.batch_bodies = changing_pattern(cmd.batch_bodies)
+            return await call_next(cmd)
+
+    broker = KafkaBroker(apply_types=True, middlewares=(MutatingMiddleware,))
+
+    @broker.subscriber(queue, batch=True)
+    async def handler(msgs, raw=Context("message")) -> None:
+        received.extend(zip(msgs, (m.key for m in raw.raw_message), strict=True))
+
+    async with TestKafkaBroker(broker) as br:
+        await br.start()
+        await br.publish_batch(*kafka_messages, topic=queue)
+
+    assert received == expected

--- a/tests/brokers/kafka/test_batch_body.py
+++ b/tests/brokers/kafka/test_batch_body.py
@@ -1,0 +1,21 @@
+import pytest
+
+from faststream.kafka.response import KafkaPublishCommand, KafkaPublishMessage
+from faststream.response.publish_type import PublishType
+
+
+def delivered(cmd):
+    return [(body, cmd.key_for(i)) for i, body in enumerate(cmd.batch_bodies)]
+
+
+@pytest.mark.kafka()
+def test_keys_order() -> None:
+    cmd = KafkaPublishCommand(
+        KafkaPublishMessage("body-A", key=b"key-A"),
+        KafkaPublishMessage("body-B", key=b"key-B"),
+        topic="topic",
+        _publish_type=PublishType.PUBLISH,
+    )
+    cmd.batch_bodies = tuple(reversed(cmd.batch_bodies))
+    delivered_cmd = delivered(cmd)
+    assert delivered_cmd == [("body-B", b"key-B"), ("body-A", b"key-A")]


### PR DESCRIPTION
# Description

In order to synchronize keys after `cmd.batch_body` reordering, I modified `batch_body.setter`. After checking whether or not `batch_body` has elements and isn't `KafkaResponse` (which is the initial type of record, before normalizing in `extract_per_message_keys_and_bodies`), keys will be reordered appropriately 

Fixes #2943

## Type of change

- [X] Bug fix (a non-breaking change that resolves an issue)
- [X] New feature (a non-breaking change that adds functionality)

## Checklist

- [X] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [X] I have conducted a self-review of my own code
- [X] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [X] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [X] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [X] I have ensured that static analysis tests are passing by running `just static-analysis`
- [X] I have included code examples to illustrate the modifications
