### PR TITLE
tests: use syrupy for AsyncAPI schema snapshot testing (#2978)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ test-core = [
     "pytest-cov>=6.2.1",
     "covdefaults>=2.3.0",
     "freezegun>=1.5.5",
+    "syrupy>=5.0.0",
 ]
 
 testing = [

--- a/tests/asyncapi/base/v2_6_0/arguments.py
+++ b/tests/asyncapi/base/v2_6_0/arguments.py
@@ -7,6 +7,7 @@ import pydantic
 import pytest
 from dirty_equals import IsDict, IsPartialDict, IsStr
 from fast_depends import Depends
+from syrupy.assertion import SnapshotAssertion
 
 from faststream import Context
 from faststream._internal.broker import BrokerUsecase
@@ -261,7 +262,7 @@ class FastAPICompatible(AsyncAPI260Factory):
                 "type": "object",
             }
 
-    def test_dataclasses_nested(self):
+    def test_dataclasses_nested(self, snapshot: SnapshotAssertion):
         @dataclass
         class Product:
             id: int
@@ -281,30 +282,7 @@ class FastAPICompatible(AsyncAPI260Factory):
 
         payload = schema["components"]["schemas"]
 
-        assert payload == {
-            "Product": {
-                "properties": {
-                    "id": {"title": "Id", "type": "integer"},
-                    "name": {"default": "", "title": "Name", "type": "string"},
-                },
-                "required": ["id"],
-                "title": "Product",
-                "type": "object",
-            },
-            "Order": {
-                "properties": {
-                    "id": {"title": "Id", "type": "integer"},
-                    "products": {
-                        "items": {"$ref": "#/components/schemas/Product"},
-                        "title": "Products",
-                        "type": "array",
-                    },
-                },
-                "required": ["id"],
-                "title": "Order",
-                "type": "object",
-            },
-        }
+        assert payload == snapshot
 
     def test_pydantic_model(self):
         class User(pydantic.BaseModel):
@@ -332,7 +310,7 @@ class FastAPICompatible(AsyncAPI260Factory):
                 "type": "object",
             }
 
-    def test_pydantic_model_with_enum(self) -> None:
+    def test_pydantic_model_with_enum(self, snapshot: SnapshotAssertion) -> None:
         class Status(str, Enum):
             registered = "registered"
             banned = "banned"
@@ -351,27 +329,9 @@ class FastAPICompatible(AsyncAPI260Factory):
 
         payload = schema["components"]["schemas"]
 
-        assert payload == {
-            "Status": IsPartialDict(
-                {
-                    "enum": ["registered", "banned"],
-                    "title": "Status",
-                    "type": "string",
-                },
-            ),
-            "User": {
-                "properties": {
-                    "id": {"title": "Id", "type": "integer"},
-                    "name": {"default": "", "title": "Name", "type": "string"},
-                    "status": {"$ref": "#/components/schemas/Status"},
-                },
-                "required": ["id", "status"],
-                "title": "User",
-                "type": "object",
-            },
-        }, payload
+        assert payload == snapshot
 
-    def test_pydantic_model_mixed_regular(self) -> None:
+    def test_pydantic_model_mixed_regular(self, snapshot: SnapshotAssertion) -> None:
         class Email(pydantic.BaseModel):
             addr: str
 
@@ -389,37 +349,7 @@ class FastAPICompatible(AsyncAPI260Factory):
 
         payload = schema["components"]["schemas"]
 
