### PR TITLE
bug(nats): [#2674] faststream raises authentication error

### DIFF
--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -170,6 +170,22 @@ if TYPE_CHECKING:
         flush_timeout: float | None
 
 
+# Server-sent `-ERR` reasons that will never succeed on retry, so the
+# initial connection attempt should fail fast instead of being silently
+# retried like a transient error until `max_reconnect_attempts` is hit.
+UNRECOVERABLE_CONNECT_ERRORS = (
+    "authorization violation",
+    "authorization timeout",
+    "invalid client protocol",
+    "maximum payload violation",
+    "invalid subject",
+    "stale connection",
+    "maximum connections exceeded",
+    "parser error",
+    "secure connection - tls required",
+)
+
+
 class NatsBroker(
     NatsRegistrator,
     BrokerUsecase[Msg, Client],
@@ -715,8 +731,10 @@ class NatsBroker(
             if error_cb is not None:
                 await error_cb(err)
 
-            if isinstance(err, Error) and "authorization violation" in str(err).lower():
-                raise err
+            if isinstance(err, Error):
+                reason = str(err).removeprefix("nats: ").strip("'").lower()
+                if reason in UNRECOVERABLE_CONNECT_ERRORS:
+                    raise err
 
             if isinstance(err, Error) and self.config.connection_state:
                 self.config.logger.log(

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -715,6 +715,9 @@ class NatsBroker(
             if error_cb is not None:
                 await error_cb(err)
 
+            if isinstance(err, Error) and "authorization violation" in str(err).lower():
+                raise err
+
             if isinstance(err, Error) and self.config.connection_state:
                 self.config.logger.log(
                     f"Connection broken with {err!r}",

--- a/tests/brokers/nats/test_connect.py
+++ b/tests/brokers/nats/test_connect.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from nats.errors import Error
 
 from faststream.nats import NatsBroker
 from tests.brokers.base.connection import BrokerConnectionTestcase
@@ -21,3 +22,14 @@ class TestConnection(BrokerConnectionTestcase):
         broker = NatsBroker(js_options={"prefix": "test"})
         broker.config.connect(mock)
         mock.jetstream.assert_called_once_with(prefix="test")
+
+
+@pytest.mark.nats()
+@pytest.mark.asyncio()
+async def test_initial_authorization_violation_fails_fast() -> None:
+
+    broker = NatsBroker()
+    error_cb = broker._connection_kwargs["error_cb"]
+
+    with pytest.raises(Error):
+        await error_cb(Error("nats: 'Authorization Violation'"))

--- a/tests/brokers/nats/test_connect.py
+++ b/tests/brokers/nats/test_connect.py
@@ -5,6 +5,7 @@ import pytest
 from nats.errors import Error
 
 from faststream.nats import NatsBroker
+from faststream.nats.broker.broker import UNRECOVERABLE_CONNECT_ERRORS
 from tests.brokers.base.connection import BrokerConnectionTestcase
 
 from .settings import Settings
@@ -26,10 +27,19 @@ class TestConnection(BrokerConnectionTestcase):
 
 @pytest.mark.nats()
 @pytest.mark.asyncio()
-async def test_initial_authorization_violation_fails_fast() -> None:
-
+@pytest.mark.parametrize("reason", UNRECOVERABLE_CONNECT_ERRORS)
+async def test_unrecoverable_connect_error_fails_fast(reason: str) -> None:
     broker = NatsBroker()
     error_cb = broker._connection_kwargs["error_cb"]
 
     with pytest.raises(Error):
-        await error_cb(Error("nats: 'Authorization Violation'"))
+        await error_cb(Error(f"nats: '{reason.title()}'"))
+
+
+@pytest.mark.nats()
+@pytest.mark.asyncio()
+async def test_recoverable_connect_error_does_not_raise() -> None:
+    broker = NatsBroker()
+    error_cb = broker._connection_kwargs["error_cb"]
+
+    await error_cb(Error("nats: 'Slow Consumer'"))


### PR DESCRIPTION
# Description

This PR fixes a NATS connection bug where FastStream would hang for ~2 minutes on startup when given invalid credentials, instead of failing immediately. What I propose:

1 - NatsBroker._connect() calls nats.connect() with allow_reconnect=True by default, which is correct for resilience against transient disconnects at runtime, but wrong for the very first connection attempt: nats-py's initial handshake treats a server-sent Authorization Violation exactly like a transient network error, silently retrying up to max_reconnect_attempts (default 60, ~2 minutes) before finally surfacing an unrelated NoServersError that hides the real cause.

2 - Rather than disabling allow_reconnect globally (which would also kill legitimate auto-reconnect after a later, transient disconnect at runtime), the fix wraps the broker's error_cb to fail fast only when the error is an authorization violation. All other errors, and any auth violation occurring after a successful connect, keep the existing retry/reconnect behavior untouched.

3 - Note: nats-py's initial-connect handshake raises this as a generic nats.errors.Error with the message "nats: 'Authorization Violation'", not the typed AuthorizationError it uses elsewhere for post-connect protocol errors (a known inconsistency in that library) — so detection is a case-insensitive substring match on "authorization violation" rather than an isinstance check.

Fixes #2674

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)


## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
