### PR TITLE
feat: add pyright over the public API surface and fix what it found

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,15 @@ repos:
         verbose: true
         pass_filenames: false
 
+    -   id: pyright
+        name: Pyright
+        entry: just pyright
+        language: python
+        types: [python]
+        require_serial: true
+        verbose: true
+        pass_filenames: false
+
     -   id: bandit
         name: bandit
         entry: just bandit

--- a/faststream/_internal/application.py
+++ b/faststream/_internal/application.py
@@ -61,7 +61,7 @@ T_HookReturn = TypeVar("T_HookReturn")
 class StartAbleApplication:
     def __init__(
         self,
-        *brokers: "BrokerUsecase[Any, Any]",
+        *brokers: "BrokerUsecase[Any, Any, Any]",
         specification: Optional["SpecificationFactory"] = None,
         config: Optional["FastDependsConfig"] = None,
     ) -> None:
@@ -77,13 +77,13 @@ class StartAbleApplication:
 
     def _init_setupable_(  # noqa: PLW3201
         self,
-        *brokers: "BrokerUsecase[Any, Any]",
+        *brokers: "BrokerUsecase[Any, Any, Any]",
         specification: Optional["SpecificationFactory"] = None,
         config: Optional["FastDependsConfig"] = None,
     ) -> None:
         self.config = config or FastDependsConfig()
         self.config.context.set_global("app", self)
-        self.brokers: list[BrokerUsecase[Any, Any]] = []
+        self.brokers: list[BrokerUsecase[Any, Any, Any]] = []
 
         self.schema: SpecificationFactory = specification or AsyncAPI()
 
@@ -96,20 +96,20 @@ class StartAbleApplication:
             await b.start()
 
     @property
-    def broker(self) -> Optional["BrokerUsecase[Any, Any]"]:
+    def broker(self) -> Optional["BrokerUsecase[Any, Any, Any]"]:
         return self.brokers[0] if self.brokers else None
 
     @deprecated(
         "This method is deprecated and will be removed in 0.8.0 Use `add_broker` instead."
     )
-    def set_broker(self, broker: "BrokerUsecase[Any, Any]") -> None:
+    def set_broker(self, broker: "BrokerUsecase[Any, Any, Any]") -> None:
         """Set already existed App object broker.
 
         Useful then you create/init broker in `on_startup` hook.
         """
         self.add_broker(broker)
 
-    def add_broker(self, broker: "BrokerUsecase[Any, Any]") -> None:
+    def add_broker(self, broker: "BrokerUsecase[Any, Any, Any]") -> None:
         if broker in self.brokers:
             msg = f"Broker {broker} is already added"
             raise SetupError(msg)
