### PR TITLE
fix(TestClient-redis): [#2963] Fixed groups for TestRedisBroker

### DIFF
--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -237,16 +237,17 @@ class FakeProducer(RedisFastProducer):
         destination = _make_destination_kwargs(cmd)
         visitors = (ChannelVisitor(), ListVisitor(), StreamVisitor())
 
-        for handler in self.subscribers:  # pragma: no branch
-            for visitor in visitors:
-                if visited_ch := visitor.visit(**destination, sub=handler):
-                    msg = visitor.get_message(
-                        visited_ch,
-                        body,
-                        handler,  # type: ignore[arg-type]
-                    )
+        for visitor, visited_ch, handler in self._find_handlers(
+            destination,
+            visitors,
+        ):
+            msg = visitor.get_message(
+                visited_ch,
+                body,
+                handler,
+            )
 
-                    await self._execute_handler(msg, handler)
+            await self._execute_handler(msg, handler)
 
         return 0
 
@@ -264,17 +265,18 @@ class FakeProducer(RedisFastProducer):
         destination = _make_destination_kwargs(cmd)
         visitors = (ChannelVisitor(), ListVisitor(), StreamVisitor())
 
-        for handler in self.subscribers:  # pragma: no branch
-            for visitor in visitors:
-                if visited_ch := visitor.visit(**destination, sub=handler):
-                    msg = visitor.get_message(
-                        visited_ch,
-                        body,
-                        handler,  # type: ignore[arg-type]
-                    )
+        for visitor, visited_ch, handler in self._find_handlers(
+            destination,
+            visitors,
+        ):
+            msg = visitor.get_message(
+                visited_ch,
+                body,
+                handler,
+            )
 
-                    with anyio.fail_after(cmd.timeout):
-                        return await self._execute_handler(msg, handler)
+            with anyio.fail_after(cmd.timeout):
+                return await self._execute_handler(msg, handler)
 
         raise SubscriberNotFound
 
@@ -292,19 +294,20 @@ class FakeProducer(RedisFastProducer):
             for m in cmd.batch_bodies
         ]
 
-        visitor = ListVisitor()
-        for handler in self.subscribers:  # pragma: no branch
-            if visitor.visit(list=cmd.destination, sub=handler):
-                casted_handler = cast("_ListHandlerMixin", handler)
+        for visitor, visited_ch, handler in self._find_handlers(
+            {"list": cmd.destination},
+            (ListVisitor(),),
+        ):
+            casted_handler = cast("_ListHandlerMixin", handler)
 
-                if casted_handler.list_sub.batch:
-                    msg = visitor.get_message(
-                        channel=cmd.destination,
-                        body=data_to_send,
-                        sub=casted_handler,
-                    )
+            if casted_handler.list_sub.batch:
+                msg = visitor.get_message(
+                    visited_ch,
+                    data_to_send,
+                    casted_handler,
+                )
 
-                    await self._execute_handler(msg, handler)
+                await self._execute_handler(msg, handler)
 
         return 0
 
@@ -328,6 +331,28 @@ class FakeProducer(RedisFastProducer):
             channel="",
             pattern=None,
         )
