### PR TITLE
fix(fastapi): support FastAPI 0.140 Dependant

### DIFF
--- a/faststream/_internal/fastapi/_compat.py
+++ b/faststream/_internal/fastapi/_compat.py
@@ -91,7 +91,7 @@ if FASTAPI_v102_3:
     ) -> SolvedDependency:
         solved_result = await solve_dependencies(
             request=request,
-            body=request._body,  # type: ignore[arg-type]
+            body=request._body,  # pyright: ignore[reportArgumentType]
             dependant=dependant,
             dependency_overrides_provider=dependency_overrides_provider,
             **extra,  # type: ignore[arg-type]
@@ -122,7 +122,7 @@ else:
     ) -> SolvedDependency:
         solved_result = await solve_dependencies(
             request=request,
-            body=request._body,  # type: ignore[arg-type]
+            body=request._body,  # pyright: ignore[reportArgumentType]
             dependant=dependant,
             dependency_overrides_provider=dependency_overrides_provider,
             **kwargs,

--- a/faststream/_internal/fastapi/get_dependant.py
+++ b/faststream/_internal/fastapi/get_dependant.py
@@ -1,10 +1,12 @@
 import inspect
 from collections.abc import Callable, Iterable
+from dataclasses import fields
 from typing import TYPE_CHECKING, Annotated, Any, cast, get_args, get_origin
 
 from fast_depends.library.serializer import OptionItem
 from fast_depends.utils import get_typed_annotation
 from fastapi import params
+from fastapi.dependencies.models import Dependant
 from fastapi.dependencies.utils import (
     get_dependant,
     get_parameterless_sub_dependant,
@@ -15,6 +17,21 @@ from faststream._internal._compat import PYDANTIC_V2
 
 if TYPE_CHECKING:
     from fastapi.dependencies import models
+
+
+class _FastStreamDependant(Dependant):
+    """FastAPI dependant extended with fields required by FastStream."""
+
+    model: type[Any]
+    custom_fields: dict[str, Any]
+    flat_params: list[OptionItem]
+
+
+def _extend_fastapi_dependant(dependant: Dependant) -> _FastStreamDependant:
+    """Copy a native FastAPI dependant into an extensible subclass."""
+    return _FastStreamDependant(**{
+        field.name: getattr(dependant, field.name) for field in fields(dependant)
+    })
 
 
 def get_fastapi_dependant(
@@ -55,6 +72,7 @@ def _patch_fastapi_dependent(dependant: "models.Dependant") -> "models.Dependant
 
     from faststream._internal._compat import PydanticUndefined
 
+    dependant = _extend_fastapi_dependant(dependant)
     params = dependant.query_params + dependant.body_params
 
     for d in dependant.dependencies:
@@ -128,12 +146,12 @@ def _patch_fastapi_dependent(dependant: "models.Dependant") -> "models.Dependant
                 f,
             )
 
-    dependant.model = create_model(  # type: ignore[attr-defined]
+    dependant.model = create_model(
         getattr(call, "__name__", type(call).__name__),
     )
 
-    dependant.custom_fields = {}  # type: ignore[attr-defined]
-    dependant.flat_params = [  # type: ignore[attr-defined]
+    dependant.custom_fields = {}
+    dependant.flat_params = [
         OptionItem(field_name=name, field_type=type_, default_value=default)
         for name, (type_, default) in params_unique.items()
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ test-core = [
 
 testing = [
     {include-group = "test-core"},
-    "fastapi==0.128.0",
+    "fastapi==0.140.0",
     "pydantic-settings>=2.0.0,<3.0.0",
     "PyYAML==6.0.3",
     "email-validator==2.3.0",

--- a/tests/fastapi/test_get_dependant.py
+++ b/tests/fastapi/test_get_dependant.py
@@ -1,0 +1,25 @@
+from typing import Annotated
+
+from fastapi import Depends
+
+from faststream._internal.fastapi.get_dependant import get_fastapi_dependant
+
+
+def test_get_fastapi_dependant_has_faststream_fields() -> None:
+    async def dependency() -> str:
+        return "dependency"
+
+    async def handler(
+        message: str,
+        dependency_value: Annotated[str, Depends(dependency)],
+    ) -> None:
+        pass
+
+    dependant = get_fastapi_dependant(handler, ())
+
+    assert dependant.call is handler
+    assert len(dependant.dependencies) == 1
+    assert dependant.dependencies[0].call is dependency
+    assert dependant.model.__name__ == "handler"
+    assert dependant.custom_fields == {}
+    assert [field.field_name for field in dependant.flat_params] == ["message"]

--- a/uv.lock
+++ b/uv.lock
@@ -835,17 +835,18 @@ pydantic = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.140.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/fb/fd7671137d9fa3df1d93a2f5111eb982709201724b29f211e4beb2d58688/fastapi-0.140.0.tar.gz", hash = "sha256:f338951b82fd74ca8f843163aec43ea1a1ce84d515415a50fa98fa25572a5544", size = 420968, upload-time = "2026-07-24T21:16:41.187Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/76/6d9e25ad88da9d3ff744bcdbec4736e38c2288611d43f673a5d9bfa27c07/fastapi-0.140.0-py3-none-any.whl", hash = "sha256:e951c0a0d9540bf5d9a2a9e078fd415da2ab7e312d435139e7d9e2e7fe9f0b23", size = 130863, upload-time = "2026-07-24T21:16:42.89Z" },
 ]
 
 [[package]]
@@ -1039,7 +1040,7 @@ dev = [
     { name = "detect-secrets", specifier = "==1.5.0" },
     { name = "dirty-equals", specifier = "==0.11" },
     { name = "email-validator", specifier = "==2.3.0" },
-    { name = "fastapi", specifier = "==0.128.0" },
+    { name = "fastapi", specifier = "==0.140.0" },
     { name = "faststream", extras = ["rabbit", "kafka", "confluent", "nats", "redis", "mqtt", "otel", "cli", "prometheus"] },
     { name = "freezegun", specifier = ">=1.5.5" },
     { name = "griffe", specifier = "==1.15.0" },
@@ -1132,7 +1133,7 @@ testing = [
     { name = "covdefaults", specifier = ">=2.3.0" },
     { name = "dirty-equals", specifier = "==0.11" },
     { name = "email-validator", specifier = "==2.3.0" },
-    { name = "fastapi", specifier = "==0.128.0" },
+    { name = "fastapi", specifier = "==0.140.0" },
     { name = "freezegun", specifier = ">=1.5.5" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "msgspec" },


### PR DESCRIPTION
## Summary

- make FastStream's FastAPI dependency adapter compatible with FastAPI 0.140's slotted `Dependant` dataclass
- preserve native `Dependant` fields while attaching FastStream's `model`, `custom_fields`, and `flat_params` metadata
- add regression coverage for native fields, nested `Depends` dependencies, and FastStream-specific fields
- update the FastAPI test pin and lockfile to 0.140.0

## Root cause

FastAPI 0.140 changed `Dependant` to a slotted dataclass, so FastStream can no longer attach its additional attributes directly to the instance returned by FastAPI. The adapter now recreates that instance as a small extensible subclass using FastAPI's dataclass fields before adding FastStream metadata.

## Verification

- `uv run pytest tests/ -m 'not connected' -q`
- `uv run pytest tests/fastapi/test_get_dependant.py -q`
- `uv run --with 'fastapi==0.128.0' pytest tests/fastapi/test_get_dependant.py -q`
- `uv run pytest tests/fastapi tests/asyncapi -q`
- Ruff check and formatting
- mypy
- Bandit and Semgrep
- `uv lock --check`

The connected broker matrix was not run locally because Docker/service infrastructure is unavailable in this environment; the repository's PR CI provides those service-backed checks.

Fixes #2959
