### PR TITLE
refactor: typing.Iterator has been replaced by typing.Generator in al…

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -3,7 +3,7 @@ import csv
 import platform
 import sys
 import time
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -23,10 +23,10 @@ class TestCase(Protocol):
     def setup_method(self) -> None: ...
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]: ...
+    def start(self) -> AsyncGenerator[float, None]: ...
 
     @asynccontextmanager
-    async def test_consume_message(self) -> None: ...
+    def test_consume_message(self) -> AsyncGenerator[None, None]: ...
 
 
 @dataclass

--- a/benchmarks/confluent_cases/test_basic.py
+++ b/benchmarks/confluent_cases/test_basic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -36,7 +36,7 @@ class TestConfluentCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/confluent_cases/test_confluent.py
+++ b/benchmarks/confluent_cases/test_confluent.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -37,7 +37,7 @@ class TestConfluentCase:
         self.consumer.assign([TopicPartition("in", 0, 0)])
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         stop_event = asyncio.Event()
 
         def acked(err, msg) -> None:  # noqa: ANN001

--- a/benchmarks/confluent_cases/test_msgspec.py
+++ b/benchmarks/confluent_cases/test_msgspec.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -40,7 +40,7 @@ class TestConfluentCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/confluent_cases/test_pydantic.py
+++ b/benchmarks/confluent_cases/test_pydantic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -35,7 +35,7 @@ class TestConfluentCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/kafka_cases/test_aiokafka.py
+++ b/benchmarks/kafka_cases/test_aiokafka.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, suppress
 
 import pytest
