### PR TITLE
feat: the 3.0 `address` field carries the address (#2357)

### DIFF
--- a/faststream/confluent/publisher/specification.py
+++ b/faststream/confluent/publisher/specification.py
@@ -26,6 +26,7 @@ class KafkaPublisherSpecification(
 
         return {
             self.name: PublisherSpec(
+                address=self.topic,
                 description=self.config.description_,
                 operation=Operation(
                     message=Message(

--- a/faststream/confluent/subscriber/specification.py
+++ b/faststream/confluent/subscriber/specification.py
@@ -37,6 +37,7 @@ class KafkaSubscriberSpecification(
             handler_name = self.config.title_ or f"{t}:{self.call_name}"
 
             channels[handler_name] = SubscriberSpec(
+                address=t,
                 description=self.description,
                 operation=Operation(
                     message=Message(

--- a/faststream/kafka/publisher/specification.py
+++ b/faststream/kafka/publisher/specification.py
@@ -26,6 +26,7 @@ class KafkaPublisherSpecification(
 
         return {
             self.name: PublisherSpec(
+                address=self.topic,
                 description=self.config.description_,
                 operation=Operation(
                     message=Message(

--- a/faststream/kafka/subscriber/specification.py
+++ b/faststream/kafka/subscriber/specification.py
@@ -48,6 +48,7 @@ class KafkaSubscriberSpecification(
             handler_name = self.config.title_ or f"{t}:{self.call_name}"
 
             channels[handler_name] = SubscriberSpec(
+                address=t,
                 description=self.description,
                 operation=Operation(
                     message=Message(

--- a/faststream/mqtt/publisher/specification.py
+++ b/faststream/mqtt/publisher/specification.py
@@ -30,6 +30,7 @@ class MQTTPublisherSpecification(
 
         return {
             self.name: PublisherSpec(
+                address=self.topic,
                 description=self.config.description_,
                 operation=Operation(
                     message=Message(

--- a/faststream/mqtt/subscriber/specification.py
+++ b/faststream/mqtt/subscriber/specification.py
@@ -28,11 +28,21 @@ class MQTTSubscriberSpecification(
         super().__init__(_outer_config, specification_config, calls)
 
     @property
+    def address(self) -> str:
+        """The topic a message actually arrives on.
+
+        A shared subscription is asked for by prefixing the topic with
+        `$share/<group>/`, but no message ever carries that prefix in its topic, so
+        the address does not either. The channel name and the MQTT channel binding
+        both keep it, which is where the group stays visible.
+        """
+        return self.config.address.add_prefix(self._outer_config.prefix).template
+
+    @property
     def topic(self) -> str:
-        base = self.config.address.add_prefix(self._outer_config.prefix).template
         if self.config.shared:
-            return f"$share/{self.config.shared}/{base}"
-        return base
+            return f"$share/{self.config.shared}/{self.address}"
+        return self.address
 
     @property
     def name(self) -> str:
@@ -45,6 +55,7 @@ class MQTTSubscriberSpecification(
 
         return {
             self.name: SubscriberSpec(
+                address=self.address,
                 description=self.description,
                 operation=Operation(
                     message=Message(

--- a/faststream/nats/publisher/specification.py
+++ b/faststream/nats/publisher/specification.py
@@ -31,6 +31,7 @@ class NatsPublisherSpecification(
 
         return {
             self.name: PublisherSpec(
+                address=self.subject.template,
                 description=self.config.description_,
                 operation=Operation(
                     message=Message(

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -50,6 +50,7 @@ class NatsSubscriberSpecification(
 
         return {
             self.name: SubscriberSpec(
+                address=self.subject.template,
                 description=self.description,
                 operation=Operation(
                     message=Message(

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -39,6 +39,22 @@ class NatsSubscriberSpecification(
         return self.subject.template or ", ".join(self.filter_subjects)
 
     @property
+    def address(self) -> str | None:
+        """The subject a publisher sends to for this endpoint to receive it.
+
+        A JetStream consumer with no `subject` reaches the stream through
+        `filter_subjects`, and a single one of those is that address. Several are
+        not: no one string is the address, so the document gives none.
+        """
+        if subject := self.subject.template:
+            return subject
+
+        if len(subjects := self.filter_subjects) == 1:
+            return subjects[0]
+
+        return None
+
+    @property
     def name(self) -> str:
         if self.config.title_:
             return self.config.title_
@@ -50,7 +66,7 @@ class NatsSubscriberSpecification(
 
         return {
             self.name: SubscriberSpec(
-                address=self.subject.template,
+                address=self.address,
                 description=self.description,
                 operation=Operation(
                     message=Message(

--- a/faststream/rabbit/publisher/specification.py
+++ b/faststream/rabbit/publisher/specification.py
@@ -36,19 +36,22 @@ class RabbitPublisherSpecification(
         return None
 
     @property
-    def address(self) -> str:
+    def address(self) -> str | None:
         """The routing key a message published here travels by, prefixed.
 
         The exchange decides first, not the declaration: a fanout reaches every
         queue bound to it and ignores any routing key handed to it, so one declared
         anyway still addresses nothing. The subscriber gates on the same question,
         which is what keeps both ends of an address showing one string.
+
+        `None` rather than `""` for that case: AsyncAPI reads an absent address as
+        unknown, and an empty one as an address zero characters long.
         """
         if not is_routing_exchange(self.config.exchange):
-            return ""
+            return None
 
         routing = self.routing
-        return f"{self._outer_config.prefix}{routing}" if routing else ""
+        return f"{self._outer_config.prefix}{routing}" if routing else None
 
     @property
     def name(self) -> str:

--- a/faststream/rabbit/publisher/specification.py
+++ b/faststream/rabbit/publisher/specification.py
@@ -20,22 +20,44 @@ class RabbitPublisherSpecification(
     PublisherSpecification[RabbitBrokerConfig, RabbitPublisherSpecificationConfig],
 ):
     @property
+    def routing(self) -> str | None:
+        """The routing key this publisher was declared with, as the name reads it.
+
+        This is the channel name's question, not the address's: an explicit
+        `routing_key` names the channel whatever the exchange does with it. See
+        `address` for the string a message actually travels by.
+        """
+        if self.config.routing_address:
+            return self.config.routing_address.template
+
+        if is_routing_exchange(self.config.exchange):
+            return self.config.queue.routing_template()
+
+        return None
+
+    @property
+    def address(self) -> str:
+        """The routing key a message published here travels by, prefixed.
+
+        The exchange decides first, not the declaration: a fanout reaches every
+        queue bound to it and ignores any routing key handed to it, so one declared
+        anyway still addresses nothing. The subscriber gates on the same question,
+        which is what keeps both ends of an address showing one string.
+        """
+        if not is_routing_exchange(self.config.exchange):
+            return ""
+
+        routing = self.routing
+        return f"{self._outer_config.prefix}{routing}" if routing else ""
+
+    @property
     def name(self) -> str:
         if self.config.title_:
             return self.config.title_
 
-        if self.config.routing_address:
-            routing: str | None = self.config.routing_address.template
-
-        elif is_routing_exchange(self.config.exchange):
-            routing = self.config.queue.routing_template()
-
-        else:
-            routing = None
-
         exchange_name = getattr(self.config.exchange, "name", None)
 
-        return f"{routing or '_'}:{exchange_name or '_'}:Publisher"
+        return f"{self.routing or '_'}:{exchange_name or '_'}:Publisher"
 
     def get_schema(self) -> dict[str, "PublisherSpec"]:
         payloads = self.get_payloads()
@@ -43,11 +65,16 @@ class RabbitPublisherSpecification(
         exchange_binding = amqp.Exchange.from_exchange(self.config.exchange)
         queue_binding = amqp.Queue.from_queue(self.config.queue)
 
+        # deliberately not `self.address`: the binding hands the routing key over
+        # whatever the exchange type, and the renderer is what drops it where the
+        # exchange ignores one. `address` answers for the document instead, so it
+        # has to make that call itself.
         r = self.config.routing_address.template or self.config.queue.routing_template()
         routing_key = f"{self._outer_config.prefix}{r}"
 
         return {
             self.name: PublisherSpec(
+                address=self.address,
                 description=self.config.description_,
                 operation=Operation(
                     bindings=OperationBinding(

--- a/faststream/rabbit/subscriber/specification.py
+++ b/faststream/rabbit/subscriber/specification.py
@@ -31,15 +31,17 @@ class RabbitSubscriberSpecification(
         return f"{self._outer_config.prefix}{queue_name}:{exchange_name or '_'}:{self.call_name}"
 
     @property
-    def address(self) -> str:
+    def address(self) -> str | None:
         """The routing key the queue is bound by, prefixed.
 
-        Empty where the exchange ignores routing keys: a fanout reaches every queue
+        `None` where the exchange ignores routing keys: a fanout reaches every queue
         bound to it, so the queue this subscriber reads from names nothing a message
-        is routed by. The document drops the queue binding for the same reason.
+        is routed by. The document drops the queue binding for the same reason, and
+        drops the address rather than giving an empty one — AsyncAPI reads an absent
+        address as unknown, which `""` does not say.
         """
         if not is_routing_exchange(self.config.exchange):
-            return ""
+            return None
 
         return self.config.queue.add_prefix(
             self._outer_config.prefix,

--- a/faststream/rabbit/subscriber/specification.py
+++ b/faststream/rabbit/subscriber/specification.py
@@ -1,5 +1,6 @@
 from faststream._internal.endpoint.subscriber import SubscriberSpecification
 from faststream.rabbit.configs import RabbitBrokerConfig
+from faststream.rabbit.utils import is_routing_exchange
 from faststream.specification.asyncapi.utils import resolve_payloads
 from faststream.specification.schema import (
     Message,
@@ -29,6 +30,21 @@ class RabbitSubscriberSpecification(
 
         return f"{self._outer_config.prefix}{queue_name}:{exchange_name or '_'}:{self.call_name}"
 
+    @property
+    def address(self) -> str:
+        """The routing key the queue is bound by, prefixed.
+
+        Empty where the exchange ignores routing keys: a fanout reaches every queue
+        bound to it, so the queue this subscriber reads from names nothing a message
+        is routed by. The document drops the queue binding for the same reason.
+        """
+        if not is_routing_exchange(self.config.exchange):
+            return ""
+
+        return self.config.queue.add_prefix(
+            self._outer_config.prefix,
+        ).routing_template()
+
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
 
@@ -41,6 +57,7 @@ class RabbitSubscriberSpecification(
 
         return {
             channel_name: SubscriberSpec(
+                address=self.address,
                 description=self.description,
                 operation=Operation(
                     bindings=OperationBinding(

--- a/faststream/redis/publisher/specification.py
+++ b/faststream/redis/publisher/specification.py
@@ -16,6 +16,7 @@ class RedisPublisherSpecification(
 
         return {
             self.name: PublisherSpec(
+                address=self.address,
                 description=self.config.description_,
                 operation=Operation(
                     message=Message(
@@ -29,6 +30,10 @@ class RedisPublisherSpecification(
                 ),
             ),
         }
+
+    @property
+    def address(self) -> str:
+        raise NotImplementedError
 
     @property
     def channel_binding(self) -> redis.ChannelBinding:
@@ -50,10 +55,10 @@ class ChannelPublisherSpecification(RedisPublisherSpecification):
         if self.config.title_:
             return self.config.title_
 
-        return f"{self.channel_name}:Publisher"
+        return f"{self.address}:Publisher"
 
     @property
-    def channel_name(self) -> str:
+    def address(self) -> str:
         # Through `PubSub`, the way the usecase does it: a prefix decorates the
         # declaration, so a `{{` of its own comes off with the rest.
         return self.channel.add_prefix(self._outer_config.prefix).address.template
@@ -61,7 +66,7 @@ class ChannelPublisherSpecification(RedisPublisherSpecification):
     @property
     def channel_binding(self) -> redis.ChannelBinding:
         return redis.ChannelBinding(
-            channel=self.channel_name,
+            channel=self.address,
             method="publish",
         )
 
@@ -81,16 +86,16 @@ class ListPublisherSpecification(RedisPublisherSpecification):
         if self.config.title_:
             return self.config.title_
 
-        return f"{self.list_name}:Publisher"
+        return f"{self.address}:Publisher"
 
     @property
-    def list_name(self) -> str:
+    def address(self) -> str:
         return f"{self._outer_config.prefix}{self.list_sub.name}"
 
     @property
     def channel_binding(self) -> redis.ChannelBinding:
         return redis.ChannelBinding(
-            channel=self.list_name,
+            channel=self.address,
             method="rpush",
         )
 
@@ -110,15 +115,15 @@ class StreamPublisherSpecification(RedisPublisherSpecification):
         if self.config.title_:
             return self.config.title_
 
-        return f"{self.stream_name}:Publisher"
+        return f"{self.address}:Publisher"
 
     @property
-    def stream_name(self) -> str:
+    def address(self) -> str:
         return f"{self._outer_config.prefix}{self.stream_sub.name}"
 
     @property
     def channel_binding(self) -> "redis.ChannelBinding":
         return redis.ChannelBinding(
-            channel=self.stream_name,
+            channel=self.address,
             method="xadd",
         )

--- a/faststream/redis/subscriber/specification.py
+++ b/faststream/redis/subscriber/specification.py
@@ -23,6 +23,7 @@ class RedisSubscriberSpecification(
 
         return {
             self.name: SubscriberSpec(
+                address=self.address,
                 description=self.description,
                 operation=Operation(
                     message=Message(
@@ -36,6 +37,10 @@ class RedisSubscriberSpecification(
                 ),
             ),
         }
+
+    @property
+    def address(self) -> str:
+        raise NotImplementedError
 
     @property
     def channel_binding(self) -> redis.ChannelBinding:
@@ -58,10 +63,10 @@ class ChannelSubscriberSpecification(RedisSubscriberSpecification):
         if self.config.title_:
             return self.config.title_
 
-        return f"{self.channel_name}:{self.call_name}"
+        return f"{self.address}:{self.call_name}"
 
     @property
-    def channel_name(self) -> str:
+    def address(self) -> str:
         # Through `PubSub`, the way the usecase does it: a prefix decorates the
         # declaration, so a `{{` of its own comes off with the rest.
         return self.channel.add_prefix(self._outer_config.prefix).address.template
@@ -69,7 +74,7 @@ class ChannelSubscriberSpecification(RedisSubscriberSpecification):
     @property
     def channel_binding(self) -> "redis.ChannelBinding":
         return redis.ChannelBinding(
-            channel=self.channel_name,
+            channel=self.address,
             method="psubscribe" if self.channel.pattern else "subscribe",
         )
 
@@ -90,16 +95,16 @@ class ListSubscriberSpecification(RedisSubscriberSpecification):
         if self.config.title_:
             return self.config.title_
 
-        return f"{self.list_name}:{self.call_name}"
+        return f"{self.address}:{self.call_name}"
 
     @property
-    def list_name(self) -> str:
+    def address(self) -> str:
         return f"{self._outer_config.prefix}{self.list_sub.name}"
 
     @property
     def channel_binding(self) -> "redis.ChannelBinding":
         return redis.ChannelBinding(
-            channel=self.list_name,
+            channel=self.address,
             method="lpop",
         )
 
@@ -120,16 +125,16 @@ class StreamSubscriberSpecification(RedisSubscriberSpecification):
         if self.config.title_:
             return self.config.title_
 
-        return f"{self.stream_name}:{self.call_name}"
+        return f"{self.address}:{self.call_name}"
 
     @property
-    def stream_name(self) -> str:
+    def address(self) -> str:
         return f"{self._outer_config.prefix}{self.stream_sub.name}"
 
     @property
     def channel_binding(self) -> "redis.ChannelBinding":
         return redis.ChannelBinding(
-            channel=self.stream_name,
+            channel=self.address,
             group_name=self.stream_sub.group,
             consumer_name=self.stream_sub.consumer,
             method="xreadgroup" if self.stream_sub.group else "xread",

--- a/faststream/specification/asyncapi/v3_0_0/generate.py
+++ b/faststream/specification/asyncapi/v3_0_0/generate.py
@@ -220,7 +220,7 @@ def get_broker_channels(
 
     for sub in filter(lambda s: s.specification.include_in_schema, broker.subscribers):
         for sub_key, sub_channel in sub.schema().items():
-            channel_obj = Channel.from_sub(sub_key, sub_channel, servers=channel_servers)
+            channel_obj = Channel.from_sub(sub_channel, servers=channel_servers)
 
             channel_key = clear_key(sub_key)
             if channel_key in channels:
@@ -256,7 +256,7 @@ def get_broker_channels(
 
     for pub in filter(lambda p: p.specification.include_in_schema, broker.publishers):
         for pub_key, pub_channel in pub.schema().items():
-            channel_obj = Channel.from_pub(pub_key, pub_channel, servers=channel_servers)
+            channel_obj = Channel.from_pub(pub_channel, servers=channel_servers)
 
             channel_key = clear_key(pub_key)
             if channel_key in channels:

--- a/faststream/specification/asyncapi/v3_0_0/schema/channels.py
+++ b/faststream/specification/asyncapi/v3_0_0/schema/channels.py
@@ -13,7 +13,8 @@ class Channel(BaseModel):
     """A class to represent a channel.
 
     Attributes:
-        address: A string representation of this channel's address.
+        address: A string representation of this channel's address, absent
+            where there is none to give.
         description : optional description of the channel
         servers : optional list of servers associated with the channel
         bindings : optional channel binding
@@ -24,7 +25,7 @@ class Channel(BaseModel):
         Config : configuration for the class (only applicable for Pydantic version 1)
     """
 
-    address: str
+    address: str | None = None
     description: str | None = None
     servers: list[dict[str, str]] | None = None
     messages: dict[str, Message | Reference]

--- a/faststream/specification/asyncapi/v3_0_0/schema/channels.py
+++ b/faststream/specification/asyncapi/v3_0_0/schema/channels.py
@@ -44,7 +44,6 @@ class Channel(BaseModel):
     @classmethod
     def from_sub(
         cls,
-        address: str,
         subscriber: SubscriberSpec,
         servers: list[dict[str, str]] | None = None,
     ) -> Self:
@@ -56,7 +55,7 @@ class Channel(BaseModel):
 
         return cls(
             description=subscriber.description,
-            address=address,
+            address=subscriber.address,
             messages={
                 "SubscribeMessage": Message.from_spec(message),
             },
@@ -67,13 +66,12 @@ class Channel(BaseModel):
     @classmethod
     def from_pub(
         cls,
-        address: str,
         publisher: PublisherSpec,
         servers: list[dict[str, str]] | None = None,
     ) -> Self:
         return cls(
             description=publisher.description,
-            address=address,
+            address=publisher.address,
             messages={
                 "Message": Message.from_spec(publisher.operation.message),
             },

--- a/faststream/specification/schema/publisher.py
+++ b/faststream/specification/schema/publisher.py
@@ -15,4 +15,4 @@ class PublisherSpec:
     description: str | None
     operation: Operation
     bindings: ChannelBinding | None
-    address: str
+    address: str | None

--- a/faststream/specification/schema/publisher.py
+++ b/faststream/specification/schema/publisher.py
@@ -6,6 +6,13 @@ from .operation import Operation
 
 @dataclass
 class PublisherSpec:
+    """One publisher, as the specification generators see it.
+
+    `address` is the Address template the endpoint publishes to, which is not the
+    key this spec is filed under — see `SubscriberSpec`.
+    """
+
     description: str | None
     operation: Operation
     bindings: ChannelBinding | None
+    address: str

--- a/faststream/specification/schema/subscriber.py
+++ b/faststream/specification/schema/subscriber.py
@@ -11,9 +11,12 @@ class SubscriberSpec:
     `address` is the Address template the endpoint listens on. It is not the key
     this spec is filed under: that key names the channel and carries the handler
     name with it, so the two differ for every subscriber.
+
+    It is `None` where the endpoint has no address — AsyncAPI reads an absent one
+    as unknown, which an empty string would not say.
     """
 
     description: str | None
     operation: Operation
     bindings: ChannelBinding | None
-    address: str
+    address: str | None

--- a/faststream/specification/schema/subscriber.py
+++ b/faststream/specification/schema/subscriber.py
@@ -6,6 +6,14 @@ from .operation import Operation
 
 @dataclass
 class SubscriberSpec:
+    """One subscriber, as the specification generators see it.
+
+    `address` is the Address template the endpoint listens on. It is not the key
+    this spec is filed under: that key names the channel and carries the handler
+    name with it, so the two differ for every subscriber.
+    """
+
     description: str | None
     operation: Operation
     bindings: ChannelBinding | None
+    address: str

--- a/tests/asyncapi/base/v3_0_0/arguments.py
+++ b/tests/asyncapi/base/v3_0_0/arguments.py
@@ -66,7 +66,8 @@ class FastAPICompatible(AsyncAPI300Factory):
         operation_key = tuple(schema["operations"].keys())[0]  # noqa: RUF015
 
         assert channel_key == "."
-        assert schema["channels"][channel_key]["address"] == "/"
+        # the title names the channel; `address` stays the address subscribed to
+        assert schema["channels"][channel_key]["address"] == "test"
 
         assert operation_key == ".Subscribe"
 

--- a/tests/asyncapi/confluent/v3_0_0/test_naming.py
+++ b/tests/asyncapi/confluent/v3_0_0/test_naming.py
@@ -30,7 +30,7 @@ class TestNaming(NamingTestCase):
             },
             "channels": {
                 "test:Handle": {
-                    "address": "test:Handle",
+                    "address": "test",
                     "servers": [
                         {
                             "$ref": "#/servers/development",

--- a/tests/asyncapi/confluent/v3_0_0/test_router.py
+++ b/tests/asyncapi/confluent/v3_0_0/test_router.py
@@ -43,7 +43,7 @@ class TestRouter(RouterTestcase):
             },
             "channels": {
                 "test_test:Handle": {
-                    "address": "test_test:Handle",
+                    "address": "test_test",
                     "servers": [{"$ref": "#/servers/development"}],
                     "messages": {
                         "SubscribeMessage": {

--- a/tests/asyncapi/kafka/v3_0_0/test_naming.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_naming.py
@@ -30,7 +30,7 @@ class TestNaming(NamingTestCase):
             },
             "channels": {
                 "test:Handle": {
-                    "address": "test:Handle",
+                    "address": "test",
                     "servers": [
                         {
                             "$ref": "#/servers/development",

--- a/tests/asyncapi/kafka/v3_0_0/test_router.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_router.py
@@ -43,7 +43,7 @@ class TestRouter(RouterTestcase):
             },
             "channels": {
                 "test_test:Handle": {
-                    "address": "test_test:Handle",
+                    "address": "test_test",
                     "servers": [{"$ref": "#/servers/development"}],
                     "messages": {
                         "SubscribeMessage": {

--- a/tests/asyncapi/kafka/v3_0_0/test_security.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_security.py
@@ -29,7 +29,7 @@ basic_schema = {
     },
     "channels": {
         "test_1:TestTopic": {
-            "address": "test_1:TestTopic",
+            "address": "test_1",
             "servers": [{"$ref": "#/servers/development"}],
             "messages": {
                 "SubscribeMessage": {
@@ -39,7 +39,7 @@ basic_schema = {
             "bindings": {"kafka": {"topic": "test_1", "bindingVersion": "0.4.0"}},
         },
         "test_2:Publisher": {
-            "address": "test_2:Publisher",
+            "address": "test_2",
             "servers": [{"$ref": "#/servers/development"}],
             "messages": {
                 "Message": {"$ref": "#/components/messages/test_2:Publisher:Message"},

--- a/tests/asyncapi/mqtt/v3_0_0/test_address_field.py
+++ b/tests/asyncapi/mqtt/v3_0_0/test_address_field.py
@@ -1,0 +1,27 @@
+import pytest
+
+from faststream.mqtt import MQTTBroker
+from tests.asyncapi.base.v3_0_0.basic import get_3_0_0_schema
+
+
+@pytest.mark.mqtt()
+def test_a_shared_subscription_is_not_part_of_the_address() -> None:
+    """`$share/<group>/` asks for a shared subscription; it is not part of a topic.
+
+    A message delivered here carries `test`, never `$share/group/test`, so that is
+    what the address says. The group is not lost from the document: the channel
+    name keeps it, and so does `bindings.mqtt.topic`.
+    """
+    broker = MQTTBroker()
+
+    @broker.subscriber("test", shared="group")
+    async def handle(body: str) -> None: ...
+
+    ((name, channel),) = get_3_0_0_schema(broker)["channels"].items()
+
+    assert channel["address"] == "test"
+
+    # 3.0 channel keys are cleaned of the characters a `$ref` cannot hold, which is
+    # why the name reads `$share.group.test` rather than the topic itself.
+    assert name == "$share.group.test:Handle"
+    assert channel["bindings"]["mqtt"]["topic"] == "$share/group/test"

--- a/tests/asyncapi/mqtt/v3_0_0/test_naming.py
+++ b/tests/asyncapi/mqtt/v3_0_0/test_naming.py
@@ -30,7 +30,7 @@ class TestNaming(NamingTestCase):
             },
             "channels": {
                 "test:Handle": {
-                    "address": "test:Handle",
+                    "address": "test",
                     "servers": [{"$ref": "#/servers/development"}],
                     "messages": {
                         "SubscribeMessage": {

--- a/tests/asyncapi/mqtt/v3_0_0/test_router.py
+++ b/tests/asyncapi/mqtt/v3_0_0/test_router.py
@@ -43,7 +43,7 @@ class TestRouter(RouterTestcase):
             },
             "channels": {
                 "test_test:Handle": {
-                    "address": "test_test:Handle",
+                    "address": "test_test",
                     "servers": [{"$ref": "#/servers/development"}],
                     "messages": {
                         "SubscribeMessage": {

--- a/tests/asyncapi/nats/v3_0_0/test_naming.py
+++ b/tests/asyncapi/nats/v3_0_0/test_naming.py
@@ -25,7 +25,8 @@ class TestNaming(NamingTestCase):
 
         (channel_name,) = schema["channels"]
         assert channel_name == "logs.{level}:Handle"
-        assert schema["channels"][channel_name]["address"] == "logs.{level}:Handle"
+        # no subject to name: this consumer reaches the stream by filtering
+        assert schema["channels"][channel_name]["address"] == ""
         assert (
             schema["channels"][channel_name]["bindings"]["nats"]["subject"]
             == "logs.{level}"
@@ -73,7 +74,7 @@ class TestNaming(NamingTestCase):
             },
             "channels": {
                 "test:Handle": {
-                    "address": "test:Handle",
+                    "address": "test",
                     "servers": [
                         {
                             "$ref": "#/servers/development",

--- a/tests/asyncapi/nats/v3_0_0/test_naming.py
+++ b/tests/asyncapi/nats/v3_0_0/test_naming.py
@@ -25,8 +25,8 @@ class TestNaming(NamingTestCase):
 
         (channel_name,) = schema["channels"]
         assert channel_name == "logs.{level}:Handle"
-        # no subject to name: this consumer reaches the stream by filtering
-        assert schema["channels"][channel_name]["address"] == ""
+        # one filtered subject, so that subject is the address
+        assert schema["channels"][channel_name]["address"] == "logs.{level}"
         assert (
             schema["channels"][channel_name]["bindings"]["nats"]["subject"]
             == "logs.{level}"
@@ -51,6 +51,9 @@ class TestNaming(NamingTestCase):
             schema["channels"][channel_name]["bindings"]["nats"]["subject"]
             == "logs.info, logs.error"
         )
+        # Two filtered subjects, so neither one of them is *the* address, and an
+        # absent address is the only way to say that.
+        assert "address" not in schema["channels"][channel_name]
 
     def test_base(self) -> None:
         broker = self.broker_class()

--- a/tests/asyncapi/nats/v3_0_0/test_router.py
+++ b/tests/asyncapi/nats/v3_0_0/test_router.py
@@ -43,7 +43,7 @@ class TestRouter(RouterTestcase):
             },
             "channels": {
                 "test_test:Handle": {
-                    "address": "test_test:Handle",
+                    "address": "test_test",
                     "servers": [{"$ref": "#/servers/development"}],
                     "messages": {
                         "SubscribeMessage": {

--- a/tests/asyncapi/rabbit/v3_0_0/test_address_field.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_address_field.py
@@ -1,0 +1,34 @@
+import pytest
+
+from faststream.rabbit import ExchangeType, RabbitBroker, RabbitExchange, RabbitQueue
+from tests.asyncapi.base.v3_0_0.basic import get_3_0_0_schema
+
+TOPIC = RabbitExchange("test-ex", type=ExchangeType.TOPIC)
+FANOUT = RabbitExchange("test-ex", type=ExchangeType.FANOUT)
+
+
+def _addresses(broker: RabbitBroker) -> dict[str, str | None]:
+    return {
+        name: channel.get("address")
+        for name, channel in get_3_0_0_schema(broker)["channels"].items()
+    }
+
+
+@pytest.mark.rabbit()
+def test_the_routing_key_is_the_address_not_the_queue() -> None:
+    """A queue is a place to read from; the routing key is what addresses a message.
+
+    It is also the only one of RabbitMQ's three names that can hold a `{param}`,
+    so a queue called one thing and bound by another renders the second.
+    """
+    broker = RabbitBroker()
+
+    @broker.subscriber(RabbitQueue("test-q", routing_key="logs.{level}"), TOPIC)
+    async def handle_logs(body: str) -> None: ...
+
+    broker.publisher(RabbitQueue("test-q", routing_key="cache"), TOPIC)
+
+    assert _addresses(broker) == {
+        "test-q:test-ex:HandleLogs": "logs.{level}",
+        "cache:test-ex:Publisher": "cache",
+    }

--- a/tests/asyncapi/rabbit/v3_0_0/test_address_field.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_address_field.py
@@ -32,3 +32,38 @@ def test_the_routing_key_is_the_address_not_the_queue() -> None:
         "test-q:test-ex:HandleLogs": "logs.{level}",
         "cache:test-ex:Publisher": "cache",
     }
+
+
+@pytest.mark.rabbit()
+def test_a_fanout_has_no_address() -> None:
+    """A fanout reaches every queue bound to it, so no key routes a message here.
+
+    The document already drops the queue binding for this case; rendering the queue
+    name as the address would put back exactly what that omission removed. Absent
+    rather than empty: AsyncAPI reads a missing address as unknown, `""` does not.
+    """
+    broker = RabbitBroker()
+
+    @broker.subscriber(RabbitQueue("test-q"), FANOUT)
+    async def handle(body: str) -> None: ...
+
+    broker.publisher(RabbitQueue("test-q"), FANOUT)
+
+    assert _addresses(broker) == {
+        "test-q:test-ex:Handle": None,
+        "_:test-ex:Publisher": None,
+    }
+
+
+@pytest.mark.rabbit()
+def test_a_routing_key_declared_on_a_fanout_is_still_no_address() -> None:
+    """The exchange decides, not the declaration.
+
+    A fanout ignores any routing key handed to it, so one declared anyway still
+    addresses nothing — and a publisher must not read an address where the
+    subscriber on the far side of it reads none.
+    """
+    broker = RabbitBroker()
+    broker.publisher(RabbitQueue("test-q"), FANOUT, routing_key="ignored")
+
+    assert _addresses(broker) == {"ignored:test-ex:Publisher": None}

--- a/tests/asyncapi/rabbit/v3_0_0/test_connection.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_connection.py
@@ -63,7 +63,7 @@ def test_custom() -> None:
         "asyncapi": "3.0.0",
         "channels": {
             "test:_:Publisher": {
-                "address": "test:_:Publisher",
+                "address": "test",
                 "bindings": {
                     "amqp": {
                         "bindingVersion": "0.3.0",

--- a/tests/asyncapi/rabbit/v3_0_0/test_naming.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_naming.py
@@ -58,7 +58,7 @@ class TestNaming(NamingTestCase):
             },
             "channels": {
                 "test:_:Handle": {
-                    "address": "test:_:Handle",
+                    "address": "test",
                     "servers": [
                         {
                             "$ref": "#/servers/development",

--- a/tests/asyncapi/rabbit/v3_0_0/test_publisher.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_publisher.py
@@ -18,7 +18,7 @@ class TestArguments(PublisherTestcase):
 
         assert schema["channels"] == {
             "_:test-ex:Publisher": {
-                "address": "_:test-ex:Publisher",
+                "address": "",
                 "bindings": {
                     "amqp": {
                         "bindingVersion": "0.3.0",
@@ -106,7 +106,7 @@ class TestArguments(PublisherTestcase):
 
         assert schema["channels"] == {
             "_:test-ex:Publisher": {
-                "address": "_:test-ex:Publisher",
+                "address": "",
                 "bindings": {
                     "amqp": {
                         "bindingVersion": "0.3.0",
@@ -162,7 +162,7 @@ class TestArguments(PublisherTestcase):
 
         assert schema["channels"] == {
             "key1:test-ex:Publisher": {
-                "address": "key1:test-ex:Publisher",
+                "address": "key1",
                 "bindings": {
                     "amqp": {
                         "bindingVersion": "0.3.0",
@@ -188,7 +188,7 @@ class TestArguments(PublisherTestcase):
                 },
             },
             "key2:test-ex:Publisher": {
-                "address": "key2:test-ex:Publisher",
+                "address": "key2",
                 "bindings": {
                     "amqp": {
                         "bindingVersion": "0.3.0",

--- a/tests/asyncapi/rabbit/v3_0_0/test_publisher.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_publisher.py
@@ -18,7 +18,8 @@ class TestArguments(PublisherTestcase):
 
         assert schema["channels"] == {
             "_:test-ex:Publisher": {
-                "address": "",
+                # no `address`: the exchange ignores routing keys, and an absent
+                # address is how the document says there is none
                 "bindings": {
                     "amqp": {
                         "bindingVersion": "0.3.0",
@@ -106,7 +107,8 @@ class TestArguments(PublisherTestcase):
 
         assert schema["channels"] == {
             "_:test-ex:Publisher": {
-                "address": "",
+                # no `address`: the exchange ignores routing keys, and an absent
+                # address is how the document says there is none
                 "bindings": {
                     "amqp": {
                         "bindingVersion": "0.3.0",

--- a/tests/asyncapi/rabbit/v3_0_0/test_router.py
+++ b/tests/asyncapi/rabbit/v3_0_0/test_router.py
@@ -49,7 +49,7 @@ class TestRouter(RouterTestcase):
             },
             "channels": {
                 "test_test:_:Handle": {
-                    "address": "test_test:_:Handle",
+                    "address": "test_key",
                     "servers": [{"$ref": "#/servers/development"}],
                     "messages": {
                         "SubscribeMessage": {

--- a/tests/asyncapi/redis/v3_0_0/test_naming.py
+++ b/tests/asyncapi/redis/v3_0_0/test_naming.py
@@ -20,7 +20,7 @@ class TestNaming(NamingTestCase):
             "asyncapi": "3.0.0",
             "channels": {
                 "test:Handle": {
-                    "address": "test:Handle",
+                    "address": "test",
                     "bindings": {
                         "redis": {
                             "bindingVersion": "custom",

--- a/tests/asyncapi/redis/v3_0_0/test_router.py
+++ b/tests/asyncapi/redis/v3_0_0/test_router.py
@@ -43,7 +43,7 @@ class TestRouter(RouterTestcase):
             },
             "channels": {
                 "test_test:Handle": {
-                    "address": "test_test:Handle",
+                    "address": "test_test",
                     "servers": [{"$ref": "#/servers/development"}],
                     "messages": {
                         "SubscribeMessage": {


### PR DESCRIPTION
`channels[].address` carries the address the endpoint reads or writes. It is **not** the channel key: the key is a name and carries the handler with it, so the two differ for every subscriber. Before this PR the key was copied into the field, which produced `address: "test:Handle"` — a string nobody publishes to.

Only 3.0 has the field. 2.6's channel object has no such attribute and its key *is* the name; putting an address there would collide two handlers listening on one address.

**Absent, not empty.** Where there is no address the field is dropped entirely, because AsyncAPI reads a missing field as *unknown* and `""` does not say that.

Every row below is a rendered schema, not a reading of the source.

## Kafka

The topic — or the pattern, where one is given.

| Declared as | Channel key | `address` |
|---|---|---|
| `subscriber("orders")` | `orders:Handle` | `orders` |
| `subscriber("orders", "events")` | `orders:Handle` · `events:Handle` | `orders` · `events` |
| `subscriber("orders", batch=True)` | `orders:Handle` | `orders` |
| `subscriber(partitions=[TopicPartition(…)])` | `orders:Handle` | `orders` |
| `subscriber(pattern="logs.{level}")` | `logs.{level}:Handle` | `logs.{level}` |
| `publisher("orders")` | `orders:Publisher` | `orders` |
| `publisher("orders", batch=True)` | `orders:Publisher` | `orders` |

One channel per topic, each with its own address. A partition contributes its topic; the partition number is not part of an address. `pattern=` is the one Kafka argument that is compiled.

## Confluent

As Kafka, minus `pattern=`, which this package has not got.

| Declared as | Channel key | `address` |
|---|---|---|
| `subscriber("orders")` | `orders:Handle` | `orders` |
| `subscriber("orders", "events")` | `orders:Handle` · `events:Handle` | `orders` · `events` |
| `subscriber("orders", batch=True)` | `orders:Handle` | `orders` |
| `subscriber(partitions=[TopicPartition(…)])` | `orders:Handle` | `orders` |
| `publisher("orders")` | `orders:Publisher` | `orders` |
| `publisher("orders", batch=True)` | `orders:Publisher` | `orders` |

## NATS

The subject — unless the consumer filters instead of subscribing.

| Declared as | Channel key | `address` |
|---|---|---|
| `subscriber("logs.{level}")` | `logs.{level}:Handle` | `logs.{level}` |
| `subscriber(…, stream=JStream(…))` | `logs.{level}:Handle` | `logs.{level}` |
| `subscriber(…, pull_sub=PullSub())` | `logs.a:Handle` | `logs.a` |
| `filter_subjects=["logs.a"]` | `logs.a:Handle` | `logs.a` |
| `filter_subjects=["logs.a", "logs.b"]` | `logs.a, logs.b:Handle` | **absent** |
| `kv_watch=KvWatch(…)` | — | **no channel** |
| `obj_watch=ObjWatch()` | — | **no channel** |
| `publisher("logs.{level}")` | `logs.{level}:Publisher` | `logs.{level}` |

A JetStream consumer with no `subject` reaches its stream through `filter_subjects`, and a single one of those is the address. Several are not: no one string is the address, so the document gives none.

`kv_watch` and `obj_watch` resolve to `NotIncludeSpecifation` — `include_in_schema` is `False` and `get_schema()` raises — so they produce no channel and the address question does not arise. Pre-existing, not touched here.

## Redis

The channel, list or stream name — whichever one was declared.

| Declared as | Channel key | `address` |
|---|---|---|
| `subscriber("chan")` | `chan:Handle` | `chan` |
| `subscriber(PubSub("logs.*", pattern=True))` | `logs.*:Handle` | `logs.*` |
| `subscriber(list=ListSub("mylist"))` | `mylist:Handle` | `mylist` |
| `subscriber(list=ListSub(…, batch=True))` | `mylist:Handle` | `mylist` |
| `subscriber(stream=StreamSub("mystream"))` | `mystream:Handle` | `mystream` |
| `subscriber(stream=StreamSub(…, group=…))` | `mystream:Handle` | `mystream` |
| `publisher("chan")` | `chan:Publisher` | `chan` |
| `publisher(list="mylist")` | `mylist:Publisher` | `mylist` |
| `publisher(stream="mystream")` | `mystream:Publisher` | `mystream` |

A list key and a stream name are literals, never compiled. A consumer group is a reading detail, not part of the address.

## RabbitMQ

The routing key — never the queue name, and nothing at all where the exchange ignores keys.

| Declared as | Channel key | `address` |
|---|---|---|
| `subscriber("q")` (default exchange) | `q:_:Handle` | `q` |
| `RabbitQueue("q", routing_key="logs.{level}")` + topic | `q:ex:Handle` | `logs.{level}` |
| `RabbitQueue("q", routing_key="rk")` + direct | `q:ex:Handle` | `rk` |
| `RabbitQueue("q")` + topic | `q:ex:Handle` | `q` |
| `RabbitQueue("q")` + fanout | `q:ex:Handle` | **absent** |
| `RabbitQueue("q")` + headers | `q:ex:Handle` | **absent** |
| `publisher(routing_key=…, exchange=topic)` | `logs.{level}:ex:Publisher` | `logs.{level}` |
| `publisher(RabbitQueue("q", routing_key="rk"), topic)` | `rk:ex:Publisher` | `rk` |
| `publisher(RabbitQueue("q"), fanout)` | `_:ex:Publisher` | **absent** |
| `publisher(…, fanout, routing_key="ignored")` | `ignored:ex:Publisher` | **absent** |

A queue is a place a consumer reads from; the routing key is the string a message is addressed with, and the only one of RabbitMQ's three names that can hold a `{param}`. With no key declared the queue name *is* the binding key, which is why those two rows coincide.

**The exchange decides, not the declaration.** A fanout reaches every queue bound to it and a headers exchange routes on headers, so neither has a key that routes anything — a `routing_key=` handed to a fanout still addresses nothing. Otherwise a publisher would read an address where the subscriber on the far side of it reads none. The document already drops the queue binding for a fanout; naming the queue as the address would put back exactly what that omission removed.

## MQTT

The topic a message arrives on — which is not always the topic you subscribed with.

| Declared as | Channel key | `address` |
|---|---|---|
| `subscriber("logs/{level}")` | `logs.{level}:Handle` | `logs/{level}` |
| `subscriber("test", shared="group")` | `$share.group.test:Handle` | `test` |
| `publisher("logs/{level}")` | `logs.{level}:Publisher` | `logs/{level}` |

The 3.0 channel key spells `/` as `.`, being cleaned of characters a `$ref` cannot hold; the address keeps MQTT's own separator.

`$share/<group>/` asks for a shared subscription and never appears in a message's topic, so the address does not carry it. The group is not lost from the document: the channel name keeps it, and so does `bindings.mqtt.topic`.

## Under a router prefix

The prefix joins the declaration and is compiled with it, so a `{{` of the prefix's own comes off with the rest — the rule #3074 established.

| Broker | Prefix | Declared | `address` |
|---|---|---|---|
| NATS | `app{{v1}}.` | `logs.{level}` | `app{v1}.logs.{level}` |
| Redis | `app{{v1}}.` | `chan` | `app{v1}.chan` |
| MQTT | `app{{v1}}/` | `logs/{level}` | `app{v1}/logs/{level}` |
| RabbitMQ | `app.` | `logs.{level}` | `app.logs.{level}` |
| Kafka | `app{{v1}}.` | `orders` | `app{{v1}}.orders` |
| Confluent | `app{{v1}}.` | `orders` | `app{{v1}}.orders` |

The last two keep their `{{`: a Kafka topic is a literal and never meets the parser, so it has no escape to undo. Known and filed rather than fixed here — see #3076, which also covers a restored `{v1}` being read as a channel parameter.

## 2.6 is untouched

Not one 2.6 snapshot moved. The same Redis declaration that renders `address: "chan"` under 3.0 renders `['bindings', 'publish', 'servers']` under 2.6 — there is nowhere to put an address, and the channel key is the name.

## Deferred

**A subscriber over several addresses should be several channels.** NATS renders two filtered subjects as one channel keyed `logs.a, logs.b`, which is not a subject anybody publishes to — hence the absent address above. Kafka already splits. #3070 does this for NATS and stacks on top of this PR.

**A literal brace cannot be expressed in an AsyncAPI address.** #3076.
