### PR TITLE
Add Redis StreamSub declare option

### DIFF
--- a/faststream/redis/schemas/stream_sub.py
+++ b/faststream/redis/schemas/stream_sub.py
@@ -19,6 +19,9 @@ class StreamSub(NameRequired):
             https://redis.io/docs/latest/develop/tools/insight/tutorials/insight-stream-consumer/#run-the-consumer
         group:
             The name of consumer group
+        declare:
+            Whether to create the Redis Stream when setting up a consumer group.
+            When False, Redis raises an error if the stream does not already exist.
         last_id:
             An Entry ID, which uses to pick up from where it left off after it is restarted.
         maxlen:
@@ -44,6 +47,7 @@ class StreamSub(NameRequired):
     __slots__ = (
         "batch",
         "consumer",
+        "declare",
         "group",
         "last_id",
         "max_records",
@@ -60,6 +64,7 @@ class StreamSub(NameRequired):
         polling_interval: int | None = None,
         group: str | None = None,
         consumer: str | None = None,
+        declare: bool = True,
         batch: bool = False,
         no_ack: bool = False,
         last_id: str | None = None,
@@ -73,6 +78,13 @@ class StreamSub(NameRequired):
 
         if last_id is None:
             last_id = ">" if group and consumer else "$"
+
+        if not declare and not (group and consumer):
+            warnings.warn(
+                message="`declare` has no effect without consumer group",
+                category=RuntimeWarning,
+                stacklevel=1,
+            )
 
         if group and consumer:
             if last_id != ">":
@@ -101,6 +113,7 @@ class StreamSub(NameRequired):
 
         self.group = group
         self.consumer = consumer
+        self.declare = declare
         self.polling_interval = polling_interval or 100
         self.batch = batch
         self.no_ack = no_ack

--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -135,7 +135,7 @@ class _StreamHandlerMixin(LogicSubscriber):
                     name=stream.name,
                     id=group_create_id,
                     groupname=stream.group,
-                    mkstream=True,
+                    mkstream=stream.declare,
                 )
             except ResponseError as e:
                 if "already exists" not in str(e):

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from redis.asyncio import Redis
+from redis.exceptions import ResponseError
 
 from faststream import AckPolicy
 from faststream.redis import (
@@ -684,6 +685,42 @@ class TestConsumeStream(RedisTestcaseConfig):
             await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
         mock.assert_called_once_with({"data": "before-group"})
+
+    async def test_stream_group_declare_creates_missing_stream(
+        self,
+        queue: str,
+    ) -> None:
+        consume_broker = self.get_broker()
+
+        @consume_broker.subscriber(
+            stream=StreamSub(queue, group="group", consumer=queue),
+        )
+        async def handler(msg: Any) -> None: ...
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+            client = br._connection
+            assert client is not None
+            assert await client.exists(queue) == 1
+
+    async def test_stream_group_declare_false_requires_existing_stream(
+        self,
+        queue: str,
+    ) -> None:
+        consume_broker = self.get_broker()
+
+        @consume_broker.subscriber(
+            stream=StreamSub(queue, group="group", consumer=queue, declare=False),
+        )
+        async def handler(msg: Any) -> None: ...
+
+        async with self.patch_broker(consume_broker) as br:
+            with pytest.raises(ResponseError, match="key to exist"):
+                await br.start()
+
+            client = br._connection
+            assert client is not None
+            assert await client.exists(queue) == 0
 
     async def test_consume_existing_group_from_last_id(
         self,

--- a/tests/brokers/redis/test_schemas.py
+++ b/tests/brokers/redis/test_schemas.py
@@ -12,3 +12,9 @@ def test_stream_group() -> None:
         StreamSub("test", consumer="consumer")
 
     StreamSub("test", group="group", consumer="consumer")
+
+
+@pytest.mark.redis()
+def test_stream_declare_has_no_effect_without_group() -> None:
+    with pytest.warns(RuntimeWarning, match="`declare` has no effect"):
+        StreamSub("test", declare=False)


### PR DESCRIPTION
## Summary
- add `declare: bool = True` to `StreamSub` for Redis consumer groups
- pass `declare` through to Redis `XGROUP CREATE` via `mkstream`, preserving the existing default creation behavior
- warn when `declare=False` is used without a consumer group because the option has no effect on the `XREAD` path

## Tests
- `uv run --group testing --extra redis pytest tests/brokers/redis/test_schemas.py tests/brokers/redis/test_consume.py::TestConsumeStream::test_stream_group_declare_creates_missing_stream tests/brokers/redis/test_consume.py::TestConsumeStream::test_stream_group_declare_false_requires_existing_stream -q`
- `uv run --group testing --extra redis pytest tests/brokers/redis/test_consume.py::TestConsumeStream tests/brokers/redis/test_schemas.py -q`
- `uv run ruff check faststream/redis/schemas/stream_sub.py faststream/redis/subscriber/usecases/stream_subscriber.py tests/brokers/redis/test_schemas.py tests/brokers/redis/test_consume.py`
- `uv run ruff format --check faststream/redis/schemas/stream_sub.py faststream/redis/subscriber/usecases/stream_subscriber.py tests/brokers/redis/test_schemas.py tests/brokers/redis/test_consume.py`
- `uv run --group lint --extra redis mypy faststream/redis/schemas/stream_sub.py faststream/redis/subscriber/usecases/stream_subscriber.py`

Closes #3013
