### PR TITLE
docs: expand RabbitMQ Streams guide

### DIFF
--- a/docs/docs/en/rabbit/examples/stream.md
+++ b/docs/docs/en/rabbit/examples/stream.md
@@ -10,12 +10,44 @@ search:
 
 # RabbitMQ Streams
 
-*RabbitMQ* has a [Streams](https://www.rabbitmq.com/streams.html){.external-link target="_blank"} feature, which is closely related to *Kafka* topics.
+*RabbitMQ* streams are persistent, replicated append-only logs. Unlike regular
+queues, consuming a message does not remove it, so different consumers can read
+the same messages or replay an earlier part of the log. Streams are useful for
+large fan-outs, replay, high throughput, and large backlogs. See the
+[RabbitMQ streams guide](https://www.rabbitmq.com/docs/streams){.external-link target="_blank"}
+for the full feature and operational details.
 
-The main difference from regular *RabbitMQ* queues is that the messages are not deleted after consuming.
+## Declare and consume a stream
 
-And **FastStream** supports this feature as well!
+Set `queue_type=QueueType.STREAM` when declaring a `RabbitQueue`. Streams are
+always durable, and RabbitMQ requires a non-zero consumer prefetch. The example
+sets that prefetch on the broker's default channel.
 
-```python linenums="1" hl_lines="4 10-12 17"
+```python linenums="1" hl_lines="4 10-14 18-20"
 {! docs_src/rabbit/subscription/stream.py !}
 ```
+
+## Choose the starting offset
+
+Pass the RabbitMQ `x-stream-offset` consumer argument through `consume_args` to
+choose where a subscriber starts reading. The example uses `first`, which
+replays the stream from its first available message.
+
+Supported values include:
+
+* `first` to start at the first available message.
+* `last` to start at the last stored chunk of messages, not only the final
+  message.
+* `next`, or no offset argument, to wait for messages published after the
+  subscriber starts.
+* An integer offset, a timestamp, or a relative time interval to start at a
+  specific position.
+
+## Configure retention
+
+Because consumption does not delete messages, configure retention so a stream
+does not grow without limit. The example keeps no more than seven days or 20 GB
+of data by passing `x-max-age` and `x-max-length-bytes` in the queue's
+`arguments` dictionary. You can also configure these limits with a RabbitMQ
+policy. RabbitMQ removes the oldest stream segments when a retention limit is
+reached.

--- a/docs/docs_src/rabbit/subscription/stream.py
+++ b/docs/docs_src/rabbit/subscription/stream.py
@@ -8,6 +8,10 @@ queue = RabbitQueue(
     name="test-stream",
     durable=True,
     queue_type=QueueType.STREAM,
+    arguments={
+        "x-max-age": "7D",
+        "x-max-length-bytes": 20_000_000_000,
+    },
 )
 
 


### PR DESCRIPTION
# Description

Expand the RabbitMQ Streams page with stream use cases, offset behavior, prefetch requirements, and retention guidance. The executable example now demonstrates a bounded stream using `x-max-age` and `x-max-length-bytes`.

Fixes #756

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not introduce new documentation warnings
- [x] I have included code examples to illustrate the modifications

## Validation

- Ruff checks passed for the example
- example import and queue arguments verified
- MkDocs build passed; strict mode reports only existing unrelated broken links

## AI assistance

Codex (GPT-5) assisted with drafting the documentation and example update. I manually reviewed the final diff and validation results.