### PR TITLE
fix: prevent handler exceptions leaking under AnyIO

### DIFF
--- a/faststream/_internal/endpoint/call_wrapper.py
+++ b/faststream/_internal/endpoint/call_wrapper.py
@@ -138,6 +138,8 @@ class HandlerCallWrapper(Generic[P_HandlerParams, T_HandlerReturn]):
 
         if error:
             self.future.set_exception(error)
+            # Mark the mirrored error as retrieved to avoid unhandled-future reports.
+            self.future.exception()
 
         else:
             self.future.set_result(result)

--- a/tests/utils/test_handler_call_wrapper.py
+++ b/tests/utils/test_handler_call_wrapper.py
@@ -1,0 +1,39 @@
+import gc
+
+import pytest
+
+from faststream._internal.endpoint.call_wrapper import HandlerCallWrapper
+
+
+@pytest.mark.anyio()
+@pytest.mark.parametrize("anyio_backend", ("asyncio",))
+async def test_handler_exception_does_not_leak_to_event_loop(
+    anyio_backend: str,
+) -> None:
+    async def handler() -> None:
+        return None
+
+    wrapper = HandlerCallWrapper(handler)
+    wrapper.set_test()
+    error = ValueError("handler failed")
+
+    wrapper.trigger(error=error)
+    del wrapper
+    gc.collect()
+
+
+@pytest.mark.asyncio()
+async def test_handler_exception_remains_available_to_wait_call() -> None:
+    async def handler() -> None:
+        return None
+
+    wrapper = HandlerCallWrapper(handler)
+    wrapper.set_test()
+    error = ValueError("handler failed")
+
+    wrapper.trigger(error=error)
+
+    with pytest.raises(ValueError, match="handler failed") as exc_info:
+        await wrapper.wait_call()
+
+    assert exc_info.value is error


### PR DESCRIPTION
# Description

Handler exceptions mirrored into `HandlerCallWrapper.future` were left unretrieved. AnyIO treats that future exception as an unhandled asynchronous error, so tests failed even when the publishing call correctly caught the handler exception.

This change marks the mirrored exception as retrieved immediately after setting it. Awaiting `wait_call()` still raises the original exception instance.

Fixes #2504

## Type of change

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Validation

- Added an AnyIO regression test that failed before the fix and passes afterward.
- Added a preservation test confirming `wait_call()` still raises the original exception.
- Ran the focused utility tests and the non-connected Confluent test-client suite.
- Ran the inherited handler-exception test across Kafka, Confluent, NATS, RabbitMQ, and Redis.
- Ran the repository pre-commit pipeline, including Ruff, mypy, Bandit, Semgrep, typo checks, and secret detection.
- `just test-coverage` and connected broker tests were not run because Docker is unavailable in the local environment.

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
