### PR TITLE
Deregister fake subscribers when the TestBroker closes

### DIFF
--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -240,6 +240,8 @@ class TestBroker(Generic[Broker, EnterType]):
             if getattr(p, "_fake_handler", None):
                 p.reset_test()
 
+        # Fakes are registered with `persistent=False`, so the broker holds them weakly
+        # and they outlive us until the next collection (see issue #2990).
         for sub in self._fake_subscribers:
             broker._subscribers.discard(sub)
 

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -240,6 +240,14 @@ class TestBroker(Generic[Broker, EnterType]):
             if getattr(p, "_fake_handler", None):
                 p.reset_test()
 
+        # Dropping our strong reference is not enough: the fakes were registered with
+        # `persistent=False`, so the broker only holds them weakly and they stay
+        # reachable until the next collection. A TestBroker starting in that window
+        # matches one as a real subscriber, keeps no strong reference of its own, and
+        # then loses it to the collector mid-test. Withdraw them here instead.
+        for sub in self._fake_subscribers:
+            broker._subscribers.discard(sub)
+
         self._fake_subscribers.clear()
 
         for sub in broker.subscribers:

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -240,11 +240,6 @@ class TestBroker(Generic[Broker, EnterType]):
             if getattr(p, "_fake_handler", None):
                 p.reset_test()
 
-        # Dropping our strong reference is not enough: the fakes were registered with
-        # `persistent=False`, so the broker only holds them weakly and they stay
-        # reachable until the next collection. A TestBroker starting in that window
-        # matches one as a real subscriber, keeps no strong reference of its own, and
-        # then loses it to the collector mid-test. Withdraw them here instead.
         for sub in self._fake_subscribers:
             broker._subscribers.discard(sub)
 

--- a/tests/brokers/base/testclient.py
+++ b/tests/brokers/base/testclient.py
@@ -37,6 +37,36 @@ class BrokerTestclientTestcase(BrokerPublishTestcase, BrokerConsumeTestcase):
         assert len(broker.subscribers) == 1, len(broker.subscribers)
 
     @pytest.mark.asyncio()
+    async def test_fake_subscribers_deregistered_without_gc(self) -> None:
+        """A second TestBroker must not reuse a fake left behind by the first.
+
+        Fakes are registered with `persistent=False`, so the broker holds them weakly.
+        Dropping the strong reference alone leaves them reachable until the next
+        collection, and a TestBroker starting inside that window matched one as a real
+        subscriber — keeping no strong reference of its own, so the collector could take
+        it away mid-test and `publish()` would raise `SubscriberNotFound`.
+        """
+        broker = self.get_broker()
+
+        @broker.subscriber("test")
+        async def handler(msg) -> None: ...
+
+        pub = broker.publisher("test2")  # noqa: F841
+
+        async with self.patch_broker(broker):
+            pass
+
+        # Deliberately no gc.collect() here — that is what used to hide the leftover.
+        assert len(broker.subscribers) == 1, len(broker.subscribers)
+
+        second_client = self.patch_broker(broker)
+        async with second_client as br:
+            # The fake belongs to this client, so it survives a collection.
+            assert len(second_client._fake_subscribers) == 1
+            gc.collect()
+            assert len(br.subscribers) == 2, len(br.subscribers)
+
+    @pytest.mark.asyncio()
     async def test_subscriber_mock(self, queue: str) -> None:
         test_broker = self.get_broker()
 

--- a/tests/brokers/base/testclient.py
+++ b/tests/brokers/base/testclient.py
@@ -38,13 +38,9 @@ class BrokerTestclientTestcase(BrokerPublishTestcase, BrokerConsumeTestcase):
 
     @pytest.mark.asyncio()
     async def test_fake_subscribers_deregistered_without_gc(self) -> None:
-        """A second TestBroker must not reuse a fake left behind by the first.
+        """Fixes https://github.com/ag2ai/faststream/issues/2990.
 
-        Fakes are registered with `persistent=False`, so the broker holds them weakly.
-        Dropping the strong reference alone leaves them reachable until the next
-        collection, and a TestBroker starting inside that window matched one as a real
-        subscriber — keeping no strong reference of its own, so the collector could take
-        it away mid-test and `publish()` would raise `SubscriberNotFound`.
+        A second TestBroker must not reuse a fake left behind by the first.
         """
         broker = self.get_broker()
 
@@ -56,12 +52,14 @@ class BrokerTestclientTestcase(BrokerPublishTestcase, BrokerConsumeTestcase):
         async with self.patch_broker(broker):
             pass
 
-        # Deliberately no gc.collect() here — that is what used to hide the leftover.
+        # No gc.collect() before this line: the leftover fake stayed weakly reachable
+        # until the next collection, which is exactly what hid the bug.
         assert len(broker.subscribers) == 1, len(broker.subscribers)
 
         second_client = self.patch_broker(broker)
         async with second_client as br:
-            # The fake belongs to this client, so it survives a collection.
+            # This client owns its own fake, so the collector cannot take it away
+            # mid-test and leave `publish()` raising `SubscriberNotFound`.
             assert len(second_client._fake_subscribers) == 1
             gc.collect()
             assert len(br.subscribers) == 2, len(br.subscribers)


### PR DESCRIPTION
Closes #2990.

## What was happening

Fake subscribers are created with `persistent=False`, which means the broker keeps them only in its `WeakSet` and the caller owns their lifetime. `_fake_close()` released ownership with `self._fake_subscribers.clear()` — but clearing the list does not unregister anything. Until the next collection the fake is still weakly reachable, so `broker.subscribers` still reports it.

A `TestBroker` starting inside that window found it through `create_publisher_fake_subscriber()` and returned `is_real=True`. `_fake_start()` only appends to `self._fake_subscribers` in the `if not is_real:` branch, so the new client kept no strong reference of its own. The next collection then removed the object from the `WeakSet`, and `publish()` raised `SubscriberNotFound` — depending on GC timing rather than on anything the test did.

## The change

Withdraw the fakes from the broker in `_fake_close()` instead of waiting for the collector.

## Reproduction

Running the script from the issue:

```python
                                                          before   after
1. fake subscribers still registered after the context exited:  1       0
2. strong refs held by this TestRabbitBroker:                   0       1
   fake subscribers registered on the broker:                   1       1
3. fake subscribers registered after gc.collect():              0       0
```

Line 2 is the failure: before the change the second client held no reference to the subscriber it was about to rely on. After, it creates its own fake and owns it.

## Tests

Added `test_fake_subscribers_deregistered_without_gc` to `BrokerTestclientTestcase`, so every broker's test client inherits it.

The existing `test_correct_clean_fake_subscribers` calls `gc.collect()` before asserting, which is exactly what hid this — the new test deliberately asserts without collecting first, then collects *inside* the second context to show the fake survives because it is properly owned.

It fails on `main` and passes with this change. The other failures in `tests/brokers/rabbit/test_test_client.py` on my machine are the `_real_` cases that need a live RabbitMQ; they fail identically before and after.
