### PR TITLE
fix: skip ack action on handler cancellation

### DIFF
--- a/faststream/middlewares/acknowledgement/middleware.py
+++ b/faststream/middlewares/acknowledgement/middleware.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -100,6 +101,9 @@ class _AcknowledgementMiddleware(BaseMiddleware):
 
             # Exception was processed and suppressed
             return True
+
+        elif isinstance(exc_val, asyncio.CancelledError):
+            return False
 
         elif self.ack_policy is AckPolicy.REJECT_ON_ERROR:
             await self.__reject()

--- a/tests/brokers/base/basic.py
+++ b/tests/brokers/base/basic.py
@@ -13,6 +13,9 @@ _BrokerT = TypeVar("_BrokerT", bound=BrokerUsecase[Any, Any], default=Any)
 
 class BaseTestcaseConfig(Generic[_BrokerT]):
     timeout: float = 3.0
+    # Default channel/list/core subscribers that force MANUAL ack have no
+    # AcknowledgementMiddleware, so cancel cannot hit the shared ack skip path.
+    supports_cancel_ack_skip: bool = True
 
     @abstractmethod
     def get_broker(
@@ -65,6 +68,10 @@ class BaseTestcaseConfig(Generic[_BrokerT]):
         dict[str, Any],
     ]:
         return args, kwargs
+
+    def get_cancel_ack_subscriber_kwargs(self, queue: str) -> dict[str, Any]:
+        """Extra subscriber kwargs for cancel acknowledgement-skip consume tests."""
+        return {}
 
     @abstractmethod
     def get_router(self, **kwargs: Any) -> BrokerRouter:

--- a/tests/brokers/base/consume.py
+++ b/tests/brokers/base/consume.py
@@ -1,12 +1,14 @@
 import asyncio
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 import anyio
 import pytest
 from pydantic import BaseModel
 
-from faststream import Context, Depends, FastStream, TestApp
+from faststream import AckPolicy, Context, Depends, FastStream, TestApp
 from faststream.exceptions import StopConsume
+from faststream.message import StreamMessage
+from tests.tools import spy_decorator
 
 from .basic import BaseTestcaseConfig
 
@@ -403,6 +405,80 @@ class BrokerConsumeTestcase(MultibrokerTestcase, BaseTestcaseConfig):
 
             with pytest.raises(AssertionError):
                 await subscriber.get_one(timeout=1e-24)
+
+    @pytest.mark.parametrize(
+        "ack_policy",
+        (
+            pytest.param(AckPolicy.ACK, id="ack"),
+            pytest.param(
+                AckPolicy.REJECT_ON_ERROR,
+                id="reject_on_error",
+                marks=[
+                    pytest.mark.filterwarnings(
+                        "ignore:AckPolicy.REJECT_ON_ERROR has the same effect"
+                    )
+                ],
+            ),
+            pytest.param(AckPolicy.NACK_ON_ERROR, id="nack_on_error"),
+        ),
+    )
+    async def test_consume_cancel_skips_ack_nack_reject(
+        self,
+        queue: str,
+        ack_policy: AckPolicy,
+    ) -> None:
+        if not self.supports_cancel_ack_skip:
+            pytest.skip("broker default subscriber has no acknowledgement middleware")
+
+        started = asyncio.Event()
+        broker = self.get_broker(graceful_timeout=0.2)
+        args, kwargs = self.get_subscriber_params(
+            queue,
+            ack_policy=ack_policy,
+            **self.get_cancel_ack_subscriber_kwargs(queue),
+        )
+
+        @broker.subscriber(*args, **kwargs)
+        async def handler(_msg: object) -> None:
+            started.set()
+            await asyncio.sleep(60)
+
+        with (
+            patch.object(
+                StreamMessage,
+                "nack",
+                spy_decorator(StreamMessage.nack),
+            ) as nack,
+            patch.object(
+                StreamMessage,
+                "ack",
+                spy_decorator(StreamMessage.ack),
+            ) as ack,
+            patch.object(
+                StreamMessage,
+                "reject",
+                spy_decorator(StreamMessage.reject),
+            ) as reject,
+        ):
+            async with self.patch_broker(broker) as br:
+                await br.start()
+                publish_task = asyncio.create_task(br.publish("hello", queue))
+                await asyncio.wait_for(started.wait(), timeout=self.timeout)
+
+                # TestBroker awaits the handler inside publish; real brokers
+                # return after enqueue, so cancel publish when still running,
+                # otherwise stop and let graceful_timeout cancel the consume task.
+                if not publish_task.done():
+                    publish_task.cancel()
+                    with pytest.raises(asyncio.CancelledError):
+                        await publish_task
+                else:
+                    await publish_task
+                    await br.stop()
+
+        nack.mock.assert_not_awaited()
+        ack.mock.assert_not_awaited()
+        reject.mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio()

