### PR TITLE
feat: render the Address template in the generated schema (#2357)

### DIFF
--- a/faststream/rabbit/publisher/specification.py
+++ b/faststream/rabbit/publisher/specification.py
@@ -28,7 +28,7 @@ class RabbitPublisherSpecification(
             routing: str | None = self.config.routing_key
 
         elif is_routing_exchange(self.config.exchange):
-            routing = self.config.queue.routing()
+            routing = self.config.queue.routing_template()
 
         else:
             routing = None
@@ -43,7 +43,7 @@ class RabbitPublisherSpecification(
         exchange_binding = amqp.Exchange.from_exchange(self.config.exchange)
         queue_binding = amqp.Queue.from_queue(self.config.queue)
 
-        r = self.config.routing_key or self.config.queue.routing()
+        r = self.config.routing_key or self.config.queue.routing_template()
         routing_key = f"{self._outer_config.prefix}{r}"
 
         return {

--- a/faststream/rabbit/subscriber/specification.py
+++ b/faststream/rabbit/subscriber/specification.py
@@ -45,7 +45,7 @@ class RabbitSubscriberSpecification(
                 operation=Operation(
                     bindings=OperationBinding(
                         amqp=amqp.OperationBinding(
-                            routing_key=queue.routing(),
+                            routing_key=queue.routing_template(),
                             queue=queue_binding,
                             exchange=exchange_binding,
                             ack=True,

--- a/faststream/redis/publisher/specification.py
+++ b/faststream/redis/publisher/specification.py
@@ -54,7 +54,7 @@ class ChannelPublisherSpecification(RedisPublisherSpecification):
 
     @property
     def channel_name(self) -> str:
-        return f"{self._outer_config.prefix}{self.channel.name}"
+        return f"{self._outer_config.prefix}{self.channel.address.template}"
 
     @property
     def channel_binding(self) -> redis.ChannelBinding:

--- a/faststream/redis/subscriber/specification.py
+++ b/faststream/redis/subscriber/specification.py
@@ -62,7 +62,7 @@ class ChannelSubscriberSpecification(RedisSubscriberSpecification):
 
     @property
     def channel_name(self) -> str:
-        return f"{self._outer_config.prefix}{self.channel.name}"
+        return f"{self._outer_config.prefix}{self.channel.address.template}"
 
     @property
     def channel_binding(self) -> "redis.ChannelBinding":

--- a/tests/asyncapi/base/address_template.py
+++ b/tests/asyncapi/base/address_template.py
@@ -1,0 +1,87 @@
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import unquote
+
+from faststream._internal.broker import BrokerUsecase
+
+
+def iter_strings(node: Any) -> Iterator[str]:
+    """Every string a generated schema contains, keys and values alike."""
+    if isinstance(node, str):
+        yield node
+
+    elif isinstance(node, dict):
+        for key, value in node.items():
+            yield key
+            yield from iter_strings(value)
+
+    elif isinstance(node, list):
+        for item in node:
+            yield from iter_strings(item)
+
+
+class AddressTemplateTestcase:
+    """The schema shows the Address template, never the Broker address.
+
+    `logs.{level}` is what the developer wrote and what documents the contract;
+    `logs.*` is one broker's way of asking for that family of addresses, and the
+    same declaration compiles to a different string on every broker. So no
+    generated document may contain it — not in a channel name, not in a binding.
+
+    Mix into a version factory (`AsyncAPI260Factory`, `AsyncAPI300Factory`), which
+    supplies the `get_spec` these tests call.
+
+    Confluent is absent on purpose: it has no template support, so its declared
+    address and its Broker address are always the same string and there is nothing
+    for this testcase to tell apart.
+    """
+
+    broker_class: type[BrokerUsecase[Any, Any]]
+
+    address_template = "logs.{level}"
+    """An Address template to declare an endpoint with."""
+
+    broker_address = "logs.*"
+    """The Broker address that template stands for — the string no document may
+    contain. A broker that never compiles its addresses has none of its own to
+    leak; the assertion then guards against it gaining one."""
+
+    def declare_subscriber(self, broker: Any) -> None:
+        broker.subscriber(self.address_template)
+
+    def declare_publisher(self, broker: Any) -> None:
+        broker.publisher(self.address_template)
+
+    def test_subscriber_renders_the_template(self) -> None:
+        broker = self.broker_class()
+        self.declare_subscriber(broker)
+        self.assert_renders_the_template(broker)
+
+    def test_publisher_renders_the_template(self) -> None:
+        broker = self.broker_class()
+        self.declare_publisher(broker)
+        self.assert_renders_the_template(broker)
+
+    def assert_renders_the_template(self, broker: Any) -> None:
+        schema = self.get_spec(broker).to_jsonable()
+
+        # Where an address is named: `channels` for most brokers, `operations` for
+        # RabbitMQ's routing key. Deliberately not `components` — a payload title
+        # carries the address too, and would satisfy this without a single channel
+        # or binding being right.
+        addressed = [schema["channels"], schema.get("operations", {})]
+
+        assert any(self.address_template in s for s in iter_strings(addressed)), (
+            f"{self.address_template!r} names no channel or binding in {addressed}"
+        )
+
+        # The leak, in contrast, is checked over the whole document: a wildcard has
+        # no business in a payload title either. 3.0 percent-encodes the address
+        # into its `$ref`s (`logs.%2A:Publisher`), so each string is checked decoded
+        # as well — otherwise an address surviving only in a component key passes.
+        leaked = [
+            s
+            for s in iter_strings(schema)
+            if self.broker_address in s or self.broker_address in unquote(s)
+        ]
+        assert not leaked, f"{self.broker_address!r} leaked into {leaked}"

--- a/tests/asyncapi/base/v2_6_0/address_template.py
+++ b/tests/asyncapi/base/v2_6_0/address_template.py
@@ -1,0 +1,9 @@
+from tests.asyncapi.base.address_template import (
+    AddressTemplateTestcase as BaseAddressTemplateTestcase,
+)
+
+from .basic import AsyncAPI260Factory
+
+
+class AddressTemplateTestcase(BaseAddressTemplateTestcase, AsyncAPI260Factory):
+    pass

--- a/tests/asyncapi/base/v3_0_0/address_template.py
+++ b/tests/asyncapi/base/v3_0_0/address_template.py
@@ -1,0 +1,9 @@
+from tests.asyncapi.base.address_template import (
+    AddressTemplateTestcase as BaseAddressTemplateTestcase,
+)
+
+from .basic import AsyncAPI300Factory
+
+
+class AddressTemplateTestcase(BaseAddressTemplateTestcase, AsyncAPI300Factory):
+    pass

--- a/tests/asyncapi/kafka/v2_6_0/test_address_template.py
+++ b/tests/asyncapi/kafka/v2_6_0/test_address_template.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+import pytest
+
+from faststream.kafka import KafkaBroker
+from tests.asyncapi.base.v2_6_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.kafka()
+class TestAddressTemplate(AddressTemplateTestcase):
+    """Kafka takes a template through `pattern=`, and only on a Subscriber.
+
+    A Publisher's topic is a literal Kafka never compiles, so its half of this
+    testcase pins that the topic reaches the document unmangled.
+    """
+
+    broker_class = KafkaBroker
+
+    broker_address = "logs..*"
+
+    def declare_subscriber(self, broker: Any) -> None:
+        broker.subscriber(pattern=self.address_template)

--- a/tests/asyncapi/kafka/v3_0_0/test_address_template.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_address_template.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+import pytest
+
+from faststream.kafka import KafkaBroker
+from tests.asyncapi.base.v3_0_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.kafka()
+class TestAddressTemplate(AddressTemplateTestcase):
+    """Kafka takes a template through `pattern=`, and only on a Subscriber.
+
+    A Publisher's topic is a literal Kafka never compiles, so its half of this
+    testcase pins that the topic reaches the document unmangled.
+    """
+
+    broker_class = KafkaBroker
+
+    broker_address = "logs..*"
+
+    def declare_subscriber(self, broker: Any) -> None:
+        broker.subscriber(pattern=self.address_template)

--- a/tests/asyncapi/mqtt/v2_6_0/test_address_template.py
+++ b/tests/asyncapi/mqtt/v2_6_0/test_address_template.py
@@ -1,0 +1,19 @@
+import pytest
+
+from faststream.mqtt import MQTTBroker
+from tests.asyncapi.base.v2_6_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.mqtt()
+class TestAddressTemplate(AddressTemplateTestcase):
+    """MQTT never compiles its topic, so the template is what it already renders.
+
+    Correct, but never decided — this pins it. MQTT has no Address syntax of its
+    own, so `logs/+` is what it *would* compile to and nothing can emit it today;
+    the leak assertion holds the line if MQTT ever gains one.
+    """
+
+    broker_class = MQTTBroker
+
+    address_template = "logs/{level}"
+    broker_address = "logs/+"

--- a/tests/asyncapi/mqtt/v3_0_0/test_address_template.py
+++ b/tests/asyncapi/mqtt/v3_0_0/test_address_template.py
@@ -1,0 +1,19 @@
+import pytest
+
+from faststream.mqtt import MQTTBroker
+from tests.asyncapi.base.v3_0_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.mqtt()
+class TestAddressTemplate(AddressTemplateTestcase):
+    """MQTT never compiles its topic, so the template is what it already renders.
+
+    Correct, but never decided — this pins it. MQTT has no Address syntax of its
+    own, so `logs/+` is what it *would* compile to and nothing can emit it today;
+    the leak assertion holds the line if MQTT ever gains one.
+    """
+
+    broker_class = MQTTBroker
+
+    address_template = "logs/{level}"
+    broker_address = "logs/+"

--- a/tests/asyncapi/nats/v2_6_0/test_address_template.py
+++ b/tests/asyncapi/nats/v2_6_0/test_address_template.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.nats import NatsBroker
+from tests.asyncapi.base.v2_6_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.nats()
+class TestAddressTemplate(AddressTemplateTestcase):
+    broker_class = NatsBroker

--- a/tests/asyncapi/nats/v3_0_0/test_address_template.py
+++ b/tests/asyncapi/nats/v3_0_0/test_address_template.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.nats import NatsBroker
+from tests.asyncapi.base.v3_0_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.nats()
+class TestAddressTemplate(AddressTemplateTestcase):
+    broker_class = NatsBroker

--- a/tests/asyncapi/rabbit/v2_6_0/test_address_template.py
+++ b/tests/asyncapi/rabbit/v2_6_0/test_address_template.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+import pytest
+
+from faststream.rabbit import ExchangeType, RabbitBroker, RabbitExchange, RabbitQueue
+from tests.asyncapi.base.v2_6_0.address_template import AddressTemplateTestcase
+
+EXCHANGE = RabbitExchange("logs-ex", type=ExchangeType.TOPIC)
+
+
+@pytest.mark.rabbit()
+class TestAddressTemplate(AddressTemplateTestcase):
+    broker_class = RabbitBroker
+
+    def declare_subscriber(self, broker: Any) -> None:
+        broker.subscriber(
+            RabbitQueue("logs-q", routing_key=self.address_template),
+            EXCHANGE,
+        )
+
+    def declare_publisher(self, broker: Any) -> None:
+        broker.publisher(
+            RabbitQueue("logs-q", routing_key=self.address_template),
+            EXCHANGE,
+        )

--- a/tests/asyncapi/rabbit/v3_0_0/test_address_template.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_address_template.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+import pytest
+
+from faststream.rabbit import ExchangeType, RabbitBroker, RabbitExchange, RabbitQueue
+from tests.asyncapi.base.v3_0_0.address_template import AddressTemplateTestcase
+
+EXCHANGE = RabbitExchange("logs-ex", type=ExchangeType.TOPIC)
+
+
+@pytest.mark.rabbit()
+class TestAddressTemplate(AddressTemplateTestcase):
+    broker_class = RabbitBroker
+
+    def declare_subscriber(self, broker: Any) -> None:
+        broker.subscriber(
+            RabbitQueue("logs-q", routing_key=self.address_template),
+            EXCHANGE,
+        )
+
+    def declare_publisher(self, broker: Any) -> None:
+        broker.publisher(
+            RabbitQueue("logs-q", routing_key=self.address_template),
+            EXCHANGE,
+        )

--- a/tests/asyncapi/redis/v2_6_0/test_address_template.py
+++ b/tests/asyncapi/redis/v2_6_0/test_address_template.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.redis import RedisBroker
+from tests.asyncapi.base.v2_6_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.redis()
+class TestAddressTemplate(AddressTemplateTestcase):
+    broker_class = RedisBroker

--- a/tests/asyncapi/redis/v2_6_0/test_arguments.py
+++ b/tests/asyncapi/redis/v2_6_0/test_arguments.py
@@ -37,7 +37,7 @@ class TestArguments(ArgumentsTestcase):
         assert schema["channels"][key]["bindings"] == {
             "redis": {
                 "bindingVersion": "custom",
-                "channel": "test.*",
+                "channel": "test.{path}",
                 "method": "psubscribe",
             },
         }

--- a/tests/asyncapi/redis/v3_0_0/test_address_template.py
+++ b/tests/asyncapi/redis/v3_0_0/test_address_template.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.redis import RedisBroker
+from tests.asyncapi.base.v3_0_0.address_template import AddressTemplateTestcase
+
+
+@pytest.mark.redis()
+class TestAddressTemplate(AddressTemplateTestcase):
+    broker_class = RedisBroker

--- a/tests/asyncapi/redis/v3_0_0/test_arguments.py
+++ b/tests/asyncapi/redis/v3_0_0/test_arguments.py
@@ -37,7 +37,7 @@ class TestArguments(ArgumentsTestcase):
         assert schema["channels"][key]["bindings"] == {
             "redis": {
                 "bindingVersion": "custom",
-                "channel": "test.*",
+                "channel": "test.{path}",
                 "method": "psubscribe",
             },
         }


### PR DESCRIPTION
Closes #2357

## The problem

Redis and RabbitMQ handed the AsyncAPI generator their Broker address, so a subscriber declared `logs.{level}` documented itself as `logs.*` — while NATS and Kafka documented the template. The same contract looked different depending on which broker carried it, and the `*` a reader saw was a dialect detail rather than anything the developer wrote.

| Broker | before | after |
|---|---|---|
| NATS | `logs.{level}` | unchanged |
| Kafka (`pattern=`) | `logs.{level}` | unchanged |
| MQTT | `logs/{level}` | unchanged |
| Redis | `logs.*` | `logs.{level}` |
| RabbitMQ | `logs.*` | `logs.{level}` |

Unblocked by #3032, which gave the Address template and the Broker address separate names. Before it, "which of the two does the schema show" was not a question anyone could answer — there was one field.

## What changed

Redis and RabbitMQ read the Address template at every specification site:

- `ChannelSubscriberSpecification.channel_name` and `ChannelPublisherSpecification.channel_name` read `channel.address.template`
- the `amqp.OperationBinding` routing key, and the publisher's fallback, read `queue.routing_template()`

One site past those four: `RabbitPublisherSpecification.name` also read `routing()`. Left alone it would have keyed a channel `logs.*:ex:Publisher` while that same channel's `routingKey` said `logs.{level}` — one document disagreeing with itself.

## Tests

A shared testcase asserts the template names a channel or a binding, and that the Broker address appears nowhere in the document — decoded as well as raw, since 3.0 percent-encodes addresses into its `$ref`s (`logs.%2A:Publisher`). It is mixed into Redis, RabbitMQ, NATS, Kafka and MQTT across both spec versions.

NATS, Kafka and MQTT were already correct; they are now pinned rather than accidental, which is what MQTT in particular needed — it renders the template only because its topic is never compiled. Confluent is absent on purpose, having no template support to tell apart.

Two existing Redis snapshots pinned the old `test.*` rendering and were updated.

## Breaking change to generated documents

Channel keys change where the address composes them: a Redis subscriber on `logs.{level}` was keyed `logs.*:Handle` and is now `logs.{level}:Handle`. Anything pinning a generated document will see the diff.

This does not touch what a broker reports at runtime. `TestRedisBroker` still hands a message the pattern it was subscribed with, because that has to match what real Redis reports.

## Out of scope

- 3.0's `address` field still carries the channel name (`logs.{level}:Handle`) — #2357 follow-up, tracked separately
- `parameters` is still never emitted — #3036, and it depends on the `address` fix landing first

## Verification

`6116 passed, 89 skipped, 7 xfailed` · mypy clean on 512 files · ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)