### PR TITLE
Allow MANUAL ack_policy with max_workers on Redis streams

### DIFF
--- a/faststream/redis/subscriber/factory.py
+++ b/faststream/redis/subscriber/factory.py
@@ -156,10 +156,6 @@ def _validate_input_for_misconfigure(
 ) -> None:
     validate_options(channel=channel, list=list, stream=stream)
 
-    if stream and ack_policy is AckPolicy.MANUAL and max_workers > 1:
-        msg = "Max workers not work with manual no_ack mode."
-        raise SetupError(msg)
-
     if ack_policy is not EMPTY:
         if channel:
             warnings.warn(

--- a/tests/brokers/redis/test_misconfigure.py
+++ b/tests/brokers/redis/test_misconfigure.py
@@ -1,8 +1,51 @@
 import pytest
 
+from faststream import AckPolicy
 from faststream.exceptions import SetupError
 from faststream.nats import NatsRouter
-from faststream.redis import RedisBroker, RedisRouter
+from faststream.redis import RedisBroker, RedisRouter, StreamSub
+from faststream.redis.subscriber.usecases import StreamConcurrentSubscriber
+
+
+@pytest.mark.redis()
+def test_manual_ack_with_max_workers() -> None:
+    """`XACK` is per-entry, so acking manually from concurrent tasks cannot conflict.
+
+    The combination used to raise on the direct argument only. Declaring the same
+    policy as a router default already reached `StreamConcurrentSubscriber`, because
+    `ack_policy` is still `EMPTY` when the subscriber is validated.
+    """
+    broker = RedisBroker()
+
+    @broker.subscriber(
+        stream=StreamSub("stream", group="group", consumer="consumer"),
+        ack_policy=AckPolicy.MANUAL,
+        max_workers=2,
+    )
+    async def handle(msg: str) -> None: ...
+
+    (subscriber,) = broker.subscribers
+    assert isinstance(subscriber, StreamConcurrentSubscriber)
+    assert subscriber.ack_policy is AckPolicy.MANUAL
+
+
+@pytest.mark.redis()
+def test_manual_ack_with_max_workers_via_router_default() -> None:
+    """The router-default path reaches the same subscriber, and always did."""
+    router = RedisRouter(ack_policy=AckPolicy.MANUAL)
+
+    @router.subscriber(
+        stream=StreamSub("stream", group="group", consumer="consumer"),
+        max_workers=2,
+    )
+    async def handle(msg: str) -> None: ...
+
+    broker = RedisBroker()
+    broker.include_router(router)
+
+    (subscriber,) = broker.subscribers
+    assert isinstance(subscriber, StreamConcurrentSubscriber)
+    assert subscriber.ack_policy is AckPolicy.MANUAL
 
 
 @pytest.mark.redis()


### PR DESCRIPTION
Closes #3043.

## Why the restriction can go

`XACK` is per-entry and carries no ordering semantics, so acknowledging from concurrent handler tasks cannot conflict. The Confluent check this was modelled on (`"Max workers not work with manual commit mode."`) guards cumulative offset commits, which Redis streams have no equivalent of.

The check was also only half-applied. It inspects the `ack_policy` argument passed to `subscriber()`, but that argument is still `EMPTY` when the policy comes from a router or broker default — the `if ack_policy is not EMPTY:` block immediately below it exists for exactly that reason. So the same configuration already ran, depending only on how it was expressed:

```python
# raised SetupError
@broker.subscriber(
    stream=StreamSub("stream", group="group", consumer="consumer"),
    ack_policy=AckPolicy.MANUAL,
    max_workers=2,
)
async def handle(msg: str) -> None: ...

# reached StreamConcurrentSubscriber with AckPolicy.MANUAL and ran
router = RedisRouter(ack_policy=AckPolicy.MANUAL)

@router.subscriber(
    stream=StreamSub("stream", group="group", consumer="consumer"),
    max_workers=2,
)
async def handle(msg: str) -> None: ...
```

I confirmed both paths locally before changing anything: the first raised, the second produced a `StreamConcurrentSubscriber` whose `ack_policy` was `AckPolicy.MANUAL`.

## Tests

Two tests in `tests/brokers/redis/test_misconfigure.py`, one per path, asserting the subscriber type and the resolved policy. The direct-argument test fails on `main`; the router-default one passes there already, which is the inconsistency written down.

No existing test asserted this `SetupError`.

## One note

`max_workers` is now unused inside `_validate_input_for_misconfigure`. I left it in the signature deliberately, because of the TODO a few lines below in the same file:

```python
# TODO: raise warning if max_workers in `_validate_input_for_misconfigure`
```

Happy to drop the parameter instead if that TODO is stale.