--- a/tests/brokers/base/consume.py
+++ b/tests/brokers/base/consume.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import anyio
@@ -426,11 +427,11 @@ class BrokerConsumeTestcase(MultibrokerTestcase, BaseTestcaseConfig):
         self,
         queue: str,
         ack_policy: AckPolicy,
+        event: asyncio.Event,
     ) -> None:
         if not self.supports_cancel_ack_skip:
             pytest.skip("broker default subscriber has no acknowledgement middleware")
 
-        started = asyncio.Event()
         broker = self.get_broker(graceful_timeout=0.2)
         args, kwargs = self.get_subscriber_params(
             queue,
@@ -439,8 +440,8 @@ class BrokerConsumeTestcase(MultibrokerTestcase, BaseTestcaseConfig):
         )
 
         @broker.subscriber(*args, **kwargs)
-        async def handler(_msg: object) -> None:
-            started.set()
+        async def handler(_msg: Any) -> None:
+            event.set()
             await asyncio.sleep(60)
 
         with (
@@ -463,18 +464,18 @@ class BrokerConsumeTestcase(MultibrokerTestcase, BaseTestcaseConfig):
             async with self.patch_broker(broker) as br:
                 await br.start()
                 publish_task = asyncio.create_task(br.publish("hello", queue))
-                await asyncio.wait_for(started.wait(), timeout=self.timeout)
+                await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
                 # TestBroker awaits the handler inside publish; real brokers
-                # return after enqueue, so cancel publish when still running,
-                # otherwise stop and let graceful_timeout cancel the consume task.
+                # return after enqueue, so cancel publish when still running.
+                # Otherwise broker context exit stops and cancels after
+                # graceful_timeout.
                 if not publish_task.done():
                     publish_task.cancel()
                     with pytest.raises(asyncio.CancelledError):
                         await publish_task
                 else:
                     await publish_task
-                    await br.stop()
 
         nack.mock.assert_not_awaited()
         ack.mock.assert_not_awaited()

--- a/tests/brokers/confluent/basic.py
+++ b/tests/brokers/confluent/basic.py
@@ -36,6 +36,9 @@ class ConfluentTestcaseConfig(BaseTestcaseConfig[KafkaBroker]):
             **kwargs,
         }
 
