### PR TITLE
fix(asyncapi): upgrade react-component version to 3.1.5

### DIFF
--- a/faststream/specification/asyncapi/site.py
+++ b/faststream/specification/asyncapi/site.py
@@ -10,11 +10,11 @@ if TYPE_CHECKING:
     from faststream.specification import Specification
 
 ASYNCAPI_JS_DEFAULT_URL = (
-    "https://unpkg.com/@asyncapi/react-component@3.0.2/browser/standalone/index.js"
+    "https://unpkg.com/@asyncapi/react-component@3.1.5/browser/standalone/index.js"
 )
 
 ASYNCAPI_CSS_DEFAULT_URL = (
-    "https://unpkg.com/@asyncapi/react-component@3.0.2/styles/default.min.css"
+    "https://unpkg.com/@asyncapi/react-component@3.1.5/styles/default.min.css"
 )
 
 


### PR DESCRIPTION
# Description

A subscriber declared with a `filter` produces channel keys like
`test-queue:_:[Handle,DefaultHandler]`, so its `$ref`s carry `[`, `]`, `,`.
The pinned viewer (`@asyncapi/react-component` 3.0.2, which ships
`@asyncapi/parser` 3.6.0) rejects those refs and renders
"Referencing in this place is not allowed" instead of the docs.

Fixed upstream in asyncapi/parser-js#1133, released in `@asyncapi/parser` 3.6.1
and bundled into `@asyncapi/react-component` 3.1.5. This bumps the pin.

Fixes #2772

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