-        assert payload == {
-            "Email": {
-                "title": "Email",
-                "type": "object",
-                "properties": {"addr": {"title": "Addr", "type": "string"}},
-                "required": ["addr"],
-            },
-            "User": {
-                "title": "User",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "default": "", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "email": {"$ref": "#/components/schemas/Email"},
-                },
-                "required": ["id", "email"],
-            },
-            "Handle:Message:Payload": {
-                "title": "Handle:Message:Payload",
-                "type": "object",
-                "properties": {
-                    "user": {"$ref": "#/components/schemas/User"},
-                    "description": {
-                        "title": "Description",
-                        "default": "",
-                        "type": "string",
-                    },
-                },
-                "required": ["user"],
-            },
-        }
+        assert payload == snapshot
 
     def test_nested_models_in_union_should_be_in_schemas(self) -> None:
         """Test that nested Pydantic models in union types are promoted to components/schemas.

--- a/tests/asyncapi/base/v3_0_0/arguments.py
+++ b/tests/asyncapi/base/v3_0_0/arguments.py
@@ -8,6 +8,7 @@ import pytest
 from dirty_equals import IsDict, IsPartialDict, IsStr
 from fast_depends import Depends
 from fastapi import Depends as APIDepends
+from syrupy.assertion import SnapshotAssertion
 
 from faststream import Context
 from faststream._internal._compat import PYDANTIC_V2
@@ -317,7 +318,7 @@ class FastAPICompatible(AsyncAPI300Factory):
                 "type": "object",
             }
 
-    def test_pydantic_model_with_enum(self) -> None:
+    def test_pydantic_model_with_enum(self, snapshot: SnapshotAssertion) -> None:
         class Status(str, Enum):
             registered = "registered"
             banned = "banned"
@@ -336,27 +337,9 @@ class FastAPICompatible(AsyncAPI300Factory):
 
         payload = schema["components"]["schemas"]
 
-        assert payload == {
-            "Status": IsPartialDict(
-                {
-                    "enum": ["registered", "banned"],
-                    "title": "Status",
-                    "type": "string",
-                },
-            ),
-            "User": {
-                "properties": {
-                    "id": {"title": "Id", "type": "integer"},
-                    "name": {"default": "", "title": "Name", "type": "string"},
-                    "status": {"$ref": "#/components/schemas/Status"},
-                },
-                "required": ["id", "status"],
-                "title": "User",
-                "type": "object",
-            },
-        }, payload
+        assert payload == snapshot
 
-    def test_pydantic_model_mixed_regular(self) -> None:
+    def test_pydantic_model_mixed_regular(self, snapshot: SnapshotAssertion) -> None:
         class Email(pydantic.BaseModel):
             addr: str
 
@@ -374,37 +357,7 @@ class FastAPICompatible(AsyncAPI300Factory):
 
         payload = schema["components"]["schemas"]
 
-        assert payload == {
-            "Email": {
-                "title": "Email",
-                "type": "object",
-                "properties": {"addr": {"title": "Addr", "type": "string"}},
-                "required": ["addr"],
-            },
-            "User": {
-                "title": "User",
-                "type": "object",
-                "properties": {
-                    "name": {"title": "Name", "default": "", "type": "string"},
-                    "id": {"title": "Id", "type": "integer"},
-                    "email": {"$ref": "#/components/schemas/Email"},
-                },
-                "required": ["id", "email"],
-            },
-            "Handle:Message:Payload": {
-                "title": "Handle:Message:Payload",
-                "type": "object",
-                "properties": {
-                    "user": {"$ref": "#/components/schemas/User"},
-                    "description": {
-                        "title": "Description",
-                        "default": "",
-                        "type": "string",
-                    },
-                },
-                "required": ["user"],
-            },
-        }
+        assert payload == snapshot
 
     def test_nested_models_in_union_should_be_in_schemas(self) -> None:
         """Test that nested Pydantic models in union types are promoted to components/schemas.