+    def get_cancel_ack_subscriber_kwargs(self, queue: str) -> dict[str, Any]:
+        return {"group_id": f"{queue}-cancel-ack"}
+
     def get_broker(
         self,
         apply_types: bool = False,

--- a/tests/brokers/kafka/basic.py
+++ b/tests/brokers/kafka/basic.py
@@ -18,6 +18,12 @@ class KafkaTestcaseConfig(BaseTestcaseConfig[KafkaBroker]):
     def get_router(self, **kwargs: Any) -> KafkaRouter:
         return KafkaRouter(**kwargs)
 
+    def get_cancel_ack_subscriber_kwargs(self, queue: str) -> dict[str, Any]:
+        return {
+            "group_id": f"{queue}-cancel-ack",
+            "auto_offset_reset": "earliest",
+        }
+
 
 class KafkaMemoryTestcaseConfig(KafkaTestcaseConfig):
     @overload

--- a/tests/brokers/kafka/test_cancellation.py
+++ b/tests/brokers/kafka/test_cancellation.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import pytest
+
+from faststream import AckPolicy
+
+from .basic import KafkaTestcaseConfig
+
+
+@pytest.mark.kafka()
+@pytest.mark.connected()
+@pytest.mark.asyncio()
+@pytest.mark.filterwarnings(
+    "ignore:AckPolicy.REJECT_ON_ERROR has the same effect as AckPolicy.ACK."
+)
+class TestKafkaCancellation(KafkaTestcaseConfig):
+    async def test_graceful_shutdown_redelivers_interrupted_message(
+        self,
+        queue: str,
+    ) -> None:
+        group_id = f"{queue}-group"
+        payload = f"{queue}-payload"
+        started = asyncio.Event()
+        redelivered = asyncio.Event()
+
+        broker = self.get_broker(graceful_timeout=0.3)
+
+        @broker.subscriber(
+            queue,
+            group_id=group_id,
+            ack_policy=AckPolicy.REJECT_ON_ERROR,
+            auto_offset_reset="earliest",
+        )
+        async def handle(_: str) -> None:
+            started.set()
+            await asyncio.sleep(60)
+
+        async with self.patch_broker(broker) as br:
+            await br.start()
+            await br.publish(payload, queue)
+            await asyncio.wait_for(started.wait(), timeout=self.timeout)
+            await br.stop()
+
+        restart_broker = self.get_broker()
+
+        @restart_broker.subscriber(
+            queue,
+            group_id=group_id,
+            ack_policy=AckPolicy.REJECT_ON_ERROR,
+            auto_offset_reset="earliest",
+        )
+        async def handle_retry(msg: str) -> None:
+            assert msg == payload
+            redelivered.set()
+
+        async with self.patch_broker(restart_broker) as br:
+            await br.start()
+            await asyncio.wait_for(redelivered.wait(), timeout=self.timeout)

--- a/tests/brokers/kafka/test_cancellation.py
+++ b/tests/brokers/kafka/test_cancellation.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,11 +18,13 @@ class TestKafkaCancellation(KafkaTestcaseConfig):
     async def test_graceful_shutdown_redelivers_interrupted_message(
         self,
         queue: str,
+        event: asyncio.Event,
+        event2: asyncio.Event,
+        mock: MagicMock,
     ) -> None:
         group_id = f"{queue}-group"
         payload = f"{queue}-payload"
-        started = asyncio.Event()
-        redelivered = asyncio.Event()
+        started, redelivered = event, event2
 
         broker = self.get_broker(graceful_timeout=0.3)
 
@@ -39,7 +42,6 @@ class TestKafkaCancellation(KafkaTestcaseConfig):
             await br.start()
             await br.publish(payload, queue)
             await asyncio.wait_for(started.wait(), timeout=self.timeout)
-            await br.stop()
 
         restart_broker = self.get_broker()
 
@@ -50,9 +52,11 @@ class TestKafkaCancellation(KafkaTestcaseConfig):
             auto_offset_reset="earliest",
         )
         async def handle_retry(msg: str) -> None:
-            assert msg == payload
+            mock(msg)
             redelivered.set()
 
         async with self.patch_broker(restart_broker) as br:
             await br.start()
             await asyncio.wait_for(redelivered.wait(), timeout=self.timeout)
+
+        mock.assert_called_once_with(payload)

--- a/tests/brokers/mqtt/basic.py
+++ b/tests/brokers/mqtt/basic.py
@@ -11,6 +11,7 @@ from tests.brokers.base.basic import BaseTestcaseConfig
 
 
 class MQTTTestcaseConfig(BaseTestcaseConfig[MQTTBroker]):
+    supports_cancel_ack_skip: bool = False
     version: Literal["5.0", "3.1.1"] = "3.1.1"
 
     @pytest.fixture(autouse=True)

--- a/tests/brokers/nats/basic.py
+++ b/tests/brokers/nats/basic.py
@@ -8,6 +8,8 @@ from tests.brokers.base.basic import BaseTestcaseConfig
 
 
 class NatsTestcaseConfig(BaseTestcaseConfig[NatsBroker]):
+    supports_cancel_ack_skip: bool = False
+
     def get_broker(
         self,
         apply_types: bool = False,

--- a/tests/brokers/redis/basic.py
+++ b/tests/brokers/redis/basic.py
@@ -13,6 +13,8 @@ from tests.brokers.base.basic import BaseTestcaseConfig
 
 
 class RedisTestcaseConfig(BaseTestcaseConfig[RedisBroker]):
+    supports_cancel_ack_skip: bool = False
+
     def get_broker(
         self,
         apply_types: bool = False,
@@ -54,6 +56,8 @@ class RedisClusterTestcaseConfig(BaseTestcaseConfig[RedisClusterBroker]):
     Connects to a real Redis Cluster.
     A single startup node is enough — the cluster auto-discovers the rest.
     """
+
+    supports_cancel_ack_skip: bool = False
 
     def get_broker(
         self,


### PR DESCRIPTION
# Description

When a handler is cancelled (for example after `graceful_timeout`), acknowledgement middleware skips `ack` / `nack` / `reject` so the message stays unacknowledged and can be redelivered. Covered by shared consume tests and an aiokafka restart check.

Fixes #3000 

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
