### PR TITLE
feat(redis): add StreamSub declare option

### DIFF
--- a/faststream/redis/schemas/stream_sub.py
+++ b/faststream/redis/schemas/stream_sub.py
@@ -39,11 +39,14 @@ class StreamSub(NameRequired):
             reclaimed by this consumer. Only applicable when using consumer groups.
 
             https://redis.io/docs/latest/commands/xautoclaim/
+        declare:
+            Whether to create the stream when creating a consumer group.
     """
 
     __slots__ = (
         "batch",
         "consumer",
+        "declare",
         "group",
         "last_id",
         "max_records",
@@ -66,10 +69,18 @@ class StreamSub(NameRequired):
         maxlen: int | None = None,
         max_records: int | None = None,
         min_idle_time: int | None = None,
+        declare: bool = True,
     ) -> None:
         if (group and not consumer) or (not group and consumer):
             msg = "You should specify `group` and `consumer` both"
             raise SetupError(msg)
+
+        if not declare and not group:
+            warnings.warn(
+                message="`declare` has no effect without consumer group",
+                category=RuntimeWarning,
+                stacklevel=1,
+            )
 
         if last_id is None:
             last_id = ">" if group and consumer else "$"
@@ -101,6 +112,7 @@ class StreamSub(NameRequired):
 
         self.group = group
         self.consumer = consumer
+        self.declare = declare
         self.polling_interval = polling_interval or 100
         self.batch = batch
         self.no_ack = no_ack

--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -135,7 +135,7 @@ class _StreamHandlerMixin(LogicSubscriber):
                     name=stream.name,
                     id=group_create_id,
                     groupname=stream.group,
-                    mkstream=True,
+                    mkstream=stream.declare,
                 )
             except ResponseError as e:
                 if "already exists" not in str(e):

--- a/tests/brokers/redis/test_config.py
+++ b/tests/brokers/redis/test_config.py
@@ -82,6 +82,15 @@ def test_stream_with_group_and_min_idle_time() -> None:
 
 
 @pytest.mark.redis()
+def test_stream_declare_without_group_warning() -> None:
+    with pytest.warns(
+        RuntimeWarning,
+        match="`declare` has no effect without consumer group",
+    ):
+        StreamSub("test_stream", declare=False)
+
+
+@pytest.mark.redis()
 def test_broker_ack_policy() -> None:
     broker = RedisBroker(ack_policy=AckPolicy.ACK)
     sub = broker.subscriber(

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from redis.asyncio import Redis
+from redis.exceptions import ResponseError
 
 from faststream import AckPolicy
 from faststream.redis import (
@@ -438,6 +439,38 @@ class TestConsumeList(RedisTestcaseConfig):
 @pytest.mark.redis()
 @pytest.mark.asyncio()
 class TestConsumeStream(RedisTestcaseConfig):
+    async def test_consume_group_creates_stream_by_default(self, queue: str) -> None:
+        consume_broker = self.get_broker()
+
+        @consume_broker.subscriber(
+            stream=StreamSub(queue, group="group", consumer=queue),
+        )
+        async def handler(msg: RedisMessage) -> None: ...
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+            assert await br._connection.exists(queue)
+
+    async def test_consume_group_without_declare_requires_stream(
+        self, queue: str
+    ) -> None:
+        consume_broker = self.get_broker()
+
+        @consume_broker.subscriber(
+            stream=StreamSub(
+                queue,
+                group="group",
+                consumer=queue,
+                declare=False,
+            ),
+        )
+        async def handler(msg: RedisMessage) -> None: ...
+
+        async with self.patch_broker(consume_broker) as br:
+            with pytest.raises(ResponseError, match="key to exist"):
+                await br.start()
+            assert not await br._connection.exists(queue)
+
     @pytest.mark.slow()
     async def test_consume_stream(
         self, mock: MagicMock, queue: str, event: asyncio.Event


### PR DESCRIPTION
## What this changes

- adds `StreamSub(declare: bool = True)` without changing existing positional arguments
- passes the option to Redis `XGROUP CREATE` as `mkstream`
- warns when `declare=False` is used without a consumer group, where it has no effect
- tests the compatible default and the fail-fast `declare=False` behavior against Redis

## Behavior

The default remains unchanged: FastStream creates a missing stream while creating its consumer group. With `declare=False`, Redis receives `mkstream=False`, so a missing externally managed stream raises `ResponseError` and is not created.

## Validation

- Ruff lint and format checks on all changed files
- Python bytecode compilation of all changed files
- isolated schema checks for the default, explicit `False`, and no-group warning
- `git diff --check`

The connected Redis tests are included for CI. They were not executed locally because the intentionally minimal checkout does not include the project's full test environment (`typer` is missing during root conftest loading).

Closes #3013
