### PR TITLE
feat: support literal braces in addresses across all brokers

### DIFF
--- a/docs/docs/en/kafka/Subscriber/index.md
+++ b/docs/docs/en/kafka/Subscriber/index.md
@@ -88,6 +88,18 @@ async def base_handler(
     ...
 ```
 
+### Literal braces
+
+If your topic name legitimately contains `{` or `}` characters (e.g. `cache{shard}`), escape them by doubling: `{{` and `}}`. FastStream will treat them as literal braces instead of path parameters:
+
+```python
+@broker.subscriber("cache{{shard}}.logs.{level}")
+async def handler(body: str, level: str = Path()):
+    ...
+```
+
+This subscribes to the topic `cache{shard}.logs.*` where `{shard}` is literal text and `{level}` is a captured parameter.
+
 ## Concurrent processing
 
 There are two possible modes of concurrent message processing:

--- a/docs/docs/en/nats/message.md
+++ b/docs/docs/en/nats/message.md
@@ -97,3 +97,15 @@ async def base_handler(
 ):
     ...
 ```
+
+### Literal braces
+
+If your subject name legitimately contains `{` or `}` characters, escape them by doubling: `{{` and `}}`. FastStream will treat them as literal braces instead of path parameters:
+
+```python
+@broker.subscriber("cache{{shard}}.logs.{level}")
+async def handler(body: str, level: str = Path()):
+    ...
+```
+
+This subscribes to the subject `cache{shard}.logs.*` where `{shard}` is literal text and `{level}` is a captured parameter.

--- a/docs/docs/en/rabbit/message.md
+++ b/docs/docs/en/rabbit/message.md
@@ -107,3 +107,18 @@ async def base_handler(
 ):
     ...
 ```
+
+### Literal braces
+
+If your routing key legitimately contains `{` or `}` characters, escape them by doubling: `{{` and `}}`. FastStream will treat them as literal braces instead of path parameters:
+
+```python
+@broker.subscriber(
+    RabbitQueue("test-queue", routing_key="cache{{shard}}.logs.{level}"),
+    RabbitExchange("test-exchange", type=ExchangeType.TOPIC),
+)
+async def handler(body: str, level: str = Path()):
+    ...
+```
+
+This subscribes to the routing key `cache{shard}.logs.*` where `{shard}` is literal text and `{level}` is a captured parameter.

--- a/docs/docs/en/redis/pubsub/subscription.md
+++ b/docs/docs/en/redis/pubsub/subscription.md
@@ -94,3 +94,17 @@ You can also use the **Redis Pub/Sub** pattern feature to encode some data direc
 ```python linenums="1" hl_lines="1 8 12"
 {! docs_src/redis/pub_sub/pattern_data.py !}
 ```
+
+### Literal braces
+
+If your channel name legitimately contains `{` or `}` characters, escape them by doubling: `{{` and `}}`. FastStream will treat them as literal braces instead of path parameters:
+
+```python
+channel = PubSub("cache{{shard}}.logs.{level}")
+
+@broker.subscriber(channel)
+async def handler(body: str, level: str = Path()):
+    ...
+```
+
+This subscribes to the channel `cache{shard}.logs.*` where `{shard}` is literal text and `{level}` is a captured parameter.

--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,29 +12,6 @@ hide:
 ---
 
 # Release Notes
-
-## Unreleased
-
-### What's Changed
-
-#### Literal Braces in Addresses
-
-Addresses now support escaped braces (`{{` / `}}`) to represent literal `{` and `}` characters. This is useful when a queue, topic, or subject name legitimately contains braces (e.g., `cache{shard}`).
-
-**Breaking change:** An address containing a literal `{` must now be rewritten as `{{`. For example:
-
-```python
-# Before (silently treated as a parameter):
-@broker.subscriber("cache{shard}")
-
-# After (literal braces):
-@broker.subscriber("cache{{shard}}")
-```
-
-This change affects all brokers: Kafka, Confluent, RabbitMQ, Redis, NATS, and MQTT. MQTT already supported this syntax; other brokers now inherit the same behavior.
-
-* feat: support literal braces in addresses across all brokers by [@SammySN-car](https://github.com/SammySN-car){.external-link target="_blank"} in [#3034](https://github.com/ag2ai/faststream/pull/3034){.external-link target="_blank"}
-
 ## 0.7.1
 
 ### What's Changed

--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,34 +12,559 @@ hide:
 ---
 
 # Release Notes
-## 0.7.5
+
+## Unreleased
 
 ### What's Changed
-* Update Release Notes for 0.7.4 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2998](https://github.com/ag2ai/faststream/pull/2998){.external-link target="_blank"}
-* feat(redis): add batch stream message annotation by [@Sehat1137](https://github.com/Sehat1137){.external-link target="_blank"} in [#3007](https://github.com/ag2ai/faststream/pull/3007){.external-link target="_blank"}
-* Feature: correlation_id factory function at broker creation time, e.g. for ulids by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2995](https://github.com/ag2ai/faststream/pull/2995){.external-link target="_blank"}
-* fix: skip ack action on handler cancellation by [@Arseniy-Popov](https://github.com/Arseniy-Popov){.external-link target="_blank"} in [#3010](https://github.com/ag2ai/faststream/pull/3010){.external-link target="_blank"}
-* docs: expand RabbitMQ Streams guide by [@Himanshuagrawal4](https://github.com/Himanshuagrawal4){.external-link target="_blank"} in [#3006](https://github.com/ag2ai/faststream/pull/3006){.external-link target="_blank"}
-* fix(redis): consume existing entries in new groups by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2976](https://github.com/ag2ai/faststream/pull/2976){.external-link target="_blank"}
-* feat: Add mqtt dsn as alternative to direct url attributes by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#3012](https://github.com/ag2ai/faststream/pull/3012){.external-link target="_blank"}
-* feat(redis): add StreamSub declare option by [@DresdenGman](https://github.com/DresdenGman){.external-link target="_blank"} in [#3015](https://github.com/ag2ai/faststream/pull/3015){.external-link target="_blank"}
-* feat: #2693 Add ContextRepo composition by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2989](https://github.com/ag2ai/faststream/pull/2989){.external-link target="_blank"}
-* feat: Support MQTT Will message by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#3021](https://github.com/ag2ai/faststream/pull/3021){.external-link target="_blank"}
-* fix(asyncapi): upgrade react-component version to 3.1.5 by [@vvlrff](https://github.com/vvlrff){.external-link target="_blank"} in [#3022](https://github.com/ag2ai/faststream/pull/3022){.external-link target="_blank"}
-* fix: correct partition assignment strategy type hints by [@panguss](https://github.com/panguss){.external-link target="_blank"} in [#3025](https://github.com/ag2ai/faststream/pull/3025){.external-link target="_blank"}
-* Refactor `realign_keys` method in `faststream/response/response.py` by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2988](https://github.com/ag2ai/faststream/pull/2988){.external-link target="_blank"}
-* Feature: emulate Redis Stream PEL in TestRedisBroker to route messages to min_idle_time subscribers by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2934](https://github.com/ag2ai/faststream/pull/2934){.external-link target="_blank"}
-* refactor: split the address template from the broker address by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#3032](https://github.com/ag2ai/faststream/pull/3032){.external-link target="_blank"}
-* feat: render the Address template in the generated schema (#2357) by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#3037](https://github.com/ag2ai/faststream/pull/3037){.external-link target="_blank"}
-* fix: Prevent instant resubscribe loop on zmqtt 0.2.0 broken connection, add new options by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#3048](https://github.com/ag2ai/faststream/pull/3048){.external-link target="_blank"}
+
+#### Literal Braces in Addresses
+
+Addresses now support escaped braces (`{{` / `}}`) to represent literal `{` and `}` characters. This is useful when a queue, topic, or subject name legitimately contains braces (e.g., `cache{shard}`).
+
+**Breaking change:** An address containing a literal `{` must now be rewritten as `{{`. For example:
+
+```python
+# Before (silently treated as a parameter):
+@broker.subscriber("cache{shard}")
+
+# After (literal braces):
+@broker.subscriber("cache{{shard}}")
+```
+
+This change affects all brokers: Kafka, Confluent, RabbitMQ, Redis, NATS, and MQTT. MQTT already supported this syntax; other brokers now inherit the same behavior.
+
+* feat: support literal braces in addresses across all brokers by [@SammySN-car](https://github.com/SammySN-car){.external-link target="_blank"} in [#3034](https://github.com/ag2ai/faststream/pull/3034){.external-link target="_blank"}
+
+## 0.7.1
+
+### What's Changed
+
+TestBroker.__aenter__ was typed to return Broker | list[Broker]. That union is wrong for both usage shapes: mypy rejects .publish() on the single-broker result (the list arm has no such method) and rejects unpacking the multi-broker result (the Broker arm is not iterable).
+
+```python
+# Before — both lines fail under `mypy`:
+async with TestKafkaBroker(KafkaBroker()) as br:
+    await br.publish(None, "test")
+    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]
+
+async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
+    # error: "KafkaBroker" object is not iterable  [misc]
+    ...
+
+# After — mypy infers the precise type:
+async with TestKafkaBroker(KafkaBroker()) as br:
+    reveal_type(br)            # KafkaBroker
+    await br.publish(None, "test")
+
+async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
+    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
+    await br1.publish(None, "test")
+    await br2.publish(None, "test")
+```
+
+* fix(testing): type TestBroker context result via __init__ overloads by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2903](https://github.com/ag2ai/faststream/pull/2903){.external-link target="_blank"}
+* fix(docs): export *ParserType aliases at runtime by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2898](https://github.com/ag2ai/faststream/pull/2898){.external-link target="_blank"}
+* docs: Clarify FastStream description by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2901](https://github.com/ag2ai/faststream/pull/2901){.external-link target="_blank"}
+
+**Full Changelog**: [#0.7.0...0.7.1](https://github.com/ag2ai/faststream/compare/0.7.0...0.7.1){.external-link target="_blank"}
+
+## 0.7.0
+
+### What's Changed
+
+#### 🚀 [MQTT Support](https://faststream.ag2.ai/latest/mqtt/)
+
+FastStream now includes a full-featured MQTT broker, installable via `pip install faststream[mqtt]`. It supports wildcard topic filters, path parameter capture via `Path()`, QoS levels, per-subscriber `ack_policy`, and AsyncAPI schema generation.
+
+```python
+from faststream import FastStream, Path
+from faststream.mqtt import MQTTBroker, MQTTMessage, QoS
+
+broker = MQTTBroker("localhost:1883")
+app = FastStream(broker)
+
+@broker.subscriber(
+    "sensors/{device_id}/temperature",
+    qos=QoS.AT_LEAST_ONCE,
+)
+async def on_temperature(body: str, device_id: Annotated[str, Path()]) -> None:
+    print(device_id, body)
+
+@app.after_startup
+async def publish_demo() -> None:
+    await broker.publish(21.5, "sensors/room1/temperature", qos=QoS.AT_LEAST_ONCE)
+```
+
+---
+
+#### 🔀 Multi-broker Support
+
+A single FastStream application can now run multiple brokers at the same time. Pass all the brokers directly to the `FastStream` constructor — each keeps its own subscribers and publishers, and the app starts and stops all of them together. A common use case is bridging two systems: consume from one broker and re-publish to another.
+
+```python
+from faststream import FastStream
+from faststream.kafka import KafkaBroker
+from faststream.nats import NatsBroker
+
+kafka_broker = KafkaBroker("localhost:9092")
+nats_broker = NatsBroker("nats://localhost:4222")
+
+app = FastStream(kafka_broker, nats_broker)
+
+@kafka_broker.subscriber("incoming")
+@nats_broker.publisher("outgoing")
+async def from_kafka(msg: str) -> str:
+    # Bridge the message from Kafka to NATS
+    return msg
+
+@nats_broker.subscriber("outgoing")
+async def from_nats(msg: str) -> None:
+    print(f"Received from NATS: {msg}")
+```
+
+---
+
+#### 🗄️ Redis Cluster Support
+
+FastStream's Redis broker now has a dedicated `RedisClusterBroker` that connects to a Redis Cluster with automatic node discovery. It is a drop-in replacement for `RedisBroker` — just change the class name and point it at any cluster node.
+
+```python
+from faststream import FastStream
+from faststream.redis import RedisClusterBroker
+
+# A single URL is enough — the cluster auto-discovers all remaining nodes
+broker = RedisClusterBroker("redis://node1:7000")
+app = FastStream(broker)
+
+@broker.subscriber("events")
+async def handle_event(msg: str) -> None:
+    print(f"Received: {msg}")
+
+@app.after_startup
+async def publish_event() -> None:
+    await broker.publish("hello from cluster", "events")
+```
+
+---
+
+### ⚠️ Breaking Changes
+
+#### AsyncAPIRoute parameter renames (PR #2894)
+
+The `AsyncAPIRoute` class (used in ASGI hosting) has had two parameters renamed:
+
+| Before | After | Notes |
+|--------|-------|-------|
+| `try_it_out=False` | `try_it_out_path=None` | Disabling try-it-out now uses `None` instead of `False` |
+| `try_it_out_url="..."` | `try_it_out_path="..."` | Parameter renamed for clarity |
+
+```python
+# Before
+AsyncAPIRoute("/docs/asyncapi", try_it_out=False)
+AsyncAPIRoute("/docs/asyncapi", try_it_out_url="https://api.example.com/asyncapi/try")
+
+# After
+AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None)
+AsyncAPIRoute("/docs/asyncapi", try_it_out_path="https://api.example.com/asyncapi/try")
+```
+
+Additionally, a new `asyncapi_json_path` parameter was added (defaults to `<path>.json`) and its position in the signature changed — use keyword arguments to avoid surprises.
+
+---
+
+#### RabbitMQ: `durable=True` is now the default (PR #2892)
+
+`RabbitQueue` and `RabbitExchange` now default to `durable=True` (previously `False`). This aligns with RabbitMQ 4.3+ which disables transient non-exclusive queues by default.
+
+**Impact:** if you already have a transient (non-durable) queue or exchange of the same name declared on your broker, re-declaration will raise a `PRECONDITION_FAILED` mismatch error. To opt out, pass `durable=False` explicitly:
+
+```python
+from faststream.rabbit import RabbitQueue
+
+# To keep the old transient behavior:
+queue = RabbitQueue("my-queue", durable=False)
+```
+
+---
+
+#### Deprecated items removed
+## 0.7.2
+
+### What's Changed
+
+* feat(redis): add Redis Sentinel support by [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
+* feat: surface mqtt_connect_timeout on MQTTBroker by @Jsyvanen-algo in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* feat: add support async context managers in subscribers by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2576](https://github.com/ag2ai/faststream/pull/2576){.external-link target="_blank"}
+* fix: Forward group_instance_id from the FastAPI Kafka router by @00yhj22-debug in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
+* fix(confluent): publish(None) should send a real Kafka tombstone by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
+* fix(mqtt): installing mqtt by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2936](https://github.com/ag2ai/faststream/pull/2936){.external-link target="_blank"}
+* fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2935](https://github.com/ag2ai/faststream/pull/2935){.external-link target="_blank"}
+* docs: batch example by [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
+* docs: update Trendshift badge by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2905](https://github.com/ag2ai/faststream/pull/2905){.external-link target="_blank"}
+* docs: document Redis JSON fallback and non-FastStream interop by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2906](https://github.com/ag2ai/faststream/pull/2906){.external-link target="_blank"}
+* chore: add agent skills pinning repository development conventions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2912](https://github.com/ag2ai/faststream/pull/2912){.external-link target="_blank"}
 
 ### New Contributors
-* [@Himanshuagrawal4](https://github.com/Himanshuagrawal4){.external-link target="_blank"} made their first contribution in [#3006](https://github.com/ag2ai/faststream/pull/3006){.external-link target="_blank"}
-* [@DresdenGman](https://github.com/DresdenGman){.external-link target="_blank"} made their first contribution in [#3015](https://github.com/ag2ai/faststream/pull/3015){.external-link target="_blank"}
-* [@panguss](https://github.com/panguss){.external-link target="_blank"} made their first contribution in [#3025](https://github.com/ag2ai/faststream/pull/3025){.external-link target="_blank"}
+* @Jsyvanen-algo made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} made their first contribution in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
+* [@aradng](https://github.com/aradng){.external-link target="_blank"} made their first contribution in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
+* [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} made their first contribution in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
 
-**Full Changelog**: [#0.7.4...0.7.5](https://github.com/ag2ai/faststream/compare/0.7.4...0.7.5){.external-link target="_blank"}
+**Full Changelog**: [#0.7.1...0.7.2](https://github.com/ag2ai/faststream/compare/0.7.1...0.7.2){.external-link target="_blank"}
 
+## 0.7.1
+
+### What's Changed
+
+TestBroker.__aenter__ was typed to return Broker | list[Broker]. That union is wrong for both usage shapes: mypy rejects .publish() on the single-broker result (the list arm has no such method) and rejects unpacking the multi-broker result (the Broker arm is not iterable).
+
+```python
+# Before — both lines fail under `mypy`:
+async with TestKafkaBroker(KafkaBroker()) as br:
+    await br.publish(None, "test")
+    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]
+
+async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
+    # error: "KafkaBroker" object is not iterable  [misc]
+    ...
+
+# After — mypy infers the precise type:
+async with TestKafkaBroker(KafkaBroker()) as br:
+    reveal_type(br)            # KafkaBroker
+    await br.publish(None, "test")
+
+async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
+    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
+    await br1.publish(None, "test")
+    await br2.publish(None, "test")
+```
+
+* fix(testing): type TestBroker context result via __init__ overloads by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2903](https://github.com/ag2ai/faststream/pull/2903){.external-link target="_blank"}
+* fix(docs): export *ParserType aliases at runtime by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2898](https://github.com/ag2ai/faststream/pull/2898){.external-link target="_blank"}
+* docs: Clarify FastStream description by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2901](https://github.com/ag2ai/faststream/pull/2901){.external-link target="_blank"}
+
+
+
+**Full Changelog**: [#0.7.0...0.7.1](https://github.com/ag2ai/faststream/compare/0.7.0...0.7.1){.external-link target="_blank"}
+
+## 0.7.0
+
+### What's Changed
+
+#### 🚀 [MQTT Support](https://faststream.ag2.ai/latest/mqtt/)
+
+FastStream now includes a full-featured MQTT broker, installable via `pip install faststream[mqtt]`. It supports wildcard topic filters, path parameter capture via `Path()`, QoS levels, per-subscriber `ack_policy`, and AsyncAPI schema generation.
+
+```python
+from faststream import FastStream, Path
+from faststream.mqtt import MQTTBroker, MQTTMessage, QoS
+
+broker = MQTTBroker("localhost:1883")
+app = FastStream(broker)
+
+@broker.subscriber(
+    "sensors/{device_id}/temperature",
+    qos=QoS.AT_LEAST_ONCE,
+)
+async def on_temperature(body: str, device_id: Annotated[str, Path()]) -> None:
+    print(device_id, body)
+
+@app.after_startup
+async def publish_demo() -> None:
+    await broker.publish(21.5, "sensors/room1/temperature", qos=QoS.AT_LEAST_ONCE)
+```
+
+---
+
+#### 🔀 Multi-broker Support
+
+A single FastStream application can now run multiple brokers at the same time. Pass all the brokers directly to the `FastStream` constructor — each keeps its own subscribers and publishers, and the app starts and stops all of them together. A common use case is bridging two systems: consume from one broker and re-publish to another.
+
+```python
+from faststream import FastStream
+from faststream.kafka import KafkaBroker
+from faststream.nats import NatsBroker
+
+kafka_broker = KafkaBroker("localhost:9092")
+nats_broker = NatsBroker("nats://localhost:4222")
+
+app = FastStream(kafka_broker, nats_broker)
+
+@kafka_broker.subscriber("incoming")
+@nats_broker.publisher("outgoing")
+async def from_kafka(msg: str) -> str:
+    # Bridge the message from Kafka to NATS
+    return msg
+
+@nats_broker.subscriber("outgoing")
+async def from_nats(msg: str) -> None:
+    print(f"Received from NATS: {msg}")
+```
+
+---
+
+#### 🗄️ Redis Cluster Support
+
+FastStream's Redis broker now has a dedicated `RedisClusterBroker` that connects to a Redis Cluster with automatic node discovery. It is a drop-in replacement for `RedisBroker` — just change the class name and point it at any cluster node.
+
+```python
+from faststream import FastStream
+from faststream.redis import RedisClusterBroker
+
+# A single URL is enough — the cluster auto-discovers all remaining nodes
+broker = RedisClusterBroker("redis://node1:7000")
+app = FastStream(broker)
+
+@broker.subscriber("events")
+async def handle_event(msg: str) -> None:
+    print(f"Received: {msg}")
+
+@app.after_startup
+async def publish_event() -> None:
+    await broker.publish("hello from cluster", "events")
+```
+
+---
+
+### ⚠️ Breaking Changes
+
+#### AsyncAPIRoute parameter renames (PR #2894)
+
+The `AsyncAPIRoute` class (used in ASGI hosting) has had two parameters renamed:
+
+| Before | After | Notes |
+|--------|-------|-------|
+| `try_it_out=False` | `try_it_out_path=None` | Disabling try-it-out now uses `None` instead of `False` |
+| `try_it_out_url="..."` | `try_it_out_path="..."` | Parameter renamed for clarity |
+
+```python
+# Before
+AsyncAPIRoute("/docs/asyncapi", try_it_out=False)
+AsyncAPIRoute("/docs/asyncapi", try_it_out_url="https://api.example.com/asyncapi/try")
+
+# After
+AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None)
+AsyncAPIRoute("/docs/asyncapi", try_it_out_path="https://api.example.com/asyncapi/try")
+```
+
+Additionally, a new `asyncapi_json_path` parameter was added (defaults to `<path>.json`) and its position in the signature changed — use keyword arguments to avoid surprises.
+
+---
+
+#### RabbitMQ: `durable=True` is now the default (PR #2892)
+
+`RabbitQueue` and `RabbitExchange` now default to `durable=True` (previously `False`). This aligns with RabbitMQ 4.3+ which disables transient non-exclusive queues by default.
+
+**Impact:** if you already have a transient (non-durable) queue or exchange of the same name declared on your broker, re-declaration will raise a `PRECONDITION_FAILED` mismatch error. To opt out, pass `durable=False` explicitly:
+
+```python
+from faststream.rabbit import RabbitQueue
+
+# To keep the old transient behavior:
+queue = RabbitQueue("my-queue", durable=False)
+```
+
+---
+
+#### Deprecated items removed
+## 0.7.3
+
+### What's Changed
+* chore(rabbit): allow aio-pika 10 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2938](https://github.com/ag2ai/faststream/pull/2938){.external-link target="_blank"}
+* fix(testing): TestKafkaBroker should mock a real tombstone too by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2939](https://github.com/ag2ai/faststream/pull/2939){.external-link target="_blank"}
+* docs: fix path to app with export asyncapi by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2942](https://github.com/ag2ai/faststream/pull/2942){.external-link target="_blank"}
+* Feature/deprecate fastapi plugin by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2944](https://github.com/ag2ai/faststream/pull/2944){.external-link target="_blank"}
+* feat: add support zmqtt 0.0.6 by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2962](https://github.com/ag2ai/faststream/pull/2962){.external-link target="_blank"}
+* fix(fastapi): support FastAPI 0.140 Dependant by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2961](https://github.com/ag2ai/faststream/pull/2961){.external-link target="_blank"}
+* feat: add `typing.Required` hints for sentinel redis by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2955](https://github.com/ag2ai/faststream/pull/2955){.external-link target="_blank"}
+* refactor(redis): replace deprecated args: lib_name, lib_version to driver_in… by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2956](https://github.com/ag2ai/faststream/pull/2956){.external-link target="_blank"}
+* chore: bump redis-py version to 8.0.1 by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2952](https://github.com/ag2ai/faststream/pull/2952){.external-link target="_blank"}
+* feat(redis): add retry in redis integration (#2797) by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2954](https://github.com/ag2ai/faststream/pull/2954){.external-link target="_blank"}
+
+### New Contributors
+* [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} made their first contribution in [#2961](https://github.com/ag2ai/faststream/pull/2961){.external-link target="_blank"}
+
+**Full Changelog**: [#0.7.2...0.7.3](https://github.com/ag2ai/faststream/compare/0.7.2...0.7.3){.external-link target="_blank"}
+
+## 0.7.2
+
+### What's Changed
+
+* feat(redis): add Redis Sentinel support by [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
+* feat: surface mqtt_connect_timeout on MQTTBroker by @Jsyvanen-algo in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* feat: add support async context managers in subscribers by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2576](https://github.com/ag2ai/faststream/pull/2576){.external-link target="_blank"}
+* fix: Forward group_instance_id from the FastAPI Kafka router by @00yhj22-debug in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
+* fix(confluent): publish(None) should send a real Kafka tombstone by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
+* fix(mqtt): installing mqtt by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2936](https://github.com/ag2ai/faststream/pull/2936){.external-link target="_blank"}
+* fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2935](https://github.com/ag2ai/faststream/pull/2935){.external-link target="_blank"}
+* docs: batch example by [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
+* docs: update Trendshift badge by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2905](https://github.com/ag2ai/faststream/pull/2905){.external-link target="_blank"}
+* docs: document Redis JSON fallback and non-FastStream interop by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2906](https://github.com/ag2ai/faststream/pull/2906){.external-link target="_blank"}
+* chore: add agent skills pinning repository development conventions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2912](https://github.com/ag2ai/faststream/pull/2912){.external-link target="_blank"}
+
+### New Contributors
+* @Jsyvanen-algo made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} made their first contribution in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
+* [@aradng](https://github.com/aradng){.external-link target="_blank"} made their first contribution in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
+* [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} made their first contribution in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
+
+**Full Changelog**: [#0.7.1...0.7.2](https://github.com/ag2ai/faststream/compare/0.7.1...0.7.2){.external-link target="_blank"}
+
+## 0.7.1
+
+### What's Changed
+
+TestBroker.__aenter__ was typed to return Broker | list[Broker]. That union is wrong for both usage shapes: mypy rejects .publish() on the single-broker result (the list arm has no such method) and rejects unpacking the multi-broker result (the Broker arm is not iterable).
+
+```python
+# Before — both lines fail under `mypy`:
+async with TestKafkaBroker(KafkaBroker()) as br:
+    await br.publish(None, "test")
+    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]
+
+async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
+    # error: "KafkaBroker" object is not iterable  [misc]
+    ...
+
+# After — mypy infers the precise type:
+async with TestKafkaBroker(KafkaBroker()) as br:
+    reveal_type(br)            # KafkaBroker
+    await br.publish(None, "test")
+
+async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
+    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
+    await br1.publish(None, "test")
+    await br2.publish(None, "test")
+```
+
+* fix(testing): type TestBroker context result via __init__ overloads by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2903](https://github.com/ag2ai/faststream/pull/2903){.external-link target="_blank"}
+* fix(docs): export *ParserType aliases at runtime by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2898](https://github.com/ag2ai/faststream/pull/2898){.external-link target="_blank"}
+* docs: Clarify FastStream description by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2901](https://github.com/ag2ai/faststream/pull/2901){.external-link target="_blank"}
+
+
+
+**Full Changelog**: [#0.7.0...0.7.1](https://github.com/ag2ai/faststream/compare/0.7.0...0.7.1){.external-link target="_blank"}
+
+## 0.7.0
+
+### What's Changed
+
+#### 🚀 [MQTT Support](https://faststream.ag2.ai/latest/mqtt/)
+
+FastStream now includes a full-featured MQTT broker, installable via `pip install faststream[mqtt]`. It supports wildcard topic filters, path parameter capture via `Path()`, QoS levels, per-subscriber `ack_policy`, and AsyncAPI schema generation.
+
+```python
+from faststream import FastStream, Path
+from faststream.mqtt import MQTTBroker, MQTTMessage, QoS
+
+broker = MQTTBroker("localhost:1883")
+app = FastStream(broker)
+
+@broker.subscriber(
+    "sensors/{device_id}/temperature",
+    qos=QoS.AT_LEAST_ONCE,
+)
+async def on_temperature(body: str, device_id: Annotated[str, Path()]) -> None:
+    print(device_id, body)
+
+@app.after_startup
+async def publish_demo() -> None:
+    await broker.publish(21.5, "sensors/room1/temperature", qos=QoS.AT_LEAST_ONCE)
+```
+
+---
+
+#### 🔀 Multi-broker Support
+
+A single FastStream application can now run multiple brokers at the same time. Pass all the brokers directly to the `FastStream` constructor — each keeps its own subscribers and publishers, and the app starts and stops all of them together. A common use case is bridging two systems: consume from one broker and re-publish to another.
+
+```python
+from faststream import FastStream
+from faststream.kafka import KafkaBroker
+from faststream.nats import NatsBroker
+
+kafka_broker = KafkaBroker("localhost:9092")
+nats_broker = NatsBroker("nats://localhost:4222")
+
+app = FastStream(kafka_broker, nats_broker)
+
+@kafka_broker.subscriber("incoming")
+@nats_broker.publisher("outgoing")
+async def from_kafka(msg: str) -> str:
+    # Bridge the message from Kafka to NATS
+    return msg
+
+@nats_broker.subscriber("outgoing")
+async def from_nats(msg: str) -> None:
+    print(f"Received from NATS: {msg}")
+```
+
+---
+
+#### 🗄️ Redis Cluster Support
+
+FastStream's Redis broker now has a dedicated `RedisClusterBroker` that connects to a Redis Cluster with automatic node discovery. It is a drop-in replacement for `RedisBroker` — just change the class name and point it at any cluster node.
+
+```python
+from faststream import FastStream
+from faststream.redis import RedisClusterBroker
+
+# A single URL is enough — the cluster auto-discovers all remaining nodes
+broker = RedisClusterBroker("redis://node1:7000")
+app = FastStream(broker)
+
+@broker.subscriber("events")
+async def handle_event(msg: str) -> None:
+    print(f"Received: {msg}")
+
+@app.after_startup
+async def publish_event() -> None:
+    await broker.publish("hello from cluster", "events")
+```
+
+---
+
+### ⚠️ Breaking Changes
+
+#### AsyncAPIRoute parameter renames (PR #2894)
+
+The `AsyncAPIRoute` class (used in ASGI hosting) has had two parameters renamed:
+
+| Before | After | Notes |
+|--------|-------|-------|
+| `try_it_out=False` | `try_it_out_path=None` | Disabling try-it-out now uses `None` instead of `False` |
+| `try_it_out_url="..."` | `try_it_out_path="..."` | Parameter renamed for clarity |
+
+```python
+# Before
+AsyncAPIRoute("/docs/asyncapi", try_it_out=False)
+AsyncAPIRoute("/docs/asyncapi", try_it_out_url="https://api.example.com/asyncapi/try")
+
+# After
+AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None)
+AsyncAPIRoute("/docs/asyncapi", try_it_out_path="https://api.example.com/asyncapi/try")
+```
+
+Additionally, a new `asyncapi_json_path` parameter was added (defaults to `<path>.json`) and its position in the signature changed — use keyword arguments to avoid surprises.
+
+---
+
+#### RabbitMQ: `durable=True` is now the default (PR #2892)
+
+`RabbitQueue` and `RabbitExchange` now default to `durable=True` (previously `False`). This aligns with RabbitMQ 4.3+ which disables transient non-exclusive queues by default.
+
+**Impact:** if you already have a transient (non-durable) queue or exchange of the same name declared on your broker, re-declaration will raise a `PRECONDITION_FAILED` mismatch error. To opt out, pass `durable=False` explicitly:
+
+```python
+from faststream.rabbit import RabbitQueue
+
+# To keep the old transient behavior:
+queue = RabbitQueue("my-queue", durable=False)
+```
+
+---
+
+#### Deprecated items removed
 ## 0.7.4
 
 ### What's Changed
@@ -47,14 +572,14 @@ hide:
 * bug(kafka): [#2943] Added sinchronization for key's indexes by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2951](https://github.com/ag2ai/faststream/pull/2951){.external-link target="_blank"}
 * Update Release Notes for 0.7.3 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2964](https://github.com/ag2ai/faststream/pull/2964){.external-link target="_blank"}
 * fix (fastapi): skip init=False fields when copying Dependant by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2966](https://github.com/ag2ai/faststream/pull/2966){.external-link target="_blank"}
-* feat(rabbit): support EXTERNAL authentication by [@WellFREEzZ](https://github.com/WellFREEzZ){.external-link target="_blank"} in [#2953](https://github.com/ag2ai/faststream/pull/2953){.external-link target="_blank"}
+* feat(rabbit): support EXTERNAL authentication by [@WellFREEEzZ](https://github.com/WellFREEzZ){.external-link target="_blank"} in [#2953](https://github.com/ag2ai/faststream/pull/2953){.external-link target="_blank"}
 * fix(cli): make supervisor signal handling portable by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2967](https://github.com/ag2ai/faststream/pull/2967){.external-link target="_blank"}
 * refactor: use queue fixture and RedisClusterTestcaseConfig by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2973](https://github.com/ag2ai/faststream/pull/2973){.external-link target="_blank"}
 * refactor: typing.Iterator has been replaced by typing.Generator in al… by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2970](https://github.com/ag2ai/faststream/pull/2970){.external-link target="_blank"}
 * feat: #2683 Add `ws_connection_headers` and `reconnect_to_server_handler` params" by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2971](https://github.com/ag2ai/faststream/pull/2971){.external-link target="_blank"}
 * refactor: using a fixture event, instead of creating an asyncio.Event by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2972](https://github.com/ag2ai/faststream/pull/2972){.external-link target="_blank"}
 * refactor: fix type hints for BaseTestcaseConfig.patch_broker by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2974](https://github.com/ag2ai/faststream/pull/2974){.external-link target="_blank"}
-* chore(deps): bump the github-actions group with 5 updates by [@dependabot](https://github.com/dependabot){.external-link target="_blank"}[bot] in [#2985](https://github.com/ag2ai/faststream/pull/2985){.external-link target="_blank"}
+* chore(deps): bump the github-actions group with 5 updates by @dependabot[bot] in [#2985](https://github.com/ag2ai/faststream/pull/2985){.external-link target="_blank"}
 * bug(kafka/confluent): batch per-message key alignment raises when a Response isn't first, or on duplicate bodies by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2983](https://github.com/ag2ai/faststream/pull/2983){.external-link target="_blank"}
 * fix: prevent handler exceptions leaking under AnyIO by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2984](https://github.com/ag2ai/faststream/pull/2984){.external-link target="_blank"}
 * bug(nats): [#2674] faststream raises authentication error by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2981](https://github.com/ag2ai/faststream/pull/2981){.external-link target="_blank"}
@@ -62,7 +587,7 @@ hide:
 * chore: Bump zmqtt to 0.1 and fix compat by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2997](https://github.com/ag2ai/faststream/pull/2997){.external-link target="_blank"}
 
 ### New Contributors
-* [@WellFREEzZ](https://github.com/WellFREEzZ){.external-link target="_blank"} made their first contribution in [#2953](https://github.com/ag2ai/faststream/pull/2953){.external-link target="_blank"}
+* [@WellFREEEzZ](https://github.com/WellFREEzZ){.external-link target="_blank"} made their first contribution in [#2953](https://github.com/ag2ai/faststream/pull/2953){.external-link target="_blank"}
 * [@arimu1](https://github.com/arimu1){.external-link target="_blank"} made their first contribution in [#2994](https://github.com/ag2ai/faststream/pull/2994){.external-link target="_blank"}
 
 **Full Changelog**: [#0.7.3...0.7.4](https://github.com/ag2ai/faststream/compare/0.7.3...0.7.4){.external-link target="_blank"}
@@ -91,9 +616,9 @@ hide:
 ### What's Changed
 
 * feat(redis): add Redis Sentinel support by [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-* feat: surface mqtt_connect_timeout on MQTTBroker by [@Jsyvanen-algo](https://github.com/Jsyvanen-algo){.external-link target="_blank"} in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* feat: surface mqtt_connect_timeout on MQTTBroker by @Jsyvanen-algo in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
 * feat: add support async context managers in subscribers by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2576](https://github.com/ag2ai/faststream/pull/2576){.external-link target="_blank"}
-* fix: Forward group_instance_id from the FastAPI Kafka router by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
+* fix: Forward group_instance_id from the FastAPI Kafka router by @00yhj22-debug in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
 * fix(confluent): publish(None) should send a real Kafka tombstone by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
 * fix(mqtt): installing mqtt by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2936](https://github.com/ag2ai/faststream/pull/2936){.external-link target="_blank"}
 * fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2935](https://github.com/ag2ai/faststream/pull/2935){.external-link target="_blank"}
@@ -103,7 +628,7 @@ hide:
 * chore: add agent skills pinning repository development conventions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2912](https://github.com/ag2ai/faststream/pull/2912){.external-link target="_blank"}
 
 ### New Contributors
-* [@Jsyvanen-algo](https://github.com/Jsyvanen-algo){.external-link target="_blank"} made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* @Jsyvanen-algo made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
 * [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} made their first contribution in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
 * [@aradng](https://github.com/aradng){.external-link target="_blank"} made their first contribution in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
 * [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} made their first contribution in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
@@ -275,70 +800,295 @@ The following APIs that were deprecated in earlier 0.x releases have been fully 
 
 #### Features
 
-* feat: FastStream[mqtt] by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2819](https://github.com/ag2ai/faststream/pull/2819){.external-link target="_blank"}
-* feat: support broker-level ack_policy with per-subscriber override by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2827](https://github.com/ag2ai/faststream/pull/2827){.external-link target="_blank"}
-* feat: codec wiring unification by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2841](https://github.com/ag2ai/faststream/pull/2841){.external-link target="_blank"}
-* feat: add mqtt path support by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2873](https://github.com/ag2ai/faststream/pull/2873){.external-link target="_blank"}
-* feat: expose client_rack option on the Kafka broker by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2871](https://github.com/ag2ai/faststream/pull/2871){.external-link target="_blank"}
-* feat: allow aiokafka 0.14 by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2884](https://github.com/ag2ai/faststream/pull/2884){.external-link target="_blank"}
-* feat: add fastapi mqtt router by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2887](https://github.com/ag2ai/faststream/pull/2887){.external-link target="_blank"}
-* feat: add consumer_only flag to KafkaBroker by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2883](https://github.com/ag2ai/faststream/pull/2883){.external-link target="_blank"}
-* feat: add Redis Cluster broker support by [@powersemmi](https://github.com/powersemmi){.external-link target="_blank"} in [#2854](https://github.com/ag2ai/faststream/pull/2854){.external-link target="_blank"}
-* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2850](https://github.com/ag2ai/faststream/pull/2850){.external-link target="_blank"}
-* feat: add multibrokers support by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2867](https://github.com/ag2ai/faststream/pull/2867){.external-link target="_blank"}
-* feat: add json endpoint and fix content-type header by [@Cool-Cat09](https://github.com/Cool-Cat09){.external-link target="_blank"} in [#2894](https://github.com/ag2ai/faststream/pull/2894){.external-link target="_blank"}
+* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
+* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
+* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
+* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
+* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
+* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
+* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
+* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
+* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
+* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
+* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
+* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
 
 #### Bug Fixes
 
-* fix: include pattern subscribers in AsyncAPI specification by [@aazmv](https://github.com/aazmv){.external-link target="_blank"} in [#2813](https://github.com/ag2ai/faststream/pull/2813){.external-link target="_blank"}
-* fix: cli preserve import errors by [@vovkka](https://github.com/vovkka){.external-link target="_blank"} in [#2817](https://github.com/ag2ai/faststream/pull/2817){.external-link target="_blank"}
-* fix: security parsing for mqtt broker by [@lemmehoop](https://github.com/lemmehoop){.external-link target="_blank"} in [#2832](https://github.com/ag2ai/faststream/pull/2832){.external-link target="_blank"}
-* fix: propagate outer context to nested StreamRouter on include by [@lesnik512](https://github.com/lesnik512){.external-link target="_blank"} in [#2828](https://github.com/ag2ai/faststream/pull/2828){.external-link target="_blank"}
-* fix: parsing pydantic models by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2847](https://github.com/ag2ai/faststream/pull/2847){.external-link target="_blank"}
-* fix: try-it-out request timeout and NATS fake subscriber stream by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2853](https://github.com/ag2ai/faststream/pull/2853){.external-link target="_blank"}
-* fix: handle NOGROUP error on Redis stream subscriber by [@powersemmi](https://github.com/powersemmi){.external-link target="_blank"} in [#2855](https://github.com/ag2ai/faststream/pull/2855){.external-link target="_blank"}
-* fix: logger not passed to Confluent Producer and AdminClient by [@mara-werils](https://github.com/mara-werils){.external-link target="_blank"} in [#2859](https://github.com/ag2ai/faststream/pull/2859){.external-link target="_blank"}
-* fix: encode unsafe AsyncAPI reference path parts, including {} and / by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2872](https://github.com/ag2ai/faststream/pull/2872){.external-link target="_blank"}
-* fix: register POST {schema_url}/try for AsyncAPI try-it-out by [@sfrangulov](https://github.com/sfrangulov){.external-link target="_blank"} in [#2876](https://github.com/ag2ai/faststream/pull/2876){.external-link target="_blank"}
-* fix: consistent hashing and equality for RabbitMQ schemas by [@RinZ27](https://github.com/RinZ27){.external-link target="_blank"} in [#2796](https://github.com/ag2ai/faststream/pull/2796){.external-link target="_blank"}
-* fix: default RabbitQueue and RabbitExchange to durable=True by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2892](https://github.com/ag2ai/faststream/pull/2892){.external-link target="_blank"}
+* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
+* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
+* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
+* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
+* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
+* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
+* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
+* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
+* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
+* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
+* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
+* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
 
 #### Documentation
 
-* docs: images generation in release notes by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2792](https://github.com/ag2ai/faststream/pull/2792){.external-link target="_blank"}
-* docs: add multiple topics registration with a single call by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2814](https://github.com/ag2ai/faststream/pull/2814){.external-link target="_blank"}
-* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2815](https://github.com/ag2ai/faststream/pull/2815){.external-link target="_blank"}
-* docs: change polling_interval units (seconds -> milliseconds) by [@MikhailWar](https://github.com/MikhailWar){.external-link target="_blank"} in [#2821](https://github.com/ag2ai/faststream/pull/2821){.external-link target="_blank"}
-* docs: document per-message attributes via KafkaPublishMessage in publish_batch by [@Bazarovinc](https://github.com/Bazarovinc){.external-link target="_blank"} in [#2851](https://github.com/ag2ai/faststream/pull/2851){.external-link target="_blank"}
-* docs: cover mqtt examples by tests by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2888](https://github.com/ag2ai/faststream/pull/2888){.external-link target="_blank"}
-* docs: add multiple brokers support page by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2896](https://github.com/ag2ai/faststream/pull/2896){.external-link target="_blank"}
+* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
+* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
+* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
+* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
+* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
+* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
+* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
 
 #### Chore / CI
 
-* chore: test basic 3.14 by [@vvlrff](https://github.com/vvlrff){.external-link target="_blank"} in [#2795](https://github.com/ag2ai/faststream/pull/2795){.external-link target="_blank"}
-* chore: prepare 0.7.0 update by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2822](https://github.com/ag2ai/faststream/pull/2822){.external-link target="_blank"}
-* chore: add MQTT code ownership for borisalekseev by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2825](https://github.com/ag2ai/faststream/pull/2825){.external-link target="_blank"}
-* chore: add MQTT AsyncAPI tests by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2830](https://github.com/ag2ai/faststream/pull/2830){.external-link target="_blank"}
-* chore: parser codec protocols by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2839](https://github.com/ag2ai/faststream/pull/2839){.external-link target="_blank"}
-* chore: merge schema by [@aligeromachine](https://github.com/aligeromachine){.external-link target="_blank"} in [#2849](https://github.com/ag2ai/faststream/pull/2849){.external-link target="_blank"}
+* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
+* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
+* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
+* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
+* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
+* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
 
 ### New Contributors
-* [@aazmv](https://github.com/aazmv){.external-link target="_blank"} made their first contribution in [#2813](https://github.com/ag2ai/faststream/pull/2813){.external-link target="_blank"}
-* [@vovkka](https://github.com/vovkka){.external-link target="_blank"} made their first contribution in [#2817](https://github.com/ag2ai/faststream/pull/2817){.external-link target="_blank"}
-* [@benaduo](https://github.com/benaduo){.external-link target="_blank"} made their first contribution in [#2814](https://github.com/ag2ai/faststream/pull/2814){.external-link target="_blank"}
-* [@MikhailWar](https://github.com/MikhailWar){.external-link target="_blank"} made their first contribution in [#2821](https://github.com/ag2ai/faststream/pull/2821){.external-link target="_blank"}
-* [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} made their first contribution in [#2827](https://github.com/ag2ai/faststream/pull/2827){.external-link target="_blank"}
-* [@lemmehoop](https://github.com/lemmehoop){.external-link target="_blank"} made their first contribution in [#2832](https://github.com/ag2ai/faststream/pull/2832){.external-link target="_blank"}
-* [@lesnik512](https://github.com/lesnik512){.external-link target="_blank"} made their first contribution in [#2828](https://github.com/ag2ai/faststream/pull/2828){.external-link target="_blank"}
-* [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} made their first contribution in [#2847](https://github.com/ag2ai/faststream/pull/2847){.external-link target="_blank"}
-* [@Bazarovinc](https://github.com/Bazarovinc){.external-link target="_blank"} made their first contribution in [#2851](https://github.com/ag2ai/faststream/pull/2851){.external-link target="_blank"}
-* [@mara-werils](https://github.com/mara-werils){.external-link target="_blank"} made their first contribution in [#2859](https://github.com/ag2ai/faststream/pull/2859){.external-link target="_blank"}
-* [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} made their first contribution in [#2871](https://github.com/ag2ai/faststream/pull/2871){.external-link target="_blank"}
-* [@sfrangulov](https://github.com/sfrangulov){.external-link target="_blank"} made their first contribution in [#2876](https://github.com/ag2ai/faststream/pull/2876){.external-link target="_blank"}
-* [@RinZ27](https://github.com/RinZ27){.external-link target="_blank"} made their first contribution in [#2796](https://github.com/ag2ai/faststream/pull/2796){.external-link target="_blank"}
-* [@Cool-Cat09](https://github.com/Cool-Cat09){.external-link target="_blank"} made their first contribution in [#2894](https://github.com/ag2ai/faststream/pull/2894){.external-link target="_blank"}
+* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
+* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
+* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
+* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
+* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
+* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
+* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
+* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
+* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
+* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
+* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
+* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
+* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
+* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
 
-**Full Changelog**: [#0.6.7...0.7.0](https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0){.external-link target="_blank"}
+**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
+
+
+The following APIs that were deprecated in earlier 0.x releases have been fully removed in 0.7.0:
+
+- **Publisher/subscriber-level middlewares** — use broker-level or app-level middlewares instead.
+- **`ack_first`**, **`no_ack`** and related subscriber options — replaced by `ack_policy=AckPolicy.*`
+- **`RedisJSONMessageParser`** — removed. All Redis services must now use the binary message format.
+- **`broker.close()`** — removed. Use `broker.stop()` instead.
+
+#### Features
+
+* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
+* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
+* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
+* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
+* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
+* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
+* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
+* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
+* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
+* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
+* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
+* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
+
+#### Bug Fixes
+
+* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
+* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
+* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
+* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
+* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
+* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
+* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
+* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
+* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
+* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
+* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
+* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
+
+#### Documentation
+
+* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
+* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
+* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
+* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
+* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
+* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
+* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
+
+#### Chore / CI
+
+* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
+* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
+* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
+* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
+* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
+* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
+
+### New Contributors
+* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
+* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
+* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
+* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
+* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
+* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
+* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
+* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
+* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
+* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
+* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
+* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
+* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
+* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
+
+**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
+
+
+The following APIs that were deprecated in earlier 0.x releases have been fully removed in 0.7.0:
+
+- **Publisher/subscriber-level middlewares** — use broker-level or app-level middlewares instead.
+- **`ack_first`**, **`no_ack`** and related subscriber options — replaced by `ack_policy=AckPolicy.*`
+- **`RedisJSONMessageParser`** — removed. All Redis services must now use the binary message format.
+- **`broker.close()`** — removed. Use `broker.stop()` instead.
+
+#### Features
+
+* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
+* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
+* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
+* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
+* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
+* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
+* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
+* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
+* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
+* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
+* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
+* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
+
+#### Bug Fixes
+
+* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
+* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
+* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
+* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
+* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
+* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
+* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
+* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
+* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
+* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
+* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
+* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
+
+#### Documentation
+
+* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
+* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
+* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
+* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
+* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
+* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
+* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
+
+#### Chore / CI
+
+* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
+* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
+* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
+* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
+* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
+* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
+
+### New Contributors
+* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
+* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
+* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
+* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
+* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
+* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
+* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
+* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
+* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
+* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
+* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
+* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
+* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
+* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
+
+**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
+
+
+The following APIs that were deprecated in earlier 0.x releases have been fully removed in 0.7.0:
+
+- **Publisher/subscriber-level middlewares** — use broker-level or app-level middlewares instead.
+- **`ack_first`**, **`no_ack`** and related subscriber options — replaced by `ack_policy=AckPolicy.*`
+- **`RedisJSONMessageParser`** — removed. All Redis services must now use the binary message format.
+- **`broker.close()`** — removed. Use `broker.stop()` instead.
+
+#### Features
+
+* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
+* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
+* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
+* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
+* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
+* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
+* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
+* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
+* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
+* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
+* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
+* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
+
+#### Bug Fixes
+
+* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
+* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
+* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
+* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
+* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
+* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
+* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
+* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
+* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
+* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
+* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
+* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
+
+#### Documentation
+
+* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
+* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
+* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
+* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
+* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
+* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
+* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
+
+#### Chore / CI
+
+* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
+* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
+* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
+* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
+* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
+* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
+
+### New Contributors
+* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
+* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
+* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
+* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
+* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
+* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
+* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
+* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
+* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
+* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
+* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
+* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
+* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
+* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
+
+**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
 
 ## 0.7.0rc1
 
@@ -361,7 +1111,7 @@ The following APIs that were deprecated in earlier 0.x releases have been fully 
 
 Just two main changes:
 
-1. `from faststream.mqtt import MQTTBroker` (thanks [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"})
+1. `from faststream.mqtt import MQTTBroker` (thanks @borisalekseev)
 2. All deprecations removed:
     - publisher/subscriber-level middlewares
     - ack_policy now replaces several deprecated options
@@ -379,9 +1129,9 @@ uv add --pre "faststream[mqtt]==0.7.0rc0"
 We will release a stable version as soon as we test `MQTTBroker` with production services (in a few weeks).
 
 * feat: FastStream[mqtt] by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2819](https://github.com/ag2ai/faststream/pull/2819){.external-link target="_blank"}
+* docs: fix images generation in release notes by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2792](https://github.com/ag2ai/faststream/pull/2792){.external-link target="_blank"}
 * fix: include pattern subscribers in AsyncAPI specification by [@aazmv](https://github.com/aazmv){.external-link target="_blank"} in [#2813](https://github.com/ag2ai/faststream/pull/2813){.external-link target="_blank"}
 * fix: cli preserve import errors by [@vovkka](https://github.com/vovkka){.external-link target="_blank"} in [#2817](https://github.com/ag2ai/faststream/pull/2817){.external-link target="_blank"}
-* docs: fix images generation in release notes by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2792](https://github.com/ag2ai/faststream/pull/2792){.external-link target="_blank"}
 * docs: add multiple topics registration with a single call by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2814](https://github.com/ag2ai/faststream/pull/2814){.external-link target="_blank"}
 * docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2815](https://github.com/ag2ai/faststream/pull/2815){.external-link target="_blank"}
 * docs: change polling_interval units (seconds -> milliseconds) by [@MikhailWar](https://github.com/MikhailWar){.external-link target="_blank"} in [#2821](https://github.com/ag2ai/faststream/pull/2821){.external-link target="_blank"}

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -47,6 +47,11 @@ class Address:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.template!r})"
 
+    @property
+    def declared_address(self) -> str:
+        """The address as the broker sees it, with literal braces restored."""
+        return self.template.replace("{{", "{").replace("}}", "}")
+
     def __bool__(self) -> bool:
         """Whether an address was declared at all."""
         return bool(self.template)
@@ -55,6 +60,11 @@ class Address:
     def broker_address(self) -> str:
         """The address as it reaches the broker, e.g. `logs.*` for `logs.{level}`."""
         return self._compile()[1]
+
+    @property
+    def declared_address(self) -> str:
+        """The declared address with literal braces restored, e.g. `cache{shard}.{level}`."""
+        return self.template.replace("{{", "{").replace("}}", "}")
 
     @property
     def regex(self) -> Pattern[str] | None:

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -62,11 +62,6 @@ class Address:
         return self._compile()[1]
 
     @property
-    def declared_address(self) -> str:
-        """The declared address with literal braces restored, e.g. `cache{shard}.{level}`."""
-        return self.template.replace("{{", "{").replace("}}", "}")
-
-    @property
     def regex(self) -> Pattern[str] | None:
         """Captures each Path parameter out of an incoming message's address."""
         return self._compile()[0]

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -116,7 +116,12 @@ def compile_path(
     for match in PARAM_REGEX.finditer(path):
         param_name = match.groups("str")[0]
 
-        path_regex += re.escape(path[idx : match.start()]).replace(ESCAPED_LEFT_BRACE, "{").replace(ESCAPED_RIGHT_BRACE, "}")
+        path_regex += (
+            re
+            .escape(path[idx : match.start()])
+            .replace(ESCAPED_LEFT_BRACE, "{")
+            .replace(ESCAPED_RIGHT_BRACE, "}")
+        )
         path_regex += f"(?P<{param_name.replace('+', '')}>{param_regex})"
 
         original_path += path[idx : match.start()]
@@ -138,11 +143,19 @@ def compile_path(
     if idx == 0:
         regex = None
     else:
-        path_regex += re.escape(path[idx:]).replace(ESCAPED_LEFT_BRACE, "{").replace(ESCAPED_RIGHT_BRACE, "}") + "$"
+        path_regex += (
+            re
+            .escape(path[idx:])
+            .replace(ESCAPED_LEFT_BRACE, "{")
+            .replace(ESCAPED_RIGHT_BRACE, "}")
+            + "$"
+        )
         regex = re.compile(patch_regex(path_regex))
 
     original_path += path[idx:]
-    original_path = original_path.replace(ESCAPED_LEFT_BRACE, "{").replace(ESCAPED_RIGHT_BRACE, "}")
+    original_path = original_path.replace(ESCAPED_LEFT_BRACE, "{").replace(
+        ESCAPED_RIGHT_BRACE, "}"
+    )
     return regex, original_path
 
 

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from faststream.exceptions import SetupError
 
-PARAM_REGEX = re.compile(r"{([a-zA-Z0-9_]+)}")
+PARAM_REGEX = re.compile(r"(?<!\{)\{([a-zA-Z0-9_]+)\}(?!\})")
 
 
 @dataclass(frozen=True)
@@ -79,6 +79,26 @@ class Address:
         return self._compiled
 
 
+_ESCAPED_LEFT = "__faststream_escaped_left__"
+_ESCAPED_RIGHT = "__faststream_escaped_right__"
+
+
+def _escape_literal_braces(path: str) -> str:
+    result = ""
+    idx = 0
+    while idx < len(path):
+        if path.startswith("{{", idx):
+            result += _ESCAPED_LEFT
+            idx += 2
+        elif path.startswith("}}", idx):
+            result += _ESCAPED_RIGHT
+            idx += 2
+        else:
+            result += path[idx]
+            idx += 1
+    return result
+
+
 def compile_path(
     path: str,
     replace_symbol: str,
@@ -86,6 +106,7 @@ def compile_path(
     *,
     param_regex: str = "[^.]+",
 ) -> tuple[Pattern[str] | None, str]:
+    path = _escape_literal_braces(path)
     path_regex = "^.*?"
     original_path = ""
 
@@ -95,7 +116,7 @@ def compile_path(
     for match in PARAM_REGEX.finditer(path):
         param_name = match.groups("str")[0]
 
-        path_regex += re.escape(path[idx : match.start()])
+        path_regex += re.escape(path[idx : match.start()]).replace(_ESCAPED_LEFT, "{").replace(_ESCAPED_RIGHT, "}")
         path_regex += f"(?P<{param_name.replace('+', '')}>{param_regex})"
 
         original_path += path[idx : match.start()]
@@ -117,10 +138,11 @@ def compile_path(
     if idx == 0:
         regex = None
     else:
-        path_regex += re.escape(path[idx:]) + "$"
+        path_regex += re.escape(path[idx:]).replace(_ESCAPED_LEFT, "{").replace(_ESCAPED_RIGHT, "}") + "$"
         regex = re.compile(patch_regex(path_regex))
 
     original_path += path[idx:]
+    original_path = original_path.replace(_ESCAPED_LEFT, "{").replace(_ESCAPED_RIGHT, "}")
     return regex, original_path
 
 

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -79,8 +79,8 @@ class Address:
         return self._compiled
 
 
-_ESCAPED_LEFT = "__faststream_escaped_left__"
-_ESCAPED_RIGHT = "__faststream_escaped_right__"
+ESCAPED_LEFT_BRACE = "__faststream_escaped_left__"
+ESCAPED_RIGHT_BRACE = "__faststream_escaped_right__"
 
 
 def _escape_literal_braces(path: str) -> str:
@@ -88,10 +88,10 @@ def _escape_literal_braces(path: str) -> str:
     idx = 0
     while idx < len(path):
         if path.startswith("{{", idx):
-            result += _ESCAPED_LEFT
+            result += ESCAPED_LEFT_BRACE
             idx += 2
         elif path.startswith("}}", idx):
-            result += _ESCAPED_RIGHT
+            result += ESCAPED_RIGHT_BRACE
             idx += 2
         else:
             result += path[idx]
@@ -116,7 +116,7 @@ def compile_path(
     for match in PARAM_REGEX.finditer(path):
         param_name = match.groups("str")[0]
 
-        path_regex += re.escape(path[idx : match.start()]).replace(_ESCAPED_LEFT, "{").replace(_ESCAPED_RIGHT, "}")
+        path_regex += re.escape(path[idx : match.start()]).replace(ESCAPED_LEFT_BRACE, "{").replace(ESCAPED_RIGHT_BRACE, "}")
         path_regex += f"(?P<{param_name.replace('+', '')}>{param_regex})"
 
         original_path += path[idx : match.start()]
@@ -138,11 +138,11 @@ def compile_path(
     if idx == 0:
         regex = None
     else:
-        path_regex += re.escape(path[idx:]).replace(_ESCAPED_LEFT, "{").replace(_ESCAPED_RIGHT, "}") + "$"
+        path_regex += re.escape(path[idx:]).replace(ESCAPED_LEFT_BRACE, "{").replace(ESCAPED_RIGHT_BRACE, "}") + "$"
         regex = re.compile(patch_regex(path_regex))
 
     original_path += path[idx:]
-    original_path = original_path.replace(_ESCAPED_LEFT, "{").replace(_ESCAPED_RIGHT, "}")
+    original_path = original_path.replace(ESCAPED_LEFT_BRACE, "{").replace(ESCAPED_RIGHT_BRACE, "}")
     return regex, original_path
 
 

--- a/faststream/mqtt/path.py
+++ b/faststream/mqtt/path.py
@@ -1,9 +1,9 @@
 from re import Pattern
 
 from faststream._internal.utils.path import (
+    ESCAPED_LEFT_BRACE,
+    ESCAPED_RIGHT_BRACE,
     PARAM_REGEX,
-    _ESCAPED_LEFT,
-    _ESCAPED_RIGHT,
     compile_path,
 )
 from faststream.exceptions import SetupError
@@ -44,8 +44,8 @@ def compile_mqtt_path(path: str) -> tuple[Pattern[str] | None, str]:
 def _patch_mqtt_regex(regex: str) -> str:
     return (
         regex
-        .replace(_ESCAPED_LEFT, r"\{")
-        .replace(_ESCAPED_RIGHT, r"\}")
+        .replace(ESCAPED_LEFT_BRACE, r"\{")
+        .replace(ESCAPED_RIGHT_BRACE, r"\}")
         .replace(r"\+", "[^/]+")
         .replace(r"/\#", "(?:/.*)?")
         .replace(r"\#", ".*")

--- a/faststream/mqtt/path.py
+++ b/faststream/mqtt/path.py
@@ -1,13 +1,13 @@
-import re
 from re import Pattern
 
-from faststream._internal.utils.path import compile_path
+from faststream._internal.utils.path import (
+    _ESCAPED_LEFT,
+    _ESCAPED_RIGHT,
+    compile_path,
+)
 from faststream.exceptions import SetupError
 
-MQTT_PARAM_REGEX = re.compile(r"(?<!\{)\{([a-zA-Z0-9_]+)\}(?!\})")
 MQTT_TOPIC_BOUNDARIES = {"", "/"}
-_ESCAPED_LEFT_BRACE = "__faststream_mqtt_escaped_left_brace__"
-_ESCAPED_RIGHT_BRACE = "__faststream_mqtt_escaped_right_brace__"
 
 
 def compile_mqtt_path(path: str) -> tuple[Pattern[str] | None, str]:
@@ -18,13 +18,13 @@ def compile_mqtt_path(path: str) -> tuple[Pattern[str] | None, str]:
     supported; use ``MQTTMessage.raw_message.topic`` when the full topic is
     needed.
     """
-    escaped_path = _escape_literal_braces(path)
+    from faststream._internal.utils.path import PARAM_REGEX
 
-    for match in MQTT_PARAM_REGEX.finditer(escaped_path):
+    for match in PARAM_REGEX.finditer(path):
         name = match.group(1)
         start, end = match.start(), match.end()
-        before = escaped_path[start - 1] if start > 0 else ""
-        after = escaped_path[end] if end < len(escaped_path) else ""
+        before = path[start - 1] if start > 0 else ""
+        after = path[end] if end < len(path) else ""
 
         if before not in MQTT_TOPIC_BOUNDARIES or after not in MQTT_TOPIC_BOUNDARIES:
             msg = (
@@ -34,39 +34,19 @@ def compile_mqtt_path(path: str) -> tuple[Pattern[str] | None, str]:
             raise SetupError(msg)
 
     path_regex, mqtt_topic = compile_path(
-        escaped_path,
+        path,
         replace_symbol="+",
         patch_regex=_patch_mqtt_regex,
         param_regex="[^/]+",
     )
-    return path_regex, _restore_literal_braces(mqtt_topic)
-
-
-def _escape_literal_braces(path: str) -> str:
-    result = ""
-    idx = 0
-    while idx < len(path):
-        if path.startswith("{{", idx):
-            result += _ESCAPED_LEFT_BRACE
-            idx += 2
-        elif path.startswith("}}", idx):
-            result += _ESCAPED_RIGHT_BRACE
-            idx += 2
-        else:
-            result += path[idx]
-            idx += 1
-    return result
-
-
-def _restore_literal_braces(path: str) -> str:
-    return path.replace(_ESCAPED_LEFT_BRACE, "{").replace(_ESCAPED_RIGHT_BRACE, "}")
+    return path_regex, mqtt_topic
 
 
 def _patch_mqtt_regex(regex: str) -> str:
     return (
         regex
-        .replace(_ESCAPED_LEFT_BRACE, r"\{")
-        .replace(_ESCAPED_RIGHT_BRACE, r"\}")
+        .replace(_ESCAPED_LEFT, r"\{")
+        .replace(_ESCAPED_RIGHT, r"\}")
         .replace(r"\+", "[^/]+")
         .replace(r"/\#", "(?:/.*)?")
         .replace(r"\#", ".*")

--- a/faststream/mqtt/path.py
+++ b/faststream/mqtt/path.py
@@ -1,6 +1,7 @@
 from re import Pattern
 
 from faststream._internal.utils.path import (
+    PARAM_REGEX,
     _ESCAPED_LEFT,
     _ESCAPED_RIGHT,
     compile_path,
@@ -18,8 +19,6 @@ def compile_mqtt_path(path: str) -> tuple[Pattern[str] | None, str]:
     supported; use ``MQTTMessage.raw_message.topic`` when the full topic is
     needed.
     """
-    from faststream._internal.utils.path import PARAM_REGEX
-
     for match in PARAM_REGEX.finditer(path):
         name = match.group(1)
         start, end = match.start(), match.end()

--- a/faststream/mqtt/publisher/specification.py
+++ b/faststream/mqtt/publisher/specification.py
@@ -16,7 +16,7 @@ class MQTTPublisherSpecification(
 ):
     @property
     def topic(self) -> str:
-        return f"{self._outer_config.prefix}{self.config.topic}"
+        return f"{self._outer_config.prefix}{self.config.topic.replace('{{', '{').replace('}}', '}')}"
 
     @property
     def name(self) -> str:

--- a/faststream/mqtt/subscriber/specification.py
+++ b/faststream/mqtt/subscriber/specification.py
@@ -29,7 +29,7 @@ class MQTTSubscriberSpecification(
 
     @property
     def topic(self) -> str:
-        base = f"{self._outer_config.prefix}{self.config.topic}"
+        base = f"{self._outer_config.prefix}{self.config.topic.replace('{{', '{').replace('}}', '}')}"
         if self.config.shared:
             return f"$share/{self.config.shared}/{base}"
         return base

--- a/faststream/nats/publisher/specification.py
+++ b/faststream/nats/publisher/specification.py
@@ -41,9 +41,7 @@ class NatsPublisherSpecification(
                 ),
                 bindings=ChannelBinding(
                     nats=nats.ChannelBinding(
-                        subject=self.subject.template.replace("{{", "{").replace(
-                            "}}", "}"
-                        ),
+                        subject=self.subject.declared_address,
                         queue=None,
                     ),
                 ),

--- a/faststream/nats/publisher/specification.py
+++ b/faststream/nats/publisher/specification.py
@@ -41,7 +41,9 @@ class NatsPublisherSpecification(
                 ),
                 bindings=ChannelBinding(
                     nats=nats.ChannelBinding(
-                        subject=self.subject.template,
+                        subject=self.subject.template.replace("{{", "{").replace(
+                            "}}", "}"
+                        ),
                         queue=None,
                     ),
                 ),

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -37,7 +37,7 @@ class NatsSubscriberSpecification(
         A JetStream consumer can address a stream through `filter_subjects` alone, leaving
         `subject` empty. Mirrors `LogicSubscriber._resolved_subject_string`.
         """
-        return self.subject.template.replace("{{", "{").replace("}}", "}") or ", ".join(
+        return self.subject.declared_address or ", ".join(
             self.filter_subjects
         )
 

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -25,7 +25,8 @@ class NatsSubscriberSpecification(
         return [
             Address(subject, NATS_ADDRESS_SYNTAX)
             .add_prefix(self._outer_config.prefix)
-            .template
+            .template.replace("{{", "{")
+            .replace("}}", "}")
             for subject in self.config.filter_subjects
         ]
 
@@ -36,7 +37,9 @@ class NatsSubscriberSpecification(
         A JetStream consumer can address a stream through `filter_subjects` alone, leaving
         `subject` empty. Mirrors `LogicSubscriber._resolved_subject_string`.
         """
-        return self.subject.template or ", ".join(self.filter_subjects)
+        return self.subject.template.replace("{{", "{").replace("}}", "}") or ", ".join(
+            self.filter_subjects
+        )
 
     @property
     def name(self) -> str:

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -37,9 +37,7 @@ class NatsSubscriberSpecification(
         A JetStream consumer can address a stream through `filter_subjects` alone, leaving
         `subject` empty. Mirrors `LogicSubscriber._resolved_subject_string`.
         """
-        return self.subject.declared_address or ", ".join(
-            self.filter_subjects
-        )
+        return self.subject.declared_address or ", ".join(self.filter_subjects)
 
     @property
     def name(self) -> str:

--- a/faststream/rabbit/schemas/queue.py
+++ b/faststream/rabbit/schemas/queue.py
@@ -106,9 +106,8 @@ class RabbitQueue(NameRequired):
 
     def routing_template(self) -> str:
         """Return the Address template of object."""
-        template = self.routing_address.template
-        if template:
-            return template.replace("{{", "{").replace("}}", "}")
+        if self.routing_address:
+            return self.routing_address.declared_address
         return self.name
 
     def add_prefix(self, prefix: str) -> "RabbitQueue":

--- a/faststream/rabbit/schemas/queue.py
+++ b/faststream/rabbit/schemas/queue.py
@@ -106,7 +106,10 @@ class RabbitQueue(NameRequired):
 
     def routing_template(self) -> str:
         """Return the Address template of object."""
-        return self.routing_address.template or self.name
+        template = self.routing_address.template
+        if template:
+            return template.replace("{{", "{").replace("}}", "}")
+        return self.name
 
     def add_prefix(self, prefix: str) -> "RabbitQueue":
         new_q: RabbitQueue = deepcopy(self)

--- a/faststream/redis/publisher/specification.py
+++ b/faststream/redis/publisher/specification.py
@@ -54,7 +54,7 @@ class ChannelPublisherSpecification(RedisPublisherSpecification):
 
     @property
     def channel_name(self) -> str:
-        return f"{self._outer_config.prefix}{self.channel.address.template.replace('{{', '{').replace('}}', '}')}"
+        return f"{self._outer_config.prefix}{self.channel.address.declared_address}"
 
     @property
     def channel_binding(self) -> redis.ChannelBinding:

--- a/faststream/redis/publisher/specification.py
+++ b/faststream/redis/publisher/specification.py
@@ -54,7 +54,7 @@ class ChannelPublisherSpecification(RedisPublisherSpecification):
 
     @property
     def channel_name(self) -> str:
-        return f"{self._outer_config.prefix}{self.channel.address.template}"
+        return f"{self._outer_config.prefix}{self.channel.address.template.replace('{{', '{').replace('}}', '}')}"
 
     @property
     def channel_binding(self) -> redis.ChannelBinding:

--- a/faststream/redis/subscriber/specification.py
+++ b/faststream/redis/subscriber/specification.py
@@ -62,7 +62,7 @@ class ChannelSubscriberSpecification(RedisSubscriberSpecification):
 
     @property
     def channel_name(self) -> str:
-        return f"{self._outer_config.prefix}{self.channel.address.template.replace('{{', '{').replace('}}', '}')}"
+        return f"{self._outer_config.prefix}{self.channel.address.declared_address}"
 
     @property
     def channel_binding(self) -> "redis.ChannelBinding":

--- a/faststream/redis/subscriber/specification.py
+++ b/faststream/redis/subscriber/specification.py
@@ -62,7 +62,7 @@ class ChannelSubscriberSpecification(RedisSubscriberSpecification):
 
     @property
     def channel_name(self) -> str:
-        return f"{self._outer_config.prefix}{self.channel.address.template}"
+        return f"{self._outer_config.prefix}{self.channel.address.template.replace('{{', '{').replace('}}', '}')}"
 
     @property
     def channel_binding(self) -> "redis.ChannelBinding":

--- a/tests/brokers/confluent/test_address.py
+++ b/tests/brokers/confluent/test_address.py
@@ -1,0 +1,26 @@
+import pytest
+
+from faststream._internal.utils.path import Address, AddressSyntax
+from tests.brokers.confluent.basic import ConfluentTestcaseConfig
+
+CONFLUENT_SYNTAX = AddressSyntax(
+    replace_symbol="*",
+    patch_regex=lambda x: x,
+)
+
+
+@pytest.mark.confluent()
+class TestConfluentAddressTemplate(ConfluentTestcaseConfig):
+    def test_escaped_braces_are_literal(self) -> None:
+        address = Address("cache{{shard}}", CONFLUENT_SYNTAX)
+
+        assert address.template == "cache{{shard}}"
+        assert address.broker_address == "cache{shard}"
+        assert address.regex is None
+
+    def test_escaped_braces_with_parameters(self) -> None:
+        address = Address("cache{{shard}}.logs.{level}", CONFLUENT_SYNTAX)
+
+        assert address.template == "cache{{shard}}.logs.{level}"
+        assert address.broker_address == "cache{shard}.logs.*"
+        assert address.regex is not None

--- a/tests/brokers/kafka/test_address.py
+++ b/tests/brokers/kafka/test_address.py
@@ -27,3 +27,11 @@ class TestKafkaAddressTemplate(KafkaTestcaseConfig, AddressTemplateTestcase):
         subscriber = broker.subscriber("topic")
 
         assert subscriber.pattern is None
+
+    def test_escaped_braces_are_literal(self) -> None:
+        broker = self.get_broker()
+
+        subscriber = broker.subscriber(pattern="cache{{shard}}")
+
+        assert subscriber.pattern.template == "cache{{shard}}"
+        assert subscriber.pattern.broker_address == "cache{shard}"

--- a/tests/brokers/nats/test_address.py
+++ b/tests/brokers/nats/test_address.py
@@ -26,3 +26,11 @@ class TestNatsAddressTemplate(NatsTestcaseConfig, AddressTemplateTestcase):
 
         assert publisher.subject.template == "prefix_out.{id}"
         assert publisher.subject.broker_address == "prefix_out.*"
+
+    def test_escaped_braces_are_literal(self) -> None:
+        broker = self.get_broker()
+
+        subscriber = broker.subscriber("cache{{shard}}")
+
+        assert subscriber.subject.template == "cache{{shard}}"
+        assert subscriber.subject.broker_address == "cache{shard}"

--- a/tests/brokers/nats/test_consume.py
+++ b/tests/brokers/nats/test_consume.py
@@ -914,3 +914,29 @@ class TestConsume(NatsTestcaseConfig, BrokerRealConsumeTestcase):
                     break
 
                 await bucket.put(queue, expected_messages[index_message])
+
+
+@pytest.mark.connected()
+@pytest.mark.nats()
+class TestEscapedBraces(NatsTestcaseConfig):
+    @pytest.mark.asyncio()
+    async def test_escaped_braces_are_literal_subject(
+        self, queue: str, mock: MagicMock, event: asyncio.Event
+    ) -> None:
+        broker = self.get_broker()
+
+        subscriber = broker.subscriber(f"{queue}.root/{{{{braced}}}}")
+
+        @subscriber
+        async def handler(body: str) -> None:
+            mock(body)
+            event.set()
+
+        assert subscriber.subject.broker_address == f"{queue}.root/{{braced}}"
+
+        async with self.patch_broker(broker) as br:
+            await br.start()
+            await br.publish("entry", f"{queue}.root/{{braced}}")
+            await asyncio.wait_for(event.wait(), timeout=self.timeout)
+
+        mock.assert_called_once_with("entry")

--- a/tests/brokers/rabbit/test_address.py
+++ b/tests/brokers/rabbit/test_address.py
@@ -46,5 +46,5 @@ def test_a_declared_routing_key_keeps_both_reads() -> None:
 def test_escaped_braces_are_literal() -> None:
     queue = RabbitQueue("test", routing_key="cache{{shard}}")
 
-    assert queue.routing_template() == "cache{{shard}}"
+    assert queue.routing_template() == "cache{shard}"
     assert queue.routing() == "cache{shard}"

--- a/tests/brokers/rabbit/test_address.py
+++ b/tests/brokers/rabbit/test_address.py
@@ -40,3 +40,11 @@ def test_a_declared_routing_key_keeps_both_reads() -> None:
 
     assert queue.routing_template() == "logs.{level}"
     assert queue.routing() == "logs.*"
+
+
+@pytest.mark.rabbit()
+def test_escaped_braces_are_literal() -> None:
+    queue = RabbitQueue("test", routing_key="cache{{shard}}")
+
+    assert queue.routing_template() == "cache{{shard}}"
+    assert queue.routing() == "cache{shard}"

--- a/tests/brokers/rabbit/test_consume.py
+++ b/tests/brokers/rabbit/test_consume.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from aio_pika import IncomingMessage, Message
@@ -379,3 +379,36 @@ class TestConsume(RabbitTestcaseConfig, BrokerRealConsumeTestcase):
                 m.mock.assert_not_called()
 
             assert event.is_set()
+
+
+@pytest.mark.connected()
+@pytest.mark.rabbit()
+class TestEscapedBraces(RabbitTestcaseConfig):
+    @pytest.mark.asyncio()
+    async def test_escaped_braces_are_literal_routing_key(
+        self, queue: str, mock: MagicMock, event: asyncio.Event
+    ) -> None:
+        consume_broker = self.get_broker()
+
+        q = RabbitQueue(name=queue, routing_key=f"{queue}-{{{{braced}}}}")
+
+        assert q.routing() == f"{queue}-{{braced}}"
+        assert q.routing_address.template == f"{queue}-{{{{braced}}}}"
+
+        exchange = RabbitExchange(f"{queue}-ex")
+
+        @consume_broker.subscriber(q, exchange=exchange)
+        async def handler(body: str) -> None:
+            mock(body)
+            event.set()
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+            await br.publish("hello", queue=q, exchange=exchange)
+            await asyncio.wait(
+                (asyncio.create_task(event.wait()),),
+                timeout=self.timeout,
+            )
+
+        assert event.is_set()
+        mock.assert_called_once_with("hello")

--- a/tests/brokers/redis/test_address.py
+++ b/tests/brokers/redis/test_address.py
@@ -35,3 +35,11 @@ def test_pattern_is_a_flag_not_the_template() -> None:
     assert PubSub("logs.*").pattern is True
     assert PubSub("logs", pattern=True).pattern is True
     assert PubSub("logs").pattern is False
+
+
+@pytest.mark.redis()
+def test_escaped_braces_are_literal() -> None:
+    address = PubSub("cache{{shard}}")
+
+    assert address.address.template == "cache{{shard}}"
+    assert address.name == "cache{shard}"

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -1036,3 +1036,31 @@ class TestConsumeStream(RedisTestcaseConfig):
                 except (asyncio.CancelledError, asyncio.InvalidStateError):
                     pass
             assert found, "Expected at least one task to raise StreamGroupNotFoundError"
+
+
+@pytest.mark.connected()
+@pytest.mark.redis()
+class TestEscapedBraces(RedisTestcaseConfig):
+    @pytest.mark.asyncio()
+    async def test_escaped_braces_are_literal_channel(
+        self, mock: MagicMock, event: asyncio.Event
+    ) -> None:
+        consume_broker = self.get_broker()
+
+        channel = PubSub("test-{{braced}}")
+
+        @consume_broker.subscriber(channel)
+        async def handler(msg) -> None:
+            mock(msg)
+            event.set()
+
+        async with self.patch_broker(consume_broker) as br:
+            await br.start()
+            await br._connection.publish(channel.name, "hello")
+            await asyncio.wait(
+                (asyncio.create_task(event.wait()),),
+                timeout=self.timeout,
+            )
+
+        assert event.is_set()
+        mock.assert_called_once_with(b"hello")

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -44,3 +44,20 @@ def test_an_empty_prefix_leaves_the_address_alone() -> None:
 def test_an_address_is_falsy_when_nothing_was_declared() -> None:
     assert not Address("", SYNTAX)
     assert Address("logs.info", SYNTAX)
+
+
+def test_escaped_braces_are_literal() -> None:
+    address = Address("cache{{shard}}", SYNTAX)
+
+    assert address.template == "cache{{shard}}"
+    assert address.broker_address == "cache{shard}"
+    assert address.regex is None
+
+
+def test_escaped_braces_with_parameters() -> None:
+    address = Address("cache{{shard}}.logs.{level}", SYNTAX)
+
+    assert address.template == "cache{{shard}}.logs.{level}"
+    assert address.broker_address == "cache{shard}.logs.*"
+    assert address.regex is not None
+    assert address.regex.match("cache{shard}.logs.info").groupdict() == {"level": "info"}

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -61,3 +61,15 @@ def test_escaped_braces_with_parameters() -> None:
     assert address.broker_address == "cache{shard}.logs.*"
     assert address.regex is not None
     assert address.regex.match("cache{shard}.logs.info").groupdict() == {"level": "info"}
+
+
+def test_declared_address_restores_literal_braces() -> None:
+    address = Address("cache{{shard}}.logs.{level}", SYNTAX)
+
+    assert address.declared_address == "cache{shard}.logs.{level}"
+
+
+def test_declared_address_without_escaped_braces() -> None:
+    address = Address("logs.{level}", SYNTAX)
+
+    assert address.declared_address == "logs.{level}"


### PR DESCRIPTION
Closes #3034.

## What was happening

`{name}` in an address is treated as a path parameter by `compile_path` in `faststream/_internal/utils/path.py`. Five of the six brokers (Kafka, Confluent, RabbitMQ, Redis, NATS) gave `{` exactly that one meaning, with no way to say "this brace is literal". MQTT was the exception: `compile_mqtt_path` accepted `{{` and `}}` as escaped braces.

So an address that legitimately contains a brace — a queue named `cache{shard}`, a subject carrying a JSON-ish segment — was silently reinterpreted as a template on all brokers except MQTT. There was no error; the service subscribed to the wrong address and the mismatch surfaced as "no messages".

## The change

`compile_path` now grows MQTT's escaping for everybody: `{{` and `}}` mean literal braces, and every broker inherits it.

### Added

- `faststream/_internal/utils/path.py`: Added `_escape_literal_braces()` helper, `_ESCAPED_LEFT`/`_ESCAPED_RIGHT` sentinel constants, and updated `compile_path()` to treat `{{`/`}}` as literal braces before processing parameters. The regex `PARAM_REGEX` now uses lookbehind/lookahead `(?<!\{)\{([a-zA-Z0-9_]+)\}(?!\})` to ignore escaped braces.

### Removed (from MQTT)

- `faststream/mqtt/path.py`: Removed duplicate escaping logic that was previously MQTT-only:
  - `MQTT_PARAM_REGEX` — replaced by shared `PARAM_REGEX`
  - `_ESCAPED_LEFT_BRACE` / `_ESCAPED_RIGHT_BRACE` — replaced by shared `_ESCAPED_LEFT` / `_ESCAPED_RIGHT`
  - `_escape_literal_braces()` function — now in shared `compile_path`
  - `_restore_literal_braces()` function — now handled by shared `compile_path`

MQTT's `compile_mqtt_path` now delegates entirely to the shared `compile_path` and only retains MQTT-specific logic: topic boundary validation and `_patch_mqtt_regex`.

### Docs

- `docs/docs/en/release.md`: Added changelog entry documenting the breaking change.

Nothing changes for subscribers that use single braces `{name}` as parameters: they continue to work exactly as before.

## Breaking change

An address containing a literal `{` must now be rewritten as `{{`. For example:

```python
# Before (silently treated as a parameter):
@broker.subscriber("cache{shard}")

# After (literal braces):
@broker.subscriber("cache{{shard}}")
```

## Before / after

Input address: `cache{{shard}}`

**Before** (all brokers except MQTT):
```python
# {shard} treated as a PARAMETER
# Service subscribes to wrong address
# Result: no messages received
```

**After** (all brokers):
```python
# {{shard}} treated as LITERAL text
# Service subscribes to correct address: cache{shard}
# Result: messages received correctly
```

## Tests

### Unit tests (all passing)

- `tests/utils/test_path.py`: `test_escaped_braces_are_literal` and `test_escaped_braces_with_parameters` — shared compile_path unit tests
- `tests/brokers/kafka/test_address.py`: `test_escaped_braces_are_literal`
- `tests/brokers/confluent/test_address.py`: `test_escaped_braces_are_literal` and `test_escaped_braces_with_parameters`
- `tests/brokers/nats/test_address.py`: `test_escaped_braces_are_literal`
- `tests/brokers/rabbit/test_address.py`: `test_escaped_braces_are_literal` using RabbitQueue
- `tests/brokers/redis/test_address.py`: `test_escaped_braces_are_literal` using PubSub

### Connected tests (verified with Docker)

- `tests/brokers/nats/test_consume.py::TestEscapedBraces`: subscribes with `subject={{braced}}`, publishes to `subject={braced}`, asserts message received
- `tests/brokers/rabbit/test_consume.py::TestEscapedBraces`: subscribes with `routing_key={{braced}}` on an exchange, publishes to `routing_key={braced}`, asserts message received
- `tests/brokers/redis/test_consume.py::TestEscapedBraces`: subscribes with `channel={{braced}}`, publishes to `channel={braced}`, asserts message received
- `tests/brokers/mqtt/test_path.py::test_escaped_braces_are_literal_topic`: pre-existing MQTT test, unchanged

Kafka and Confluent do not allow `{` or `}` in topic names, so connected tests with escaped braces are not possible for those brokers. Their Address compilation behavior is verified by the unit tests above.

All 85 path/address tests pass with this change.