+
+    def _find_handlers(
+        self,
+        destination: "_DestinationKwargs",
+        visitors: "Sequence[Visitor]",
+    ) -> "Iterator[tuple[Visitor, str, LogicSubscriber]]":
+        published_groups: set[tuple[str, str]] = set()
+
+        for handler in self.subscribers:  # pragma: no branch
+            for visitor in visitors:
+                visited_ch = visitor.visit(**destination, sub=handler)
+                if visited_ch is None:
+                    continue
+
+                if isinstance(handler, _StreamHandlerMixin) and handler.stream_sub.group:
+                    group_key = (visited_ch, handler.stream_sub.group)
+                    if group_key in published_groups:
+                        break
+                    published_groups.add(group_key)
+
+                yield visitor, visited_ch, handler
+                break
 
 
 async def build_message(

--- a/tests/brokers/redis/test_test_client.py
+++ b/tests/brokers/redis/test_test_client.py
@@ -203,6 +203,92 @@ class TestTestclient(RedisMemoryTestcaseConfig, BrokerTestclientTestcase):
             m.mock.assert_called_once_with("hello")
             publisher.mock.assert_called_once_with([1, 2, 3])
 
+    async def test_stream_same_group_delivers_to_one_consumer(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker()
+
+        @broker.subscriber(
+            stream=StreamSub(queue, group="workers", consumer="consumer-1"),
+        )
+        async def subscriber1(msg) -> None: ...
+
+        @broker.subscriber(
+            stream=StreamSub(queue, group="workers", consumer="consumer-2"),
+        )
+        async def subscriber2(msg) -> None: ...
+
+        async with self.patch_broker(broker) as br:
+            await br.publish("hello", stream=queue)
+
+            # only one consumer in the group should receive the message
+            assert {subscriber1.mock.call_count, subscriber2.mock.call_count} == {
+                0,
+                1,
+            }
+
+    async def test_stream_same_group_executes_message_exactly_once(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker()
+
+        @broker.subscriber(
+            stream=StreamSub(queue, group="workers", consumer="claimer"),
+        )
+        @broker.subscriber(
+            stream=StreamSub(queue, group="workers", consumer="w1"),
+        )
+        async def worker(msg: str) -> None: ...
+
+        async with self.patch_broker(broker) as br:
+            await br.publish("hello", stream=queue)
+
+            worker.mock.assert_called_once_with("hello")
+
+    async def test_stream_different_groups_all_receive(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker()
+
+        @broker.subscriber(
+            stream=StreamSub(queue, group="workers-a", consumer="consumer-1"),
+        )
+        async def subscriber1(msg) -> None: ...
+
+        @broker.subscriber(
+            stream=StreamSub(queue, group="workers-b", consumer="consumer-1"),
+        )
+        async def subscriber2(msg) -> None: ...
+
+        async with self.patch_broker(broker) as br:
+            await br.publish("hello", stream=queue)
+
+            subscriber1.mock.assert_called_once_with("hello")
+            subscriber2.mock.assert_called_once_with("hello")
+
+    async def test_stream_without_group_always_receives(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker()
+
+        @broker.subscriber(
+            stream=StreamSub(queue, group="workers", consumer="consumer-1"),
+        )
+        async def grouped(msg) -> None: ...
+
+        @broker.subscriber(stream=queue)
+        async def ungrouped(msg) -> None: ...
+
+        async with self.patch_broker(broker) as br:
+            await br.publish("hello", stream=queue)
+
+            grouped.mock.assert_called_once_with("hello")
+            ungrouped.mock.assert_called_once_with("hello")
+
     async def test_publish_to_none(self) -> None:
         broker = self.get_broker()
 


### PR DESCRIPTION
# Description

`TestRedisBroker`'s `FakeProducer` previously delivered every published message to **all** matching subscribers, regardless of Redis Stream consumer group. In real Redis, a message published to a stream is delivered to only one consumer within a given consumer group (via `XREADGROUP`) — but the in-memory test broker fanned it out to every subscriber sharing that group, so tests could not accurately simulate consumer-group load balancing.

This change makes `FakeProducer` group-aware: for stream subscribers that share the same `(stream, group)`, only one of them now receives the published message, matching real Redis semantics. Subscribers with no group, or belonging to different groups, are unaffected and still all receive the message.

The fix is implemented as a new `_find_handlers` method on `FakeProducer`, which mirrors the existing `group_id`-deduplication pattern already used by the Kafka/Confluent fake producers (`faststream/kafka/testing.py`, `faststream/confluent/testing.py`). `publish`, `request`, and `publish_batch` were all refactored to share this helper for consistent behavior.

Fixes #2963

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment (`tests/brokers/redis`, `not slow and not connected`)
- [x] `mypy` and `ruff` pass on the changed files
- [x] I have included code examples to illustrate the modifications
