### PR TITLE
feat(redis): add batch stream message annotation

### DIFF
--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -7,6 +7,7 @@ try:
     from .annotations import (
         Pipeline,
         Redis,
+        RedisBatchStreamMessage,
         RedisChannelMessage,
         RedisListMessage,
         RedisMessage,
@@ -40,6 +41,7 @@ __all__ = (
     "Pipeline",
     "PubSub",
     "Redis",
+    "RedisBatchStreamMessage",
     "RedisBroker",
     "RedisChannelMessage",
     "RedisClusterBroker",

--- a/faststream/redis/annotations.py
+++ b/faststream/redis/annotations.py
@@ -12,6 +12,7 @@ from faststream.annotations import ContextRepo, Logger
 from faststream.params import NoCast
 from faststream.redis.broker.broker import RedisBroker as RB
 from faststream.redis.message import (
+    RedisBatchStreamMessage as Rbsm,
     RedisChannelMessage as Rcm,
     RedisListMessage as Rlm,
     RedisMessage as Rm,
@@ -31,6 +32,7 @@ __all__ = (
     "NoCast",
     "Pipeline",
     "Redis",
+    "RedisBatchStreamMessage",
     "RedisBroker",
     "RedisChannelMessage",
     "RedisStreamMessage",
@@ -39,6 +41,7 @@ __all__ = (
 RedisMessage = Annotated[Rm, Context("message")]
 RedisChannelMessage = Annotated[Rcm, Context("message")]
 RedisStreamMessage = Annotated[Rsm, Context("message")]
+RedisBatchStreamMessage = Annotated[Rbsm, Context("message")]
 RedisListMessage = Annotated[Rlm, Context("message")]
 
 RedisBroker = Annotated[RB, Context("broker")]

--- a/tests/brokers/redis/test_test_client.py
+++ b/tests/brokers/redis/test_test_client.py
@@ -1,9 +1,13 @@
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
 from faststream import BaseMiddleware
-from faststream.redis import ListSub, StreamSub
+from faststream.redis import ListSub, RedisBatchStreamMessage, StreamSub
+from faststream.redis.message import (
+    RedisBatchStreamMessage as RawRedisBatchStreamMessage,
+)
 from faststream.redis.testing import FakeProducer
 from tests.brokers.base.testclient import BrokerTestclientTestcase
 
@@ -178,6 +182,22 @@ class TestTestclient(RedisMemoryTestcaseConfig, BrokerTestclientTestcase):
         async with self.patch_broker(broker) as br:
             await br.publish("hello", stream=queue)
             m.mock.assert_called_once_with(["hello"])
+
+    async def test_stream_batch_message_annotation(
+        self,
+        queue: str,
+        mock: MagicMock,
+    ) -> None:
+        broker = self.get_broker(apply_types=True)
+
+        @broker.subscriber(stream=StreamSub(queue, batch=True))
+        async def handler(message: RedisBatchStreamMessage) -> None:
+            mock(type(message), await message.decode())
+
+        async with self.patch_broker(broker) as br:
+            await br.publish("hello", stream=queue)
+
+        mock.assert_called_once_with(RawRedisBatchStreamMessage, ["hello"])
 
     async def test_stream_publisher(
         self,

--- a/tests/brokers/redis/test_test_client.py
+++ b/tests/brokers/redis/test_test_client.py
@@ -1,13 +1,9 @@
 import asyncio
-from unittest.mock import MagicMock
 
 import pytest
 
 from faststream import BaseMiddleware
-from faststream.redis import ListSub, RedisBatchStreamMessage, StreamSub
-from faststream.redis.message import (
-    RedisBatchStreamMessage as RawRedisBatchStreamMessage,
-)
+from faststream.redis import ListSub, StreamSub
 from faststream.redis.testing import FakeProducer
 from tests.brokers.base.testclient import BrokerTestclientTestcase
 
@@ -182,22 +178,6 @@ class TestTestclient(RedisMemoryTestcaseConfig, BrokerTestclientTestcase):
         async with self.patch_broker(broker) as br:
             await br.publish("hello", stream=queue)
             m.mock.assert_called_once_with(["hello"])
-
-    async def test_stream_batch_message_annotation(
-        self,
-        queue: str,
-        mock: MagicMock,
-    ) -> None:
-        broker = self.get_broker(apply_types=True)
-
-        @broker.subscriber(stream=StreamSub(queue, batch=True))
-        async def handler(message: RedisBatchStreamMessage) -> None:
-            mock(type(message), await message.decode())
-
-        async with self.patch_broker(broker) as br:
-            await br.publish("hello", stream=queue)
-
-        mock.assert_called_once_with(RawRedisBatchStreamMessage, ["hello"])
 
     async def test_stream_publisher(
         self,


### PR DESCRIPTION
﻿# Description

Add the missing `RedisBatchStreamMessage` annotated context alias and expose it from the public `faststream.redis` API, matching the existing Redis message aliases.

The Redis TestBroker module remains unchanged after the redundant alias-specific test was removed at the maintainer's request. Its existing in-memory tests exercise the shared annotation injection mechanism.

Fixes #3004

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Validation

- `uv run --no-sync pytest tests/brokers/redis/test_test_client.py -m "not slow and not connected" -n auto` — 62 passed, 1 xfailed
- `just linter` — passed
- `just mypy` — passed (510 source files)
- `just bandit` — passed (0 findings across 41,547 lines)
- `PYTHONUTF8=1 PYTHONIOENCODING=utf-8 just semgrep` — passed (290 rules, 504 files, 0 findings)
- `just pre-commit` — all applicable hooks passed
- `git diff --check` — passed

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of the diff
- [x] My changes do not generate any new warnings
- [x] Existing tests in the modified Redis TestBroker module pass locally
- [x] Static analysis passes locally

## AI assistance

AI assistance was used during investigation or implementation.

