### PR TITLE
Render filter_subjects in the NATS AsyncAPI channel

### DIFF
--- a/faststream/nats/subscriber/config.py
+++ b/faststream/nats/subscriber/config.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
 class NatsSubscriberSpecificationConfig(SubscriberSpecificationConfig):
     subject: str
     queue: str | None
+    # A JetStream consumer may address a stream through `filter_subjects` instead of `subject`,
+    # so the specification layer needs them to render a meaningful address.
+    filter_subjects: list[str] = field(default_factory=list)
 
 
 @dataclass(kw_only=True)

--- a/faststream/nats/subscriber/factory.py
+++ b/faststream/nats/subscriber/factory.py
@@ -164,6 +164,7 @@ def create_subscriber(
     specification_config = NatsSubscriberSpecificationConfig(
         subject=subject,
         queue=queue or None,
+        filter_subjects=list(config.filter_subjects or ()),
         title_=title_,
         description_=description_,
         include_in_schema=include_in_schema,

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -20,11 +20,30 @@ class NatsSubscriberSpecification(
         )
 
     @property
+    def filter_subjects(self) -> list[str]:
+        """The subjects a JetStream consumer filters on, and their Broker addresses."""
+        return [
+            Address(subject, NATS_ADDRESS_SYNTAX)
+            .add_prefix(self._outer_config.prefix)
+            .template
+            for subject in self.config.filter_subjects
+        ]
+
+    @property
+    def _resolved_subject_string(self) -> str:
+        """The declared subject, falling back to the filtered subjects when there is none.
+
+        A JetStream consumer can address a stream through `filter_subjects` alone, leaving
+        `subject` empty. Mirrors `LogicSubscriber._resolved_subject_string`.
+        """
+        return self.subject.template or ", ".join(self.filter_subjects)
+
+    @property
     def name(self) -> str:
         if self.config.title_:
             return self.config.title_
 
-        return f"{self.subject.template}:{self.call_name}"
+        return f"{self._resolved_subject_string}:{self.call_name}"
 
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
@@ -41,7 +60,7 @@ class NatsSubscriberSpecification(
                 ),
                 bindings=ChannelBinding(
                     nats=nats.ChannelBinding(
-                        subject=self.subject.template,
+                        subject=self._resolved_subject_string,
                         queue=self.config.queue,
                     ),
                 ),

--- a/tests/asyncapi/nats/v3_0_0/test_naming.py
+++ b/tests/asyncapi/nats/v3_0_0/test_naming.py
@@ -1,12 +1,55 @@
 import pytest
+from nats.js.api import ConsumerConfig
 
-from faststream.nats import NatsBroker
+from faststream.nats import JStream, NatsBroker, PullSub
 from tests.asyncapi.base.v3_0_0.naming import NamingTestCase
 
 
 @pytest.mark.nats()
 class TestNaming(NamingTestCase):
     broker_class = NatsBroker
+
+    def test_filter_subjects_without_subject(self) -> None:
+        """A JetStream consumer may address a stream through `filter_subjects` and no `subject`."""
+        broker = self.broker_class()
+
+        @broker.subscriber(
+            stream=JStream("stream"),
+            pull_sub=PullSub(),
+            durable="durable",
+            config=ConsumerConfig(filter_subjects=["logs.{level}"]),
+        )
+        async def handle() -> None: ...
+
+        schema = self.get_spec(broker).to_jsonable()
+
+        (channel_name,) = schema["channels"]
+        assert channel_name == "logs.{level}:Handle"
+        assert schema["channels"][channel_name]["address"] == "logs.{level}:Handle"
+        assert (
+            schema["channels"][channel_name]["bindings"]["nats"]["subject"]
+            == "logs.{level}"
+        )
+
+    def test_multiple_filter_subjects_without_subject(self) -> None:
+        """Several filtered subjects are rendered the same way the runtime reports them."""
+        broker = self.broker_class()
+
+        @broker.subscriber(
+            stream=JStream("stream"),
+            pull_sub=PullSub(),
+            durable="durable",
+            config=ConsumerConfig(filter_subjects=["logs.info", "logs.error"]),
+        )
+        async def handle() -> None: ...
+
+        schema = self.get_spec(broker).to_jsonable()
+
+        (channel_name,) = schema["channels"]
+        assert (
+            schema["channels"][channel_name]["bindings"]["nats"]["subject"]
+            == "logs.info, logs.error"
+        )
 
     def test_base(self) -> None:
         broker = self.broker_class()


### PR DESCRIPTION
Closes #3035.

## What was happening

`NatsSubscriberSpecificationConfig` carried only `subject` and `queue`, so the specification layer had no knowledge of `filter_subjects`. A JetStream consumer declared through `filter_subjects` alone therefore rendered with an empty NATS binding subject, and the channel name collapsed to `:Handle`.

## The change

- `NatsSubscriberSpecificationConfig` now carries `filter_subjects`, populated by `create_subscriber()` from the `ConsumerConfig`.
- `NatsSubscriberSpecification` resolves the channel subject the same way the runtime already does in `LogicSubscriber._resolved_subject_string` — the declared subject, falling back to the filtered subjects joined with `", "`. Each filtered subject goes through `Address` with `NATS_ADDRESS_SYNTAX` and the broker prefix, so Path parameters render as templates just like a declared subject does.

Nothing changes for subscribers that declare a `subject`: `_resolved_subject_string` returns `self.subject.template` exactly as before.

## Before / after

Running the reproduction from the issue:

```json
// before
{
 ":Handle": {
  "address": ":Handle",
  "bindings": {"nats": {"subject": "", "bindingVersion": "custom"}}
 }
}

// after
{
 "logs.{level}:Handle": {
  "address": "logs.{level}:Handle",
  "bindings": {"nats": {"subject": "logs.{level}", "bindingVersion": "custom"}}
 }
}
```

## Tests

Added to `tests/asyncapi/nats/v3_0_0/test_naming.py`:

- `test_filter_subjects_without_subject` — the issue's reproduction, asserting the channel name, address and NATS binding subject.
- `test_multiple_filter_subjects_without_subject` — several filtered subjects render as `"logs.info, logs.error"`, matching what the runtime reports.

Both fail on `main` and pass with this change. `tests/asyncapi/nats` is otherwise green before and after.