@@ -122,7 +122,7 @@ class StartAbleApplication:
 class Application(StartAbleApplication):
     def __init__(
         self,
-        *brokers: "BrokerUsecase[Any, Any]",
+        *brokers: "BrokerUsecase[Any, Any, Any]",
         config: Optional["FastDependsConfig"] = None,
         logger: Optional["LoggerProto"] = logger,
         lifespan: Optional["Lifespan"] = None,

--- a/faststream/_internal/cli/main.py
+++ b/faststream/_internal/cli/main.py
@@ -312,7 +312,7 @@ def publish(
 
 
 async def publish_message(
-    broker: "BrokerUsecase[Any, Any]",
+    broker: "BrokerUsecase[Any, Any, Any]",
     rpc: bool,
     message: str,
     extra: dict[str, Any],

--- a/faststream/_internal/endpoint/subscriber/usecase.py
+++ b/faststream/_internal/endpoint/subscriber/usecase.py
@@ -10,6 +10,7 @@ from typing import (
     NamedTuple,
     Optional,
     Union,
+    cast,
 )
 
 from typing_extensions import Self, overload, override
@@ -284,7 +285,10 @@ class SubscriberUsecase(Endpoint, Generic[MsgType]):
         ],
     ]:
         total_deps = (*self._call_options.dependencies, *dependencies)
-        async_filter: AsyncFilter[StreamMessage[MsgType]] = to_async(filter)
+        async_filter = cast(
+            "AsyncFilter[StreamMessage[MsgType]]",
+            to_async(filter),
+        )
 
         def real_wrapper(
             func: Callable[P_HandlerParams, T_HandlerReturn],
@@ -457,7 +461,11 @@ class SubscriberUsecase(Endpoint, Generic[MsgType]):
         raise NotImplementedError
 
     @abstractmethod
-    async def __aiter__(self) -> AsyncIterator["StreamMessage[MsgType]"]:
+    def __aiter__(self) -> AsyncIterator["StreamMessage[MsgType]"]:
+        # NOTE: not `async def` on purpose. Implementations are async generators,
+        # so calling `__aiter__()` returns the iterator itself, not a coroutine.
+        # Declaring it `async` here would type it as `Coroutine[..., AsyncIterator]`,
+        # which the `async for` protocol does not accept.
         raise NotImplementedError
 
     def get_log_context(

--- a/faststream/_internal/fastapi/router.py
+++ b/faststream/_internal/fastapi/router.py
@@ -88,8 +88,8 @@ class _BackgroundMiddleware(BaseMiddleware):
 class StreamRouter(APIRouter, StartAbleApplication, Generic[MsgType]):
     """A class to route streams."""
 
-    broker_class: type["BrokerUsecase[MsgType, Any]"]
-    broker: "BrokerUsecase[MsgType, Any]"
+    broker_class: type["BrokerUsecase[MsgType, Any, Any]"]
+    broker: "BrokerUsecase[MsgType, Any, Any]"
     docs_router: APIRouter | None
     _after_startup_hooks: list[Callable[[Any], Awaitable[Mapping[str, Any] | None]]]
     _on_shutdown_hooks: list[Callable[[Any], Awaitable[None]]]

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from faststream._internal.endpoint.subscriber import SubscriberUsecase
 
 
-Broker = TypeVar("Broker", bound=BrokerUsecase[Any, Any])
+Broker = TypeVar("Broker", bound=BrokerUsecase[Any, Any, Any])
 
 # ``__aenter__`` return type. Each concrete ``TestBroker`` subclass binds it to a
 # single broker or a ``tuple`` of brokers via its overloaded ``__init__``.
@@ -260,7 +260,7 @@ class TestBroker(Generic[Broker, EnterType]):
         raise NotImplementedError
 
 
-def patch_broker_calls(broker: "BrokerUsecase[Any, Any]") -> None:
+def patch_broker_calls(broker: "BrokerUsecase[Any, Any, Any]") -> None:
     """Patch broker calls."""
     for sub in broker.subscribers:
         sub._build_fastdepends_model()

--- a/faststream/app.py
+++ b/faststream/app.py
@@ -44,7 +44,7 @@ class FastStream(Application):
 
     def __init__(
         self,
-        *brokers: "BrokerUsecase[Any, Any]",
+        *brokers: "BrokerUsecase[Any, Any, Any]",
         logger: Optional["LoggerProto"] = logger,
         provider: Optional["Provider"] = None,
         serializer: Optional["SerializerProto"] = EMPTY,

--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -91,7 +91,7 @@ class AsgiFastStream(Application):
 
     def __init__(
         self,
-        *brokers: "BrokerUsecase[Any, Any]",
+        *brokers: "BrokerUsecase[Any, Any, Any]",
         asgi_routes: Sequence[tuple[str, "ASGIApp"]] = (),
         logger: Optional["LoggerProto"] = logger,
         provider: Provider | None = None,
@@ -157,7 +157,7 @@ class AsgiFastStream(Application):
 
     def _init_setupable_(  # noqa: PLW3201
         self,
-        *brokers: "BrokerUsecase[Any, Any]",
+        *brokers: "BrokerUsecase[Any, Any, Any]",
         specification: Optional["SpecificationFactory"] = None,
         config: Optional["FastDependsConfig"] = None,
     ) -> None:

--- a/faststream/asgi/factories/asyncapi/try_it_out.py
+++ b/faststream/asgi/factories/asyncapi/try_it_out.py
@@ -46,10 +46,10 @@ class TryItOutForm(TypedDict):
 class TryItOutProcessor:
     """Dispatch try-it-out requests by the exact AsyncAPI channel when possible."""
 
-    def __init__(self, *brokers: "BrokerUsecase[Any, Any]") -> None:
+    def __init__(self, *brokers: "BrokerUsecase[Any, Any, Any]") -> None:
         registry = _get_broker_registry()
         self._entries: list[
-            tuple[BrokerUsecase[Any, Any], type[TestBroker[Any, Any]]]
+            tuple[BrokerUsecase[Any, Any, Any], type[TestBroker[Any, Any]]]
         ] = []
         for broker in brokers:
             for br_cls, test_broker_cls in registry.items():
@@ -136,7 +136,7 @@ class TryItOutProcessor:
 
 
 def make_try_it_out_handler(
-    brokers: Iterable["BrokerUsecase[Any, Any]"],
+    brokers: Iterable["BrokerUsecase[Any, Any, Any]"],
     description: str | None = None,
     tags: Sequence[Union["Tag", "TagDict", dict[str, Any]]] | None = None,
     unique_id: str | None = None,
@@ -163,7 +163,7 @@ def make_try_it_out_handler(
     return try_it_out
 
 
-def _iter_broker_destinations(broker: "BrokerUsecase[Any, Any]") -> set[str]:
+def _iter_broker_destinations(broker: "BrokerUsecase[Any, Any, Any]") -> set[str]:
     """Destinations declared on the broker (``schema()`` key before ``:``)."""
     destinations: set[str] = set()
 
@@ -178,7 +178,7 @@ def _iter_broker_destinations(broker: "BrokerUsecase[Any, Any]") -> set[str]:
     return destinations
 
 
-def _iter_broker_channels(broker: "BrokerUsecase[Any, Any]") -> set[str]:
+def _iter_broker_channels(broker: "BrokerUsecase[Any, Any, Any]") -> set[str]:
     """Full AsyncAPI channel keys declared on the broker."""
     channels: set[str] = set()
 
@@ -195,10 +195,10 @@ def _iter_broker_channels(broker: "BrokerUsecase[Any, Any]") -> set[str]:
 
 @lru_cache(maxsize=1)
 def _get_broker_registry() -> dict[
-    type["BrokerUsecase[Any, Any]"],
+    type["BrokerUsecase[Any, Any, Any]"],
     type["TestBroker[Any, Any]"],
 ]:
-    registry: dict[type[BrokerUsecase[Any, Any]], type[TestBroker[Any, Any]]] = {}
+    registry: dict[type[BrokerUsecase[Any, Any, Any]], type[TestBroker[Any, Any]]] = {}
 
     with suppress(ImportError):
         from faststream.confluent import (

--- a/faststream/asgi/factories/ping.py
+++ b/faststream/asgi/factories/ping.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 def make_ping_asgi(
-    broker: "BrokerUsecase[Any, Any]",
+    broker: "BrokerUsecase[Any, Any, Any]",
     /,
     timeout: float | None = None,
     include_in_schema: bool = True,

--- a/faststream/confluent/__init__.py
+++ b/faststream/confluent/__init__.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING, TypeAlias
+
 from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-ConfluentParserType = ParserProto["Message"]  # type: ignore[name-defined]
+if TYPE_CHECKING:
+    from confluent_kafka import Message
+
+ConfluentParserType: TypeAlias = ParserProto["Message"]
 
 try:
     from .annotations import KafkaMessage

--- a/faststream/confluent/broker/broker.py
+++ b/faststream/confluent/broker/broker.py
@@ -66,6 +66,7 @@ class KafkaBroker(
     BrokerUsecase[
         Message | tuple[Message, ...],
         Callable[..., AsyncConfluentConsumer],
+        KafkaBrokerConfig,
     ],
 ):
     url: list[str]

--- a/faststream/confluent/broker/router.py
+++ b/faststream/confluent/broker/router.py
@@ -302,7 +302,8 @@ class KafkaRouter(
         Union[
             "Message",
             tuple["Message", ...],
-        ]
+        ],
+        KafkaBrokerConfig,
     ],
 ):
     """Includable to KafkaBroker router."""

--- a/faststream/confluent/subscriber/usecase.py
+++ b/faststream/confluent/subscriber/usecase.py
@@ -125,7 +125,7 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
         )
 
     @override
-    async def __aiter__(self) -> AsyncIterator["KafkaMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["KafkaMessage"]:
         assert self.consumer, "You should start subscriber at first."
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."

--- a/faststream/kafka/__init__.py
+++ b/faststream/kafka/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
@@ -6,7 +6,7 @@ from faststream._internal.testing.app import TestApp
 if TYPE_CHECKING:
     from aiokafka import ConsumerRecord
 
-KafkaParserType: TypeAlias = ParserProto["ConsumerRecord"]
+KafkaParserType: TypeAlias = ParserProto["ConsumerRecord[Any, Any]"]
 
 try:
     from aiokafka import ConsumerRecord, TopicPartition

--- a/faststream/kafka/__init__.py
+++ b/faststream/kafka/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
@@ -6,7 +6,7 @@ from faststream._internal.testing.app import TestApp
 if TYPE_CHECKING:
     from aiokafka import ConsumerRecord
 
-KafkaParserType = ParserProto["ConsumerRecord"]
+KafkaParserType: TypeAlias = ParserProto["ConsumerRecord"]
 
 try:
     from aiokafka import ConsumerRecord, TopicPartition

--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -174,8 +174,8 @@ if TYPE_CHECKING:
         compression_type: Literal["gzip", "snappy", "lz4", "zstd"] | None
         max_batch_size: int
         partitioner: Callable[
-            [bytes, list[Partition], list[Partition]],
-            Partition,
+            [bytes, list[Any], list[Any]],
+            Any,
         ]
         max_request_size: int
         linger_ms: int
@@ -189,6 +189,7 @@ class KafkaBroker(
     BrokerUsecase[
         aiokafka.ConsumerRecord | tuple[aiokafka.ConsumerRecord, ...],
         Callable[..., aiokafka.AIOKafkaConsumer],
+        KafkaBrokerConfig,
     ],
 ):
     url: list[str]

--- a/faststream/kafka/broker/broker.py
+++ b/faststream/kafka/broker/broker.py
@@ -187,7 +187,7 @@ if TYPE_CHECKING:
 class KafkaBroker(
     KafkaRegistrator,
     BrokerUsecase[
-        aiokafka.ConsumerRecord | tuple[aiokafka.ConsumerRecord, ...],
+        aiokafka.ConsumerRecord[Any, Any] | tuple[aiokafka.ConsumerRecord[Any, Any], ...],
         Callable[..., aiokafka.AIOKafkaConsumer],
         KafkaBrokerConfig,
     ],

--- a/faststream/kafka/broker/registrator.py
+++ b/faststream/kafka/broker/registrator.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 class KafkaRegistrator(
     Registrator[
-        ConsumerRecord | tuple[ConsumerRecord, ...],
+        ConsumerRecord[Any, Any] | tuple[ConsumerRecord[Any, Any], ...],
         KafkaBrokerConfig,
     ],
 ):

--- a/faststream/kafka/broker/router.py
+++ b/faststream/kafka/broker/router.py
@@ -391,7 +391,8 @@ class KafkaRouter(
         Union[
             "ConsumerRecord",
             tuple["ConsumerRecord", ...],
-        ]
+        ],
+        KafkaBrokerConfig,
     ],
 ):
     """Includable to KafkaBroker router."""

--- a/faststream/kafka/broker/router.py
+++ b/faststream/kafka/broker/router.py
@@ -389,8 +389,8 @@ class KafkaRouter(
     KafkaRegistrator,
     BrokerRouter[
         Union[
-            "ConsumerRecord",
-            tuple["ConsumerRecord", ...],
+            "ConsumerRecord[Any, Any]",
+            tuple["ConsumerRecord[Any, Any]", ...],
         ],
         KafkaBrokerConfig,
     ],

--- a/faststream/kafka/fastapi/fastapi.py
+++ b/faststream/kafka/fastapi/fastapi.py
@@ -64,7 +64,9 @@ if TYPE_CHECKING:
 Partition = TypeVar("Partition")
 
 
-class KafkaRouter(StreamRouter[ConsumerRecord | tuple[ConsumerRecord, ...]]):
+class KafkaRouter(
+    StreamRouter[ConsumerRecord[Any, Any] | tuple[ConsumerRecord[Any, Any], ...]]
+):
     """A class to represent a Kafka router."""
 
     broker_class = KB

--- a/faststream/kafka/message.py
+++ b/faststream/kafka/message.py
@@ -39,15 +39,15 @@ class FakeConsumer:
 FAKE_CONSUMER = FakeConsumer()
 
 
-class KafkaRawMessage(ConsumerRecord):  # type: ignore[misc]
+class KafkaRawMessage(ConsumerRecord[Any, Any]):  # type: ignore[misc]
     consumer: AIOKafkaConsumer
 
 
 class KafkaMessage(
     StreamMessage[
         Union[
-            "ConsumerRecord",
-            tuple["ConsumerRecord", ...],
+            "ConsumerRecord[Any, Any]",
+            tuple["ConsumerRecord[Any, Any]", ...],
         ]
     ],
 ):

--- a/faststream/kafka/schemas/params.py
+++ b/faststream/kafka/schemas/params.py
@@ -17,7 +17,6 @@ class AdminClientConnectionParams(TypedDict, total=False):
         retry_backoff_ms : The backoff time in milliseconds for retrying failed requests.
         metadata_max_age_ms : The maximum age of metadata in milliseconds.
         security_protocol : The security protocol to use for the connection. Must be one of "SSL" or "PLAINTEXT".
-        api_version : The API version to use for the connection.
         connections_max_idle_ms : The maximum idle time in milliseconds before closing a connection.
         ssl_context : Pre-configured SSLContext for wrapping socket connections.
         sasl_mechanism : The SASL mechanism to use for authentication. Must be one of "PLAIN", "GSSAPI", "SCRAM-SHA-256", "SCRAM-SHA-512", or "OAUTHBEARER".
@@ -38,7 +37,6 @@ class AdminClientConnectionParams(TypedDict, total=False):
         "SSL",
         "PLAINTEXT",
     ]
-    api_version: str
     connections_max_idle_ms: int
     sasl_mechanism: Literal[
         "PLAIN",

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -165,7 +165,7 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
         return msg
 
     @override
-    async def __aiter__(self) -> AsyncIterator["KafkaMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["KafkaMessage"]:
         assert self.consumer, "You should start subscriber at first."
         assert not self.calls, (
             "You can't use `get_one` method if subscriber has registered handlers."

--- a/faststream/mqtt/broker/broker.py
+++ b/faststream/mqtt/broker/broker.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
 class MQTTBroker(
     MQTTRegistrator,
-    BrokerUsecase[zmqtt.Message, zmqtt.MQTTClient],
+    BrokerUsecase[zmqtt.Message, zmqtt.MQTTClient, MQTTBrokerConfig],
 ):
     """MQTT broker for FastStream using the zmqtt client library."""
 

--- a/faststream/mqtt/broker/router.py
+++ b/faststream/mqtt/broker/router.py
@@ -1,7 +1,7 @@
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
-from zmqtt import QoS
+from zmqtt import Message, QoS
 
 from faststream._internal.broker.router import (
     ArgsContainer,
@@ -100,7 +100,7 @@ class MQTTRoute(SubscriberRoute):
 
 class MQTTRouter(
     MQTTRegistrator,
-    BrokerRouter["Any"],
+    BrokerRouter[Message, MQTTBrokerConfig],
 ):
     """Includable to MQTTBroker router."""
 

--- a/faststream/mqtt/subscriber/usecase.py
+++ b/faststream/mqtt/subscriber/usecase.py
@@ -165,7 +165,7 @@ class MQTTBaseSubscriber(TasksMixin, SubscriberUsecase[zmqtt.Message]):
         )
 
     @override
-    async def __aiter__(self) -> AsyncIterator["StreamMessage[zmqtt.Message]"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["StreamMessage[zmqtt.Message]"]:
         if self._subscription is None:
             await self._create_subscription()
 

--- a/faststream/nats/__init__.py
+++ b/faststream/nats/__init__.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING, TypeAlias
+
 from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-NatsParserType = ParserProto["Msg"]  # type: ignore[name-defined]
+if TYPE_CHECKING:
+    from nats.aio.msg import Msg
+
+NatsParserType: TypeAlias = ParserProto["Msg"]
 
 try:
     from nats.js.api import (

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -196,7 +196,7 @@ UNRECOVERABLE_CONNECT_ERRORS = (
 
 class NatsBroker(
     NatsRegistrator,
-    BrokerUsecase[Msg, Client],
+    BrokerUsecase[Msg, Client, NatsBrokerConfig],
 ):
     """A class to represent a NATS broker."""
 

--- a/faststream/nats/broker/router.py
+++ b/faststream/nats/broker/router.py
@@ -216,7 +216,7 @@ class NatsRoute(SubscriberRoute):
         )
 
 
-class NatsRouter(NatsRegistrator, BrokerRouter[Msg]):
+class NatsRouter(NatsRegistrator, BrokerRouter[Msg, NatsBrokerConfig]):
     """Includable to NatsBroker router."""
 
     def __init__(

--- a/faststream/nats/subscriber/usecases/core_subscriber.py
+++ b/faststream/nats/subscriber/usecases/core_subscriber.py
@@ -82,7 +82,7 @@ class CoreSubscriber(DefaultSubscriber["Msg"]):
         return msg
 
     @override
-    async def __aiter__(self) -> AsyncIterator["NatsMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["NatsMessage"]:
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."
         )

--- a/faststream/nats/subscriber/usecases/key_value_subscriber.py
+++ b/faststream/nats/subscriber/usecases/key_value_subscriber.py
@@ -97,7 +97,7 @@ class KeyValueWatchSubscriber(
         )
 
     @override
-    async def __aiter__(self) -> AsyncIterator["NatsKvMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["NatsKvMessage"]:
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."
         )

--- a/faststream/nats/subscriber/usecases/object_storage_subscriber.py
+++ b/faststream/nats/subscriber/usecases/object_storage_subscriber.py
@@ -101,7 +101,7 @@ class ObjStoreWatchSubscriber(
         )
 
     @override
-    async def __aiter__(self) -> AsyncIterator["NatsObjMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["NatsObjMessage"]:
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."
         )

--- a/faststream/nats/subscriber/usecases/stream_basic.py
+++ b/faststream/nats/subscriber/usecases/stream_basic.py
@@ -103,7 +103,7 @@ class StreamSubscriber(DefaultSubscriber["Msg"]):
         return msg
 
     @override
-    async def __aiter__(self) -> AsyncIterator["NatsMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["NatsMessage"]:
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."
         )

--- a/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
+++ b/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
@@ -175,7 +175,7 @@ class BatchPullStreamSubscriber(
         )
 
     @override
-    async def __aiter__(self) -> AsyncIterator["NatsMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["NatsMessage"]:
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."
         )

--- a/faststream/rabbit/__init__.py
+++ b/faststream/rabbit/__init__.py
@@ -1,7 +1,12 @@
+from typing import TYPE_CHECKING, TypeAlias
+
 from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-RabbitParserType = ParserProto["IncomingMessage"]  # type: ignore[name-defined]
+if TYPE_CHECKING:
+    from aio_pika import IncomingMessage
+
+RabbitParserType: TypeAlias = ParserProto["IncomingMessage"]
 
 try:
     from .annotations import RabbitMessage

--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
 
 class RabbitBroker(
     RabbitRegistrator,
-    BrokerUsecase[IncomingMessage, RobustConnection],
+    BrokerUsecase[IncomingMessage, RobustConnection, RabbitBrokerConfig],
 ):
     """A class to represent a RabbitMQ broker."""
 

--- a/faststream/rabbit/broker/router.py
+++ b/faststream/rabbit/broker/router.py
@@ -210,7 +210,7 @@ class RabbitRoute(SubscriberRoute):
         )
 
 
-class RabbitRouter(RabbitRegistrator, BrokerRouter[IncomingMessage]):
+class RabbitRouter(RabbitRegistrator, BrokerRouter[IncomingMessage, RabbitBrokerConfig]):
     """Includable to RabbitBroker router."""
 
     def __init__(

--- a/faststream/rabbit/subscriber/usecase.py
+++ b/faststream/rabbit/subscriber/usecase.py
@@ -162,7 +162,7 @@ class RabbitSubscriber(SubscriberUsecase["IncomingMessage"]):
         return msg
 
     @override
-    async def __aiter__(self) -> AsyncIterator["RabbitMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["RabbitMessage"]:
         assert self._queue_obj, "You should start subscriber at first."
         assert not self.calls, (
             "You can't use iterator method if subscriber has registered handlers."

--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -1,7 +1,13 @@
+from typing import TYPE_CHECKING, TypeAlias
+
 from faststream._internal.parser import ParserProto
 from faststream._internal.testing.app import TestApp
 
-RedisParserType = ParserProto["Mapping[str, Any]"]  # type: ignore[name-defined]
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+RedisParserType: TypeAlias = ParserProto["Mapping[str, Any]"]
 
 try:
     from .annotations import (

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 
 class RedisBroker(
     RedisRegistrator,
-    BrokerUsecase[UnifyRedisDict, "Redis[bytes]"],
+    BrokerUsecase[UnifyRedisDict, "Redis[bytes]", RedisBrokerConfig],
 ):
     """Redis broker."""
 

--- a/faststream/redis/broker/router.py
+++ b/faststream/redis/broker/router.py
@@ -9,7 +9,7 @@ from faststream._internal.broker.router import (
 from faststream._internal.constants import EMPTY
 from faststream.middlewares import AckPolicy
 from faststream.redis.configs.broker import RedisRouterConfig
-from faststream.redis.message import BaseMessage
+from faststream.redis.message import UnifyRedisDict
 
 from .registrator import RedisRegistrator
 
@@ -153,7 +153,7 @@ class RedisRoute(SubscriberRoute):
 
 class RedisRouter(
     RedisRegistrator,
-    BrokerRouter[BaseMessage],
+    BrokerRouter[UnifyRedisDict, RedisRouterConfig],
 ):
     """Includable to RedisBroker router."""
 

--- a/faststream/redis/publisher/usecase.py
+++ b/faststream/redis/publisher/usecase.py
@@ -260,10 +260,10 @@ class ListPublisher(LogicPublisher):
 
 class ListBatchPublisher(ListPublisher):
     @override
-    async def publish(  # type: ignore[override]
+    async def publish(
         self,
         *messages: "SendableMessage",
-        list: str,
+        list: str | None = None,
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,

--- a/faststream/redis/subscriber/usecases/channel_subscriber.py
+++ b/faststream/redis/subscriber/usecases/channel_subscriber.py
@@ -117,7 +117,7 @@ class ChannelSubscriber(LogicSubscriber):
         return msg
 
     @override
-    async def __aiter__(self) -> AsyncIterator["RedisChannelMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["RedisChannelMessage"]:
         assert self.subscription, "You should start subscriber at first."
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."

--- a/faststream/redis/subscriber/usecases/list_subscriber.py
+++ b/faststream/redis/subscriber/usecases/list_subscriber.py
@@ -122,7 +122,7 @@ class _ListHandlerMixin(LogicSubscriber):
         return msg
 
     @override
-    async def __aiter__(self) -> AsyncIterator["RedisListMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["RedisListMessage"]:
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."
         )

--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -267,7 +267,7 @@ class _StreamHandlerMixin(LogicSubscriber):
         return msg
 
     @override
-    async def __aiter__(self) -> AsyncIterator["RedisStreamMessage"]:  # type: ignore[override]
+    async def __aiter__(self) -> AsyncIterator["RedisStreamMessage"]:
         assert not self.calls, (
             "You can't use iterator if subscriber has registered handlers."
         )

--- a/faststream/specification/asyncapi/factory.py
+++ b/faststream/specification/asyncapi/factory.py
@@ -14,7 +14,7 @@ class AsyncAPI(SpecificationFactory):
     def __init__(
         self,
         /,
-        *brokers: "BrokerUsecase[Any, Any]",
+        *brokers: "BrokerUsecase[Any, Any, Any]",
         title: str = "FastStream",
         version: str = "0.1.0",
         description: str | None = None,
@@ -37,7 +37,7 @@ class AsyncAPI(SpecificationFactory):
         self.identifier = identifier
         self.schema_version = schema_version
 
-        self.brokers: list[BrokerUsecase[Any, Any]] = []
+        self.brokers: list[BrokerUsecase[Any, Any, Any]] = []
         for br in brokers:
             self.add_broker(br)
 
@@ -45,7 +45,7 @@ class AsyncAPI(SpecificationFactory):
 
     def add_broker(
         self,
-        broker: "BrokerUsecase[Any, Any]",
+        broker: "BrokerUsecase[Any, Any, Any]",
         /,
     ) -> "SpecificationFactory":
         if broker not in self.brokers:

--- a/faststream/specification/asyncapi/v2_6_0/generate.py
+++ b/faststream/specification/asyncapi/v2_6_0/generate.py
@@ -60,7 +60,7 @@ def convert_list_of_dict_to_dict(
 
 
 def get_app_schema(
-    *brokers: "BrokerUsecase[Any, Any]",
+    *brokers: "BrokerUsecase[Any, Any, Any]",
     title: str,
     app_version: str,
     schema_version: str,
@@ -153,14 +153,14 @@ def resolve_channel_messages(
 
 
 def get_broker_server(
-    *brokers: "BrokerUsecase[Any, Any]",
+    *brokers: "BrokerUsecase[Any, Any, Any]",
 ) -> tuple[
     dict[str, Server],
-    dict["BrokerUsecase[Any, Any]", list[str]],
+    dict["BrokerUsecase[Any, Any, Any]", list[str]],
 ]:
     """Get the broker server for an application."""
     servers: list[Server] = []
-    broker_servers: list[tuple[BrokerUsecase[Any, Any], Server]] = []
+    broker_servers: list[tuple[BrokerUsecase[Any, Any, Any], Server]] = []
 
     for broker in brokers:
         specification = broker.specification
@@ -191,7 +191,7 @@ def get_broker_server(
         server_name = "development" if single_server else f"Server{i}"
         servers_by_names[server_name] = server
 
-    broker_server_names: dict[BrokerUsecase[Any, Any], list[str]] = {}
+    broker_server_names: dict[BrokerUsecase[Any, Any, Any], list[str]] = {}
     for name, server in servers_by_names.items():
         for broker, br_server in broker_servers:
             if server == br_server:
@@ -201,7 +201,8 @@ def get_broker_server(
 
 
 def get_broker_channels(
-    broker: "BrokerUsecase[MsgType, ConnectionType]", servers: list[str] | None = None
+    broker: "BrokerUsecase[MsgType, ConnectionType, Any]",
+    servers: list[str] | None = None,
 ) -> dict[str, Channel]:
     """Get the broker channels for an application."""
     channels = {}
@@ -241,7 +242,7 @@ def get_asgi_routes(
             channel = Channel(
                 description=asgi_app.description,
                 subscribe=Operation(
-                    tags=asgi_app.tags,
+                    tags=[Tag.from_spec(tag) for tag in asgi_app.tags or ()] or None,
                     operationId=asgi_app.unique_id,
                     bindings=OperationBinding(
                         http=http_bindings.OperationBinding(

--- a/faststream/specification/asyncapi/v2_6_0/schema/tag.py
+++ b/faststream/specification/asyncapi/v2_6_0/schema/tag.py
@@ -64,5 +64,5 @@ class Tag(BaseModel):
         return cls(
             name=tag_data.get("name"),
             description=tag_data.get("description"),
-            externalDocs=tag_data.get("external_docs"),
+            externalDocs=ExternalDocs.from_spec(tag_data.get("external_docs")),
         )

--- a/faststream/specification/asyncapi/v3_0_0/generate.py
+++ b/faststream/specification/asyncapi/v3_0_0/generate.py
@@ -63,7 +63,7 @@ def convert_list_of_dict_to_dict(
 
 
 def get_app_schema(
-    *brokers: "BrokerUsecase[Any, Any]",
+    *brokers: "BrokerUsecase[Any, Any, Any]",
     title: str,
     app_version: str,
     schema_version: str,
@@ -149,14 +149,14 @@ def get_app_schema(
 
 
 def get_broker_server(
-    *brokers: "BrokerUsecase[MsgType, ConnectionType]",
+    *brokers: "BrokerUsecase[MsgType, ConnectionType, Any]",
 ) -> tuple[
     dict[str, Server],
-    dict["BrokerUsecase[Any, Any]", list[str]],
+    dict["BrokerUsecase[Any, Any, Any]", list[str]],
 ]:
     """Get the broker server for an application."""
     servers: list[Server] = []
-    broker_servers: list[tuple[BrokerUsecase[Any, Any], Server]] = []
+    broker_servers: list[tuple[BrokerUsecase[Any, Any, Any], Server]] = []
 
     for broker in brokers:
         specification = broker.specification
@@ -197,7 +197,7 @@ def get_broker_server(
         server_name = "development" if single_server else f"Server{i}"
         servers_by_names[server_name] = server
 
-    broker_server_names: dict[BrokerUsecase[Any, Any], list[str]] = {}
+    broker_server_names: dict[BrokerUsecase[Any, Any, Any], list[str]] = {}
     for name, server in servers_by_names.items():
         for broker, br_server in broker_servers:
             if server == br_server:
@@ -207,7 +207,8 @@ def get_broker_server(
 
 
 def get_broker_channels(
-    broker: "BrokerUsecase[MsgType, ConnectionType]", servers: list[str] | None = None
+    broker: "BrokerUsecase[MsgType, ConnectionType, Any]",
+    servers: list[str] | None = None,
 ) -> tuple[dict[str, Channel], dict[str, Operation]]:
     """Get the broker channels for an application."""
     channels = {}

--- a/faststream/specification/base/generator.py
+++ b/faststream/specification/base/generator.py
@@ -19,7 +19,7 @@ class SpecificationFactory(Protocol):
     @abstractmethod
     def add_broker(
         self,
-        broker: "BrokerUsecase[Any, Any]",
+        broker: "BrokerUsecase[Any, Any, Any]",
         /,
     ) -> "SpecificationFactory":
         raise NotImplementedError

--- a/justfile
+++ b/justfile
@@ -119,6 +119,11 @@ _static *params:
 mypy *params:
   just _static mypy {{params}}
 
+[doc("Pyright check")]
+[group("static analysis")]
+pyright *params:
+  just _static pyright {{params}}
+
 [doc("Bandit check")]
 [group("static analysis")]
 bandit:
@@ -136,7 +141,7 @@ zizmor:
 
 [doc("Static analysis check")]
 [group("static analysis")]
-static-analysis: mypy bandit semgrep
+static-analysis: mypy pyright bandit semgrep
 
 
 # Pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ disallow_any_unimported = false
 # the framework surfaces here — but internal annotations are not policed.
 include = ["tests/mypy"]
 pythonVersion = "3.10"
-typeCheckingMode = "basic"
+typeCheckingMode = "strict"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,8 @@ lint = [
     "codespell==2.4.1",
     "zizmor==1.22.0",
     "mypy==1.19.1",
-    # mypy extensions
+    "pyright==1.1.407",
+    # type checkers extensions
     "types-Deprecated",
     "types-PyYAML",
     "types-setuptools",
@@ -200,6 +201,14 @@ warn_unused_ignores = true
 disallow_incomplete_defs = true
 disallow_untyped_decorators = true
 disallow_any_unimported = false
+
+[tool.pyright]
+# Public API surface only: `tests/mypy` exercises the documented API the way a
+# user does. Pyright still follows imports into `faststream/`, so breakage in
+# the framework surfaces here — but internal annotations are not policed.
+include = ["tests/mypy"]
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/tests/mypy/kafka.py
+++ b/tests/mypy/kafka.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 import prometheus_client
 from typing_extensions import assert_type
@@ -58,17 +59,17 @@ KafkaBroker(decoder=async_decoder)
 KafkaBroker(decoder=custom_decoder)
 
 
-def sync_parser(msg: ConsumerRecord) -> KafkaMessage:
+def sync_parser(msg: ConsumerRecord[Any, Any]) -> KafkaMessage:
     return ""  # type: ignore[return-value]
 
 
-async def async_parser(msg: ConsumerRecord) -> KafkaMessage:
+async def async_parser(msg: ConsumerRecord[Any, Any]) -> KafkaMessage:
     return ""  # type: ignore[return-value]
 
 
 async def custom_parser(
-    msg: ConsumerRecord,
-    original: Callable[[ConsumerRecord], Awaitable[KafkaMessage]],
+    msg: ConsumerRecord[Any, Any],
+    original: Callable[[ConsumerRecord[Any, Any]], Awaitable[KafkaMessage]],
 ) -> KafkaMessage:
     return await original(msg)
 

--- a/uv.lock
+++ b/uv.lock
@@ -918,6 +918,7 @@ dev = [
     { name = "prometheus-client" },
     { name = "psutil" },
     { name = "pydantic-settings" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-codspeed" },
@@ -960,6 +961,7 @@ lint = [
     { name = "bandit" },
     { name = "codespell" },
     { name = "mypy" },
+    { name = "pyright" },
     { name = "ruff" },
     { name = "semgrep" },
     { name = "types-aiofiles" },
@@ -1060,6 +1062,7 @@ dev = [
     { name = "prometheus-client", specifier = ">=0.20.0,<0.30.0" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "pydantic-settings", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pyright", specifier = "==1.1.407" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-codspeed", specifier = ">=4.3.0" },
@@ -1102,6 +1105,7 @@ lint = [
     { name = "bandit", specifier = "==1.9.3" },
     { name = "codespell", specifier = "==2.4.1" },
     { name = "mypy", specifier = "==1.19.1" },
+    { name = "pyright", specifier = "==1.1.407" },
     { name = "ruff", specifier = "==0.14.14" },
     { name = "semgrep", specifier = "==1.150.0" },
     { name = "types-aiofiles" },
@@ -2826,6 +2830,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.407"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/1b/0aa08ee42948b61745ac5b5b5ccaec4669e8884b53d31c8ec20b2fcd6b6f/pyright-1.1.407.tar.gz", hash = "sha256:099674dba5c10489832d4a4b2d302636152a9a42d317986c38474c76fe562262", size = 4122872, upload-time = "2025-10-24T23:17:15.145Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/93/b69052907d032b00c40cb656d21438ec00b3a471733de137a3f65a49a0a0/pyright-1.1.407-py3-none-any.whl", hash = "sha256:6dd419f54fcc13f03b52285796d65e639786373f433e243f8b94cf93a7444d21", size = 5997008, upload-time = "2025-10-24T23:17:13.159Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds pyright alongside mypy, scoped to the **public API surface** rather than the whole package.

## Scope

```toml
[tool.pyright]
include = ["tests/mypy"]
pythonVersion = "3.10"
typeCheckingMode = "strict"
```

`tests/mypy` exercises the documented API the way a user does. Pyright still follows imports into `faststream/`, so a break in the framework surfaces where that API is used — but internal annotations are not policed. That keeps the signal about what users actually see, and keeps the gate from turning into a style debate about framework internals.

Wiring matches the existing checkers: a `lint`-group dependency, a `just pyright` recipe folded into `just static-analysis`, and a pre-commit hook. Worth noting for CI: mypy has no dedicated GitHub Actions job either — static analysis reaches CI through `pre-commit run --hook-stage manual --all-files` in the "Run linters" step of `pr_autoupdate.yaml`, so the hook is what makes this run there.

## What it found

**Every broker and router supplied only 2 of `Registrator`'s 3 type parameters.** `BrokerConfigType` has a default, so the omission was silent — every broker and router was typed against the base `BrokerConfig` instead of its own config. Now spelled out for kafka, confluent, nats, rabbit, redis and mqtt. Two more slipped in behind that: `RedisRouter` passed `BaseMessage` where the registrator expects `UnifyRedisDict`, and `MQTTRouter` passed the string `"Any"` as its message type.

Internal annotations that hold a broker — `app`, the ASGI factories, the AsyncAPI generators, `TestBroker`, `StreamRouter` — widen to a third `Any`. That part is not cosmetic: `BrokerUsecase` is invariant in the config parameter, so without it the concrete config types are no longer assignable and mypy fails.

**`ListBatchPublisher.publish()` required `list=`** while `ListPublisher.publish()` declares it optional. The `# type: ignore[override]` was hiding a signature users could not satisfy the documented way. Now `list: str | None = None`, and the ignore is gone.

**`SubscriberUsecase.__aiter__` was declared `async def`.** With no `yield` in its body that types as `Coroutine[..., AsyncIterator[...]]` — a shape the `async for` protocol does not accept, so the base class was by its own declaration not async-iterable. All 12 concrete implementations are async generators, and each carried a `# type: ignore[override]` to cover the mismatch. The base is a plain `def` now and all 12 ignores are gone. Since `warn_unused_ignores = true`, mypy staying green is the proof they were redundant rather than load-bearing.

**Four exported parser aliases pointed at names that do not exist.** `NatsParserType`, `ConfluentParserType`, `RabbitParserType` and `RedisParserType` are in `__all__` but were written as `ParserProto["Msg"]` and friends with no matching import, silenced by `# type: ignore[name-defined]` — so the parameter resolved to nothing for every checker and for anyone reading the annotation. Added the `TYPE_CHECKING` imports; all five aliases (Kafka included, which worked only by accident of an unrelated runtime import) are now annotated `TypeAlias`, which is also what makes ruff resolve the reference. Runtime value is unchanged — still a `ForwardRef`.

**`AdminClientConnectionParams` declared `api_version`, which `AIOKafkaAdminClient` does not accept.** This one has a runtime effect worth calling out: `filter_by_dict` selects admin kwargs from this TypedDict's annotations, so the field is precisely what forwarded `protocol_version` into a constructor that rejects it. Removing it stops the forwarding. `ConsumerConnectionParams` and `ProducerConnectionParams` are untouched — see below.

**`Tag.from_spec()` (dict branch) and the v2 ASGI route builder passed specification-level tags and external docs straight into the AsyncAPI models**, skipping the conversion the branch directly above them performs — a `ValidationError` for an `ExternalDocs` object.

Also: `KafkaInitKwargs.partitioner` was annotated with a `Partition` TypeVar that is meaningless in a TypedDict field.

**`aiokafka.ConsumerRecord` was used bare, and it is generic** (`ConsumerRecord[KT, VT]`). Under `strict` that made every derived type partially unknown — 31 errors from a single root cause. Parameterised as `ConsumerRecord[Any, Any]` rather than `[bytes, bytes]`: `KafkaBroker` exposes `key_deserializer` and `value_deserializer` typed `Callable[[bytes], Any]`, so key and value are only `bytes` when no deserializer is configured, and promising `bytes` would be wrong for everyone who sets one. Applied to the annotations that leak the parameter — the `KafkaBroker`, `KafkaRegistrator`, `KafkaRouter` and FastAPI `KafkaRouter` generic arguments, `KafkaRawMessage`, `KafkaMessage` and `KafkaParserType`.

## Left open on purpose

`ConsumerConnectionParams` and `ProducerConnectionParams` also declare `api_version`, and aiokafka 0.13's consumer and producer do not accept it either — so `KafkaBroker(protocol_version=...)` raises `TypeError` there too. Removing the field would silently drop a user's setting instead of failing, which is a different trade-off from the admin-client case, so that call is left to the maintainer.

## Verification

- `just mypy` — `Success: no issues found in 512 source files`
- `just pyright` — `0 errors, 0 warnings, 0 informations`
- `ruff check` / `ruff format --check` — clean
- full test suite against live brokers — green

One caution: `tests/prometheus/kafka/test_kafka.py::TestPrometheus::test_metrics` failed on two of four full-suite runs, with a *different* parametrisation each time, and passes in isolation. It asserts `event.is_set()` after an `asyncio.wait(timeout=...)` race with a live broker. Pre-existing load-sensitive flakiness, not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