--- a/tests/asyncapi/confluent/v2_6_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/confluent/v2_6_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/confluent/v2_6_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/confluent/v2_6_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/confluent/v2_6_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/confluent/v2_6_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/confluent/v3_0_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/confluent/v3_0_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/confluent/v3_0_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/confluent/v3_0_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/confluent/v3_0_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/confluent/v3_0_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/kafka/v2_6_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/kafka/v2_6_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/kafka/v2_6_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/kafka/v2_6_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/kafka/v2_6_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/kafka/v2_6_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/kafka/v3_0_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/kafka/v3_0_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/kafka/v3_0_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/kafka/v3_0_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/kafka/v3_0_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/kafka/v3_0_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/mqtt/v2_6_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/mqtt/v2_6_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/mqtt/v2_6_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/mqtt/v2_6_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/mqtt/v2_6_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/mqtt/v2_6_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/mqtt/v3_0_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/mqtt/v3_0_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/mqtt/v3_0_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/mqtt/v3_0_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/mqtt/v3_0_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/mqtt/v3_0_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/nats/v2_6_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/nats/v2_6_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/nats/v2_6_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/nats/v2_6_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/nats/v2_6_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/nats/v2_6_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/nats/v3_0_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/nats/v3_0_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/nats/v3_0_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/nats/v3_0_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/nats/v3_0_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/nats/v3_0_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/rabbit/v2_6_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/rabbit/v2_6_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/rabbit/v2_6_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/rabbit/v2_6_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/rabbit/v2_6_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/rabbit/v2_6_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/rabbit/v3_0_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/rabbit/v3_0_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/rabbit/v3_0_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/rabbit/v3_0_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/rabbit/v3_0_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/rabbit/v3_0_0/__snapshots__/test_router.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/redis/v2_6_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/redis/v2_6_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/redis/v2_6_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/redis/v2_6_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/redis/v2_6_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/redis/v2_6_0/__snapshots__/test_router.ambr
@@ -1,0 +1,133 @@
+# serializer version: 1
+# name: TestRouterArguments.test_dataclasses_nested
+  dict({
+    'Order': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'products': dict({
+          'items': dict({
+            '$ref': '#/components/schemas/Product',
+          }),
+          'title': 'Products',
+          'type': 'array',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Order',
+      'type': 'object',
+    }),
+    'Product': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+      ]),
+      'title': 'Product',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/redis/v3_0_0/__snapshots__/test_arguments.ambr
+++ b/tests/asyncapi/redis/v3_0_0/__snapshots__/test_arguments.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/redis/v3_0_0/__snapshots__/test_fastapi.ambr
+++ b/tests/asyncapi/redis/v3_0_0/__snapshots__/test_fastapi.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/tests/asyncapi/redis/v3_0_0/__snapshots__/test_router.ambr
+++ b/tests/asyncapi/redis/v3_0_0/__snapshots__/test_router.ambr
@@ -1,0 +1,91 @@
+# serializer version: 1
+# name: TestRouterArguments.test_pydantic_model_mixed_regular
+  dict({
+    'Email': dict({
+      'properties': dict({
+        'addr': dict({
+          'title': 'Addr',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'addr',
+      ]),
+      'title': 'Email',
+      'type': 'object',
+    }),
+    'Handle:Message:Payload': dict({
+      'properties': dict({
+        'description': dict({
+          'default': '',
+          'title': 'Description',
+          'type': 'string',
+        }),
+        'user': dict({
+          '$ref': '#/components/schemas/User',
+        }),
+      }),
+      'required': list([
+        'user',
+      ]),
+      'title': 'Handle:Message:Payload',
+      'type': 'object',
+    }),
+    'User': dict({
+      'properties': dict({
+        'email': dict({
+          '$ref': '#/components/schemas/Email',
+        }),
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+      }),
+      'required': list([
+        'id',
+        'email',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---
+# name: TestRouterArguments.test_pydantic_model_with_enum
+  dict({
+    'Status': dict({
+      'enum': list([
+        'registered',
+        'banned',
+      ]),
+      'title': 'Status',
+      'type': 'string',
+    }),
+    'User': dict({
+      'properties': dict({
+        'id': dict({
+          'title': 'Id',
+          'type': 'integer',
+        }),
+        'name': dict({
+          'default': '',
+          'title': 'Name',
+          'type': 'string',
+        }),
+        'status': dict({
+          '$ref': '#/components/schemas/Status',
+        }),
+      }),
+      'required': list([
+        'id',
+        'status',
+      ]),
+      'title': 'User',
+      'type': 'object',
+    }),
+  })
+# ---

--- a/uv.lock
+++ b/uv.lock
@@ -932,6 +932,7 @@ dev = [
     { name = "ruff" },
     { name = "semgrep" },
     { name = "setuptools" },
+    { name = "syrupy" },
     { name = "types-aiofiles" },
     { name = "types-deprecated" },
     { name = "types-docutils" },
@@ -988,6 +989,7 @@ test-core = [
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "syrupy" },
 ]
 testing = [
     { name = "covdefaults" },
@@ -1008,6 +1010,7 @@ testing = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
+    { name = "syrupy" },
     { name = "uvicorn" },
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
 ]
@@ -1074,6 +1077,7 @@ dev = [
     { name = "ruff", specifier = "==0.14.14" },
     { name = "semgrep", specifier = "==1.150.0" },
     { name = "setuptools", specifier = ">=80.9.0" },
+    { name = "syrupy", specifier = ">=5.0.0" },
     { name = "types-aiofiles" },
     { name = "types-deprecated" },
     { name = "types-docutils" },
@@ -1128,6 +1132,7 @@ test-core = [
     { name = "pytest-rerunfailures", specifier = ">=15.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "syrupy", specifier = ">=5.0.0" },
 ]
 testing = [
     { name = "covdefaults", specifier = ">=2.3.0" },
@@ -1148,6 +1153,7 @@ testing = [
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "syrupy", specifier = ">=5.0.0" },
     { name = "uvicorn", specifier = ">=0.34.3" },
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'", specifier = ">=0.15.1" },
 ]
@@ -3550,6 +3556,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/de/a0c3d1244912c260638f0f925e190e493ccea37ecaea9bbad7c14413b803/super_collections-0.6.2.tar.gz", hash = "sha256:0c8d8abacd9fad2c7c1c715f036c29f5db213f8cac65f24d45ecba12b4da187a", size = 31315, upload-time = "2025-09-30T00:37:08.067Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/43/47c7cf84b3bd74a8631b02d47db356656bb8dff6f2e61a4c749963814d0d/super_collections-0.6.2-py3-none-any.whl", hash = "sha256:291b74d26299e9051d69ad9d89e61b07b6646f86a57a2f5ab3063d206eee9c56", size = 16173, upload-time = "2025-09-30T00:37:07.104Z" },
+]
+
+[[package]]
+name = "syrupy"
+version = "5.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/39/17dde9f0c76cc5abcdeef1b2243791bb850d498f784147b8e460dd23abe8/syrupy-5.5.3.tar.gz", hash = "sha256:fa21e4ae77c89ec5abfca513338d8a7eb916da6618ca0f8db301476e0768e57a", size = 91614, upload-time = "2026-07-11T15:54:31.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/f9/617a194c1a4203279998e1859426cf2635042533a99a93d63d3ee1fb967e/syrupy-5.5.3-py3-none-any.whl", hash = "sha256:0b260a0c9dad55e1fb83818973dc36fbc1aea3fd5381592f442a986686c4171a", size = 54959, upload-time = "2026-07-11T15:54:29.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace large hand-written dict literals in the shared AsyncAPI arguments test cases with syrupy snapshots, so expected schemas are generated once and diffed automatically instead of being maintained by hand across every broker/version test module.

# Description

Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context.

Fixes #2978

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