@@ -34,7 +34,7 @@ class TestKafkaCase:
             await admin.close()
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         await self.create_topic()
         producer = AIOKafkaProducer(bootstrap_servers="localhost:9092")
         consumer = AIOKafkaConsumer(

--- a/benchmarks/kafka_cases/test_basic.py
+++ b/benchmarks/kafka_cases/test_basic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -34,7 +34,7 @@ class TestKafkaCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/kafka_cases/test_msgspec.py
+++ b/benchmarks/kafka_cases/test_msgspec.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -40,7 +40,7 @@ class TestKafkaCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/kafka_cases/test_pydantic.py
+++ b/benchmarks/kafka_cases/test_pydantic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -35,7 +35,7 @@ class TestKafkaCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/nats_cases/test_basic.py
+++ b/benchmarks/nats_cases/test_basic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -33,7 +33,7 @@ class TestNatsCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/nats_cases/test_msgspec.py
+++ b/benchmarks/nats_cases/test_msgspec.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -40,7 +40,7 @@ class TestNatsTestCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/nats_cases/test_nats.py
+++ b/benchmarks/nats_cases/test_nats.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -24,7 +24,7 @@ class TestNatsTestCase:
         self.EVENTS_PROCESSED = 0
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         nc = await nats.connect(servers=["nats://localhost:4222"])
 
         async def message_handler(msg: Any) -> None:

--- a/benchmarks/nats_cases/test_pydantic.py
+++ b/benchmarks/nats_cases/test_pydantic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -35,7 +35,7 @@ class TestNatsTestCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/nats_cases/test_stream.py
+++ b/benchmarks/nats_cases/test_stream.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -34,7 +34,7 @@ class TestNatsTestCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/rabbit_cases/test_aiopika.py
+++ b/benchmarks/rabbit_cases/test_aiopika.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import aio_pika
@@ -23,7 +23,7 @@ class TestRabbitCase:
         self.EVENTS_PROCESSED = 0
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         connection = await aio_pika.connect_robust("amqp://guest:guest@localhost:5672/")
         channel = await connection.channel()
 

--- a/benchmarks/rabbit_cases/test_basic.py
+++ b/benchmarks/rabbit_cases/test_basic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -34,7 +34,7 @@ class TestRabbitCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/rabbit_cases/test_msgspec.py
+++ b/benchmarks/rabbit_cases/test_msgspec.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -40,7 +40,7 @@ class TestRabbitCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/rabbit_cases/test_pydantic.py
+++ b/benchmarks/rabbit_cases/test_pydantic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -35,7 +35,7 @@ class TestRabbitCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/redis_cases/test_basic.py
+++ b/benchmarks/redis_cases/test_basic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -34,7 +34,7 @@ class TestRedisCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/redis_cases/test_msgspec.py
+++ b/benchmarks/redis_cases/test_msgspec.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -40,7 +40,7 @@ class TestRedisCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/redis_cases/test_pydantic.py
+++ b/benchmarks/redis_cases/test_pydantic.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -35,7 +35,7 @@ class TestRedisCase:
         self.handler = handle
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         async with self.broker:
             await self.broker.start()
             start_time = time.time()

--- a/benchmarks/redis_cases/test_redis.py
+++ b/benchmarks/redis_cases/test_redis.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
@@ -23,7 +23,7 @@ class TestRedisCase:
         self.EVENTS_PROCESSED = 0
 
     @asynccontextmanager
-    async def start(self) -> AsyncIterator[float]:
+    async def start(self) -> AsyncGenerator[float, None]:
         client = redis.Redis(host="localhost", port=6379, decode_responses=False)
         pubsub = client.pubsub()
         await pubsub.subscribe("in")

--- a/docs/docs/en/getting-started/asyncapi/hosting.md
+++ b/docs/docs/en/getting-started/asyncapi/hosting.md
@@ -155,7 +155,7 @@ You can choose the method that best fits with your application architecture.
 
 === "ASGI Application"
     ```python linenums="1" hl_lines="5 22"
-    from typing import AsyncIterator
+    from typing import AsyncGenerator
     from contextlib import asynccontextmanager
 
     from fastapi import FastAPI
@@ -170,7 +170,7 @@ You can choose the method that best fits with your application architecture.
         print(msg)
 
     @asynccontextmanager
-    async def broker_lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async def broker_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         async with broker:
             await broker.start()
             yield
@@ -181,7 +181,7 @@ You can choose the method that best fits with your application architecture.
 
 === "Any HTTP Application"
     ```python linenums="1" hl_lines="23-26"
-    from typing import AsyncIterator
+    from typing import AsyncGenerator
     from contextlib import asynccontextmanager
 
     from fastapi import FastAPI, responses
@@ -195,7 +195,7 @@ You can choose the method that best fits with your application architecture.
         print(msg)
 
     @asynccontextmanager
-    async def broker_lifespan(app: FastAPI) -> AsyncIterator[None]:
+    async def broker_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         async with broker:
             await broker.start()
             yield

--- a/faststream/_internal/application.py
+++ b/faststream/_internal/application.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncGenerator, Callable, Sequence
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
@@ -32,7 +32,7 @@ try:
     from faststream.exceptions import StartupValidationError
 
     @asynccontextmanager
-    async def catch_startup_validation_error() -> AsyncIterator[None]:
+    async def catch_startup_validation_error() -> AsyncGenerator[None, None]:
         try:
             yield
         except PValidation as e:
@@ -216,7 +216,7 @@ class Application(StartAbleApplication):
     async def _start_hooks_context(
         self,
         **run_extra_options: "SettingField",
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None, None]:
         async with catch_startup_validation_error():
             for func in self._on_startup_calling:
                 await func(**run_extra_options)
@@ -230,7 +230,7 @@ class Application(StartAbleApplication):
     async def _startup_logging(
         self,
         log_level: int = logging.INFO,
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None, None]:
         """Separated startup logging."""
         self._log(
             log_level,
@@ -260,7 +260,7 @@ class Application(StartAbleApplication):
                 await broker.stop()
 
     @asynccontextmanager
-    async def _shutdown_hooks_context(self) -> AsyncIterator[None]:
+    async def _shutdown_hooks_context(self) -> AsyncGenerator[None, None]:
         for func in self._on_shutdown_calling:
             await func()
 
@@ -273,7 +273,7 @@ class Application(StartAbleApplication):
     async def _shutdown_logging(
         self,
         log_level: int = logging.INFO,
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None, None]:
         """Separated startup logging."""
         self._log(log_level, "FastStream app shutting down...")
 

--- a/faststream/_internal/context/repository.py
+++ b/faststream/_internal/context/repository.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator, Mapping
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from typing import Any
@@ -97,7 +97,7 @@ class ContextRepo:
         return context_value
 
     @contextmanager
-    def scope(self, key: str, value: Any) -> Iterator[None]:
+    def scope(self, key: str, value: Any) -> Generator[None, None, None]:
         """Sets a local variable and yields control to the caller. After the caller is done, the local variable is reset.
 
         Args:

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -2,7 +2,7 @@ import json
 import warnings
 from abc import abstractmethod
 from collections.abc import (
-    AsyncIterator,
+    AsyncGenerator,
     Awaitable,
     Callable,
     Iterable,
@@ -273,7 +273,7 @@ class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
         @asynccontextmanager
         async def start_broker_lifespan(
             app: "FastAPI",
-        ) -> AsyncIterator[Mapping[str, Any] | None]:
+        ) -> AsyncGenerator[Mapping[str, Any] | None, None]:
             """Starts the lifespan of a broker."""
             self.fastapi_config.set_application(app)
 

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -1,13 +1,21 @@
 import warnings
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Generator
+from collections.abc import AsyncGenerator, Generator
 from contextlib import (
     AsyncExitStack,
     asynccontextmanager,
     contextmanager,
 )
 from functools import partial
-from typing import TYPE_CHECKING, Any, Generic, Optional, Protocol, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    Optional,
+    Protocol,
+    TypeVar,
+    cast,
+)
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -97,7 +105,7 @@ class TestBroker(Generic[Broker, EnterType]):
         await self._ctx.__aexit__(exc_type, exc_val, exc_tb)
 
     @asynccontextmanager
-    async def _create_ctx(self) -> AsyncIterator[list[Broker]]:
+    async def _create_ctx(self) -> AsyncGenerator[list[Broker], None]:
         async with AsyncExitStack() as stack:
             saved_running = {}
             started_brokers = []
@@ -123,7 +131,7 @@ class TestBroker(Generic[Broker, EnterType]):
                 sub.running = was_running
 
     @asynccontextmanager
-    async def _do_start(self, broker: Broker) -> AsyncIterator[Broker]:
+    async def _do_start(self, broker: Broker) -> AsyncGenerator[Broker, None]:
         try:
             if not self.connect_only:
                 await broker.start()

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Generator, Iterator
+from collections.abc import AsyncIterator, Generator
 from contextlib import (
     AsyncExitStack,
     asynccontextmanager,
@@ -134,11 +134,11 @@ class TestBroker(Generic[Broker, EnterType]):
             self._fake_close(broker)
 
     @contextmanager
-    def _patch_producer(self, broker: Broker) -> Iterator[None]:
+    def _patch_producer(self, broker: Broker) -> Generator[None, None, None]:
         raise NotImplementedError
 
     @contextmanager
-    def _patch_logger(self, broker: Broker) -> Iterator[None]:
+    def _patch_logger(self, broker: Broker) -> Generator[None, None, None]:
         broker._setup_logger()
 
         logger_state = broker.config.logger

--- a/faststream/_internal/utils/functions.py
+++ b/faststream/_internal/utils/functions.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager
 from functools import partial, wraps
@@ -64,7 +64,7 @@ def to_async(
 
 
 @asynccontextmanager
-async def fake_context(*args: Any, **kwargs: Any) -> AsyncIterator[None]:
+async def fake_context(*args: Any, **kwargs: Any) -> AsyncGenerator[None, None]:
     yield None
 
 

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import traceback
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, Sequence
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Optional, Protocol
 
@@ -250,7 +250,7 @@ class AsgiFastStream(Application):
     async def start_lifespan_context(
         self,
         run_extra_options: dict[str, "SettingField"] | None = None,
-    ) -> AsyncIterator[None]:
+    ) -> AsyncGenerator[None, None]:
         run_extra_options = run_extra_options or self._run_extra_options
 
         async with self.lifespan_context(**run_extra_options):

--- a/faststream/confluent/testing.py
+++ b/faststream/confluent/testing.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from collections.abc import Callable, Generator, Iterable, Sequence
 from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional, cast, overload
@@ -70,7 +70,7 @@ class TestKafkaBroker(TestBroker[KafkaBroker, EnterType]):
         )
 
     @contextmanager
-    def _patch_producer(self, broker: KafkaBroker) -> Iterator[None]:
+    def _patch_producer(self, broker: KafkaBroker) -> Generator[None, None, None]:
         fake_producer = FakeProducer(broker, self.brokers)
 
         with ExitStack() as es:

--- a/faststream/kafka/testing.py
+++ b/faststream/kafka/testing.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
+from collections.abc import Callable, Generator, Iterable, Sequence
 from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional, cast, overload
@@ -72,7 +72,7 @@ class TestKafkaBroker(TestBroker[KafkaBroker, EnterType]):
         )
 
     @contextmanager
-    def _patch_producer(self, broker: KafkaBroker) -> Iterator[None]:
+    def _patch_producer(self, broker: KafkaBroker) -> Generator[None, None, None]:
         fake_producer = FakeProducer(broker, self.brokers)
 
         with ExitStack() as es:

--- a/faststream/mqtt/testing.py
+++ b/faststream/mqtt/testing.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast, overload
 from unittest.mock import MagicMock
@@ -158,7 +158,7 @@ class TestMQTTBroker(TestBroker[MQTTBroker, EnterType]):
         super()._fake_start(broker, *args, **kwargs)
 
     @contextmanager
-    def _patch_producer(self, broker: MQTTBroker) -> Iterator[None]:
+    def _patch_producer(self, broker: MQTTBroker) -> Generator[None, None, None]:
         fake_producer = FakeProducer(broker, self.brokers)
         with change_producer(broker.config.broker_config, fake_producer):
             yield

--- a/faststream/nats/testing.py
+++ b/faststream/nats/testing.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator, Iterable, Iterator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING, Any, Optional, cast, overload
 from unittest.mock import AsyncMock
@@ -107,7 +107,7 @@ class TestNatsBroker(TestBroker[NatsBroker, EnterType]):
         return sub, is_real
 
     @contextmanager
-    def _patch_producer(self, broker: NatsBroker) -> Iterator[None]:
+    def _patch_producer(self, broker: NatsBroker) -> Generator[None, None, None]:
         fake_producer = FakeProducer(broker, self.brokers)
 
         with ExitStack() as es:

--- a/faststream/rabbit/testing.py
+++ b/faststream/rabbit/testing.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING, Any, Optional, Union, cast, overload
 from unittest import mock
@@ -94,7 +94,7 @@ class TestRabbitBroker(TestBroker[RabbitBroker, EnterType]):
             yield
 
     @contextmanager
-    def _patch_producer(self, broker: RabbitBroker) -> Iterator[None]:
+    def _patch_producer(self, broker: RabbitBroker) -> Generator[None, None, None]:
         fake_producer = FakeProducer(broker, self.brokers)
 
         with ExitStack() as es:

--- a/faststream/redis/annotations.py
+++ b/faststream/redis/annotations.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Annotated
 
 from redis.asyncio.client import (
@@ -45,7 +45,7 @@ RedisBroker = Annotated[RB, Context("broker")]
 Redis = Annotated[RedisClient, Context("broker._connection")]
 
 
-async def get_pipe(redis: Redis) -> AsyncIterator[RedisPipeline]:
+async def get_pipe(redis: Redis) -> AsyncGenerator[RedisPipeline, None]:
     async with redis.pipeline() as pipe:
         yield pipe
 

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import AsyncGenerator, Iterable, Iterator, Sequence
+from collections.abc import AsyncGenerator, Generator, Iterable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, asynccontextmanager, contextmanager
 from functools import partial
@@ -111,7 +111,7 @@ class TestRedisBroker(TestBroker[RedisBroker, EnterType]):
                 yield brokers
 
     @contextmanager
-    def _patch_producer(self, broker: RedisBroker) -> Iterator[None]:
+    def _patch_producer(self, broker: RedisBroker) -> Generator[None, None, None]:
         with ExitStack() as es:
             es.enter_context(
                 change_producer(

--- a/tests/brokers/base/basic.py
+++ b/tests/brokers/base/basic.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
 
@@ -27,7 +27,7 @@ class BaseTestcaseConfig:
             return brokers[0]
 
         @asynccontextmanager
-        async def enter_broker() -> AsyncIterator[list[BrokerUsecase]]:
+        async def enter_broker() -> AsyncGenerator[list[BrokerUsecase], None]:
             started_brokers = []
 
             async with AsyncExitStack() as stack:

--- a/tests/brokers/confluent/test_security.py
+++ b/tests/brokers/confluent/test_security.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -7,7 +8,9 @@ from faststream.exceptions import SetupError
 
 
 @contextmanager
-def patch_aio_consumer_and_producer() -> tuple[MagicMock, MagicMock]:
+def patch_aio_consumer_and_producer() -> Generator[
+    tuple[MagicMock, MagicMock], None, None
+]:
     try:
         producer = MagicMock(return_value=AsyncMock())
 

--- a/tests/cli/require_broker/test_app.py
+++ b/tests/cli/require_broker/test_app.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import signal
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -282,7 +282,7 @@ async def test_running_lifespan_contextmanager(
     app: FastStream,
 ) -> None:
     @asynccontextmanager
-    async def lifespan(env: str) -> AsyncIterator[None]:
+    async def lifespan(env: str) -> AsyncGenerator[None, None]:
         mock.on(env)
         yield
         mock.off()
@@ -357,7 +357,7 @@ def test_sync_test_app_with_excp(mock: MagicMock) -> None:
 @pytest.mark.asyncio()
 async def test_lifespan_contextmanager(async_mock: AsyncMock, app: FastStream) -> None:
     @asynccontextmanager
-    async def lifespan(env: str) -> AsyncIterator[None]:
+    async def lifespan(env: str) -> AsyncGenerator[None, None]:
         await async_mock.on(env)
         yield
         await async_mock.off()
@@ -379,7 +379,7 @@ async def test_lifespan_contextmanager(async_mock: AsyncMock, app: FastStream) -
 
 def test_sync_lifespan_contextmanager(async_mock: AsyncMock, app: FastStream) -> None:
     @asynccontextmanager
-    async def lifespan(env: str) -> AsyncIterator[None]:
+    async def lifespan(env: str) -> AsyncGenerator[None, None]:
         await async_mock.on(env)
         yield
         await async_mock.off()

--- a/tests/docs/kafka/test_security.py
+++ b/tests/docs/kafka/test_security.py
@@ -1,4 +1,5 @@
 import ssl
+from collections.abc import Generator
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -6,7 +7,9 @@ import pytest
 
 
 @contextmanager
-def patch_aio_consumer_and_producer() -> tuple[MagicMock, MagicMock]:
+def patch_aio_consumer_and_producer() -> Generator[
+    tuple[MagicMock, MagicMock], None, None
+]:
     try:
         producer = MagicMock(return_value=AsyncMock())
         admin_client = MagicMock(return_value=AsyncMock())

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from typing import Any
 from unittest.mock import Mock
@@ -7,7 +7,9 @@ from pytest import MonkeyPatch  # noqa: PT013
 
 
 @contextmanager
-def mock_pydantic_settings_env(env_mapping: Mapping[str, Any]) -> None:
+def mock_pydantic_settings_env(
+    env_mapping: Mapping[str, Any],
+) -> Generator[None, None, None]:
     with MonkeyPatch().context() as c:
         mock = Mock()
         mock.return_value = env_mapping


### PR DESCRIPTION
refactor: typing.Iterator has been replaced by typing.Generator in all @contextmanager

# Description

Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
