### PR TITLE
fix(docs): repair the release-notes generator and the duplicated 0.7.* notes

### DIFF
--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -359,7 +359,7 @@ The following APIs that were deprecated in earlier 0.x releases have been fully 
 
 ### What's Changed
 
-Just two main changes: 
+Just two main changes:
 
 1. `from faststream.mqtt import MQTTBroker` (thanks [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"})
 2. All deprecations removed:
@@ -377,7 +377,7 @@ uv add --pre "faststream[mqtt]==0.7.0rc0"
 ```
 
 We will release a stable version as soon as we test `MQTTBroker` with production services (in a few weeks).
-   
+
 * feat: FastStream[mqtt] by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2819](https://github.com/ag2ai/faststream/pull/2819){.external-link target="_blank"}
 * fix: include pattern subscribers in AsyncAPI specification by [@aazmv](https://github.com/aazmv){.external-link target="_blank"} in [#2813](https://github.com/ag2ai/faststream/pull/2813){.external-link target="_blank"}
 * fix: cli preserve import errors by [@vovkka](https://github.com/vovkka){.external-link target="_blank"} in [#2817](https://github.com/ag2ai/faststream/pull/2817){.external-link target="_blank"}

--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,768 +12,13 @@ hide:
 ---
 
 # Release Notes
-## 0.7.1
-
-### What's Changed
-
-TestBroker.__aenter__ was typed to return Broker | list[Broker]. That union is wrong for both usage shapes: mypy rejects .publish() on the single-broker result (the list arm has no such method) and rejects unpacking the multi-broker result (the Broker arm is not iterable).
-
-```python
-# Before — both lines fail under `mypy`:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    await br.publish(None, "test")
-    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    # error: "KafkaBroker" object is not iterable  [misc]
-    ...
-
-# After — mypy infers the precise type:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    reveal_type(br)            # KafkaBroker
-    await br.publish(None, "test")
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
-    await br1.publish(None, "test")
-    await br2.publish(None, "test")
-```
-
-* fix(testing): type TestBroker context result via __init__ overloads by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2903](https://github.com/ag2ai/faststream/pull/2903){.external-link target="_blank"}
-* fix(docs): export *ParserType aliases at runtime by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2898](https://github.com/ag2ai/faststream/pull/2898){.external-link target="_blank"}
-* docs: Clarify FastStream description by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2901](https://github.com/ag2ai/faststream/pull/2901){.external-link target="_blank"}
-
-**Full Changelog**: [#0.7.0...0.7.1](https://github.com/ag2ai/faststream/compare/0.7.0...0.7.1){.external-link target="_blank"}
-
-## 0.7.0
-
-### What's Changed
-
-#### 🚀 [MQTT Support](https://faststream.ag2.ai/latest/mqtt/)
-
-FastStream now includes a full-featured MQTT broker, installable via `pip install faststream[mqtt]`. It supports wildcard topic filters, path parameter capture via `Path()`, QoS levels, per-subscriber `ack_policy`, and AsyncAPI schema generation.
-
-```python
-from faststream import FastStream, Path
-from faststream.mqtt import MQTTBroker, MQTTMessage, QoS
-
-broker = MQTTBroker("localhost:1883")
-app = FastStream(broker)
-
-@broker.subscriber(
-    "sensors/{device_id}/temperature",
-    qos=QoS.AT_LEAST_ONCE,
-)
-async def on_temperature(body: str, device_id: Annotated[str, Path()]) -> None:
-    print(device_id, body)
-
-@app.after_startup
-async def publish_demo() -> None:
-    await broker.publish(21.5, "sensors/room1/temperature", qos=QoS.AT_LEAST_ONCE)
-```
-
----
-
-#### 🔀 Multi-broker Support
-
-A single FastStream application can now run multiple brokers at the same time. Pass all the brokers directly to the `FastStream` constructor — each keeps its own subscribers and publishers, and the app starts and stops all of them together. A common use case is bridging two systems: consume from one broker and re-publish to another.
-
-```python
-from faststream import FastStream
-from faststream.kafka import KafkaBroker
-from faststream.nats import NatsBroker
-
-kafka_broker = KafkaBroker("localhost:9092")
-nats_broker = NatsBroker("nats://localhost:4222")
-
-app = FastStream(kafka_broker, nats_broker)
-
-@kafka_broker.subscriber("incoming")
-@nats_broker.publisher("outgoing")
-async def from_kafka(msg: str) -> str:
-    # Bridge the message from Kafka to NATS
-    return msg
-
-@nats_broker.subscriber("outgoing")
-async def from_nats(msg: str) -> None:
-    print(f"Received from NATS: {msg}")
-```
-
----
-
-#### 🗄️ Redis Cluster Support
-
-FastStream's Redis broker now has a dedicated `RedisClusterBroker` that connects to a Redis Cluster with automatic node discovery. It is a drop-in replacement for `RedisBroker` — just change the class name and point it at any cluster node.
-
-```python
-from faststream import FastStream
-from faststream.redis import RedisClusterBroker
-
-# A single URL is enough — the cluster auto-discovers all remaining nodes
-broker = RedisClusterBroker("redis://node1:7000")
-app = FastStream(broker)
-
-@broker.subscriber("events")
-async def handle_event(msg: str) -> None:
-    print(f"Received: {msg}")
-
-@app.after_startup
-async def publish_event() -> None:
-    await broker.publish("hello from cluster", "events")
-```
-
----
-
-### ⚠️ Breaking Changes
-
-#### AsyncAPIRoute parameter renames (PR #2894)
-
-The `AsyncAPIRoute` class (used in ASGI hosting) has had two parameters renamed:
-
-| Before | After | Notes |
-|--------|-------|-------|
-| `try_it_out=False` | `try_it_out_path=None` | Disabling try-it-out now uses `None` instead of `False` |
-| `try_it_out_url="..."` | `try_it_out_path="..."` | Parameter renamed for clarity |
-
-```python
-# Before
-AsyncAPIRoute("/docs/asyncapi", try_it_out=False)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_url="https://api.example.com/asyncapi/try")
-
-# After
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path="https://api.example.com/asyncapi/try")
-```
-
-Additionally, a new `asyncapi_json_path` parameter was added (defaults to `<path>.json`) and its position in the signature changed — use keyword arguments to avoid surprises.
-
----
-
-#### RabbitMQ: `durable=True` is now the default (PR #2892)
-
-`RabbitQueue` and `RabbitExchange` now default to `durable=True` (previously `False`). This aligns with RabbitMQ 4.3+ which disables transient non-exclusive queues by default.
-
-**Impact:** if you already have a transient (non-durable) queue or exchange of the same name declared on your broker, re-declaration will raise a `PRECONDITION_FAILED` mismatch error. To opt out, pass `durable=False` explicitly:
-
-```python
-from faststream.rabbit import RabbitQueue
-
-# To keep the old transient behavior:
-queue = RabbitQueue("my-queue", durable=False)
-```
-
----
-
-#### Deprecated items removed
-## 0.7.2
-
-### What's Changed
-
-* feat(redis): add Redis Sentinel support by [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-* feat: surface mqtt_connect_timeout on MQTTBroker by @Jsyvanen-algo in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
-* feat: add support async context managers in subscribers by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2576](https://github.com/ag2ai/faststream/pull/2576){.external-link target="_blank"}
-* fix: Forward group_instance_id from the FastAPI Kafka router by @00yhj22-debug in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
-* fix(confluent): publish(None) should send a real Kafka tombstone by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
-* fix(mqtt): installing mqtt by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2936](https://github.com/ag2ai/faststream/pull/2936){.external-link target="_blank"}
-* fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2935](https://github.com/ag2ai/faststream/pull/2935){.external-link target="_blank"}
-* docs: batch example by [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
-* docs: update Trendshift badge by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2905](https://github.com/ag2ai/faststream/pull/2905){.external-link target="_blank"}
-* docs: document Redis JSON fallback and non-FastStream interop by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2906](https://github.com/ag2ai/faststream/pull/2906){.external-link target="_blank"}
-* chore: add agent skills pinning repository development conventions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2912](https://github.com/ag2ai/faststream/pull/2912){.external-link target="_blank"}
-
-### New Contributors
-* @Jsyvanen-algo made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
-* [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} made their first contribution in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
-* [@aradng](https://github.com/aradng){.external-link target="_blank"} made their first contribution in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
-* [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} made their first contribution in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-
-**Full Changelog**: [#0.7.1...0.7.2](https://github.com/ag2ai/faststream/compare/0.7.1...0.7.2){.external-link target="_blank"}
-
-## 0.7.1
-
-### What's Changed
-
-TestBroker.__aenter__ was typed to return Broker | list[Broker]. That union is wrong for both usage shapes: mypy rejects .publish() on the single-broker result (the list arm has no such method) and rejects unpacking the multi-broker result (the Broker arm is not iterable).
-
-```python
-# Before — both lines fail under `mypy`:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    await br.publish(None, "test")
-    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    # error: "KafkaBroker" object is not iterable  [misc]
-    ...
-
-# After — mypy infers the precise type:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    reveal_type(br)            # KafkaBroker
-    await br.publish(None, "test")
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
-    await br1.publish(None, "test")
-    await br2.publish(None, "test")
-```
-
-* fix(testing): type TestBroker context result via __init__ overloads by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2903](https://github.com/ag2ai/faststream/pull/2903){.external-link target="_blank"}
-* fix(docs): export *ParserType aliases at runtime by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2898](https://github.com/ag2ai/faststream/pull/2898){.external-link target="_blank"}
-* docs: Clarify FastStream description by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2901](https://github.com/ag2ai/faststream/pull/2901){.external-link target="_blank"}
-
-
-
-**Full Changelog**: [#0.7.0...0.7.1](https://github.com/ag2ai/faststream/compare/0.7.0...0.7.1){.external-link target="_blank"}
-
-## 0.7.0
-
-### What's Changed
-
-#### 🚀 [MQTT Support](https://faststream.ag2.ai/latest/mqtt/)
-
-FastStream now includes a full-featured MQTT broker, installable via `pip install faststream[mqtt]`. It supports wildcard topic filters, path parameter capture via `Path()`, QoS levels, per-subscriber `ack_policy`, and AsyncAPI schema generation.
-
-```python
-from faststream import FastStream, Path
-from faststream.mqtt import MQTTBroker, MQTTMessage, QoS
-
-broker = MQTTBroker("localhost:1883")
-app = FastStream(broker)
-
-@broker.subscriber(
-    "sensors/{device_id}/temperature",
-    qos=QoS.AT_LEAST_ONCE,
-)
-async def on_temperature(body: str, device_id: Annotated[str, Path()]) -> None:
-    print(device_id, body)
-
-@app.after_startup
-async def publish_demo() -> None:
-    await broker.publish(21.5, "sensors/room1/temperature", qos=QoS.AT_LEAST_ONCE)
-```
-
----
-
-#### 🔀 Multi-broker Support
-
-A single FastStream application can now run multiple brokers at the same time. Pass all the brokers directly to the `FastStream` constructor — each keeps its own subscribers and publishers, and the app starts and stops all of them together. A common use case is bridging two systems: consume from one broker and re-publish to another.
-
-```python
-from faststream import FastStream
-from faststream.kafka import KafkaBroker
-from faststream.nats import NatsBroker
-
-kafka_broker = KafkaBroker("localhost:9092")
-nats_broker = NatsBroker("nats://localhost:4222")
-
-app = FastStream(kafka_broker, nats_broker)
-
-@kafka_broker.subscriber("incoming")
-@nats_broker.publisher("outgoing")
-async def from_kafka(msg: str) -> str:
-    # Bridge the message from Kafka to NATS
-    return msg
-
-@nats_broker.subscriber("outgoing")
-async def from_nats(msg: str) -> None:
-    print(f"Received from NATS: {msg}")
-```
-
----
-
-#### 🗄️ Redis Cluster Support
-
-FastStream's Redis broker now has a dedicated `RedisClusterBroker` that connects to a Redis Cluster with automatic node discovery. It is a drop-in replacement for `RedisBroker` — just change the class name and point it at any cluster node.
-
-```python
-from faststream import FastStream
-from faststream.redis import RedisClusterBroker
-
-# A single URL is enough — the cluster auto-discovers all remaining nodes
-broker = RedisClusterBroker("redis://node1:7000")
-app = FastStream(broker)
-
-@broker.subscriber("events")
-async def handle_event(msg: str) -> None:
-    print(f"Received: {msg}")
-
-@app.after_startup
-async def publish_event() -> None:
-    await broker.publish("hello from cluster", "events")
-```
-
----
-
-### ⚠️ Breaking Changes
-
-#### AsyncAPIRoute parameter renames (PR #2894)
-
-The `AsyncAPIRoute` class (used in ASGI hosting) has had two parameters renamed:
-
-| Before | After | Notes |
-|--------|-------|-------|
-| `try_it_out=False` | `try_it_out_path=None` | Disabling try-it-out now uses `None` instead of `False` |
-| `try_it_out_url="..."` | `try_it_out_path="..."` | Parameter renamed for clarity |
-
-```python
-# Before
-AsyncAPIRoute("/docs/asyncapi", try_it_out=False)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_url="https://api.example.com/asyncapi/try")
-
-# After
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path="https://api.example.com/asyncapi/try")
-```
-
-Additionally, a new `asyncapi_json_path` parameter was added (defaults to `<path>.json`) and its position in the signature changed — use keyword arguments to avoid surprises.
-
----
-
-#### RabbitMQ: `durable=True` is now the default (PR #2892)
-
-`RabbitQueue` and `RabbitExchange` now default to `durable=True` (previously `False`). This aligns with RabbitMQ 4.3+ which disables transient non-exclusive queues by default.
-
-**Impact:** if you already have a transient (non-durable) queue or exchange of the same name declared on your broker, re-declaration will raise a `PRECONDITION_FAILED` mismatch error. To opt out, pass `durable=False` explicitly:
-
-```python
-from faststream.rabbit import RabbitQueue
-
-# To keep the old transient behavior:
-queue = RabbitQueue("my-queue", durable=False)
-```
-
----
-
-#### Deprecated items removed
-## 0.7.3
-
-### What's Changed
-* chore(rabbit): allow aio-pika 10 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2938](https://github.com/ag2ai/faststream/pull/2938){.external-link target="_blank"}
-* fix(testing): TestKafkaBroker should mock a real tombstone too by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2939](https://github.com/ag2ai/faststream/pull/2939){.external-link target="_blank"}
-* docs: fix path to app with export asyncapi by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2942](https://github.com/ag2ai/faststream/pull/2942){.external-link target="_blank"}
-* Feature/deprecate fastapi plugin by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2944](https://github.com/ag2ai/faststream/pull/2944){.external-link target="_blank"}
-* feat: add support zmqtt 0.0.6 by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2962](https://github.com/ag2ai/faststream/pull/2962){.external-link target="_blank"}
-* fix(fastapi): support FastAPI 0.140 Dependant by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2961](https://github.com/ag2ai/faststream/pull/2961){.external-link target="_blank"}
-* feat: add `typing.Required` hints for sentinel redis by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2955](https://github.com/ag2ai/faststream/pull/2955){.external-link target="_blank"}
-* refactor(redis): replace deprecated args: lib_name, lib_version to driver_in… by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2956](https://github.com/ag2ai/faststream/pull/2956){.external-link target="_blank"}
-* chore: bump redis-py version to 8.0.1 by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2952](https://github.com/ag2ai/faststream/pull/2952){.external-link target="_blank"}
-* feat(redis): add retry in redis integration (#2797) by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2954](https://github.com/ag2ai/faststream/pull/2954){.external-link target="_blank"}
-
-### New Contributors
-* [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} made their first contribution in [#2961](https://github.com/ag2ai/faststream/pull/2961){.external-link target="_blank"}
-
-**Full Changelog**: [#0.7.2...0.7.3](https://github.com/ag2ai/faststream/compare/0.7.2...0.7.3){.external-link target="_blank"}
-
-## 0.7.2
-
-### What's Changed
-
-* feat(redis): add Redis Sentinel support by [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-* feat: surface mqtt_connect_timeout on MQTTBroker by @Jsyvanen-algo in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
-* feat: add support async context managers in subscribers by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2576](https://github.com/ag2ai/faststream/pull/2576){.external-link target="_blank"}
-* fix: Forward group_instance_id from the FastAPI Kafka router by @00yhj22-debug in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
-* fix(confluent): publish(None) should send a real Kafka tombstone by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
-* fix(mqtt): installing mqtt by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2936](https://github.com/ag2ai/faststream/pull/2936){.external-link target="_blank"}
-* fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2935](https://github.com/ag2ai/faststream/pull/2935){.external-link target="_blank"}
-* docs: batch example by [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
-* docs: update Trendshift badge by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2905](https://github.com/ag2ai/faststream/pull/2905){.external-link target="_blank"}
-* docs: document Redis JSON fallback and non-FastStream interop by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2906](https://github.com/ag2ai/faststream/pull/2906){.external-link target="_blank"}
-* chore: add agent skills pinning repository development conventions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2912](https://github.com/ag2ai/faststream/pull/2912){.external-link target="_blank"}
-
-### New Contributors
-* @Jsyvanen-algo made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
-* [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} made their first contribution in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
-* [@aradng](https://github.com/aradng){.external-link target="_blank"} made their first contribution in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
-* [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} made their first contribution in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-
-**Full Changelog**: [#0.7.1...0.7.2](https://github.com/ag2ai/faststream/compare/0.7.1...0.7.2){.external-link target="_blank"}
-
-## 0.7.1
-
-### What's Changed
-
-TestBroker.__aenter__ was typed to return Broker | list[Broker]. That union is wrong for both usage shapes: mypy rejects .publish() on the single-broker result (the list arm has no such method) and rejects unpacking the multi-broker result (the Broker arm is not iterable).
-
-```python
-# Before — both lines fail under `mypy`:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    await br.publish(None, "test")
-    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    # error: "KafkaBroker" object is not iterable  [misc]
-    ...
-
-# After — mypy infers the precise type:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    reveal_type(br)            # KafkaBroker
-    await br.publish(None, "test")
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
-    await br1.publish(None, "test")
-    await br2.publish(None, "test")
-```
-
-* fix(testing): type TestBroker context result via __init__ overloads by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2903](https://github.com/ag2ai/faststream/pull/2903){.external-link target="_blank"}
-* fix(docs): export *ParserType aliases at runtime by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2898](https://github.com/ag2ai/faststream/pull/2898){.external-link target="_blank"}
-* docs: Clarify FastStream description by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2901](https://github.com/ag2ai/faststream/pull/2901){.external-link target="_blank"}
-
-
-
-**Full Changelog**: [#0.7.0...0.7.1](https://github.com/ag2ai/faststream/compare/0.7.0...0.7.1){.external-link target="_blank"}
-
-## 0.7.0
-
-### What's Changed
-
-#### 🚀 [MQTT Support](https://faststream.ag2.ai/latest/mqtt/)
-
-FastStream now includes a full-featured MQTT broker, installable via `pip install faststream[mqtt]`. It supports wildcard topic filters, path parameter capture via `Path()`, QoS levels, per-subscriber `ack_policy`, and AsyncAPI schema generation.
-
-```python
-from faststream import FastStream, Path
-from faststream.mqtt import MQTTBroker, MQTTMessage, QoS
-
-broker = MQTTBroker("localhost:1883")
-app = FastStream(broker)
-
-@broker.subscriber(
-    "sensors/{device_id}/temperature",
-    qos=QoS.AT_LEAST_ONCE,
-)
-async def on_temperature(body: str, device_id: Annotated[str, Path()]) -> None:
-    print(device_id, body)
-
-@app.after_startup
-async def publish_demo() -> None:
-    await broker.publish(21.5, "sensors/room1/temperature", qos=QoS.AT_LEAST_ONCE)
-```
-
----
-
-#### 🔀 Multi-broker Support
-
-A single FastStream application can now run multiple brokers at the same time. Pass all the brokers directly to the `FastStream` constructor — each keeps its own subscribers and publishers, and the app starts and stops all of them together. A common use case is bridging two systems: consume from one broker and re-publish to another.
-
-```python
-from faststream import FastStream
-from faststream.kafka import KafkaBroker
-from faststream.nats import NatsBroker
-
-kafka_broker = KafkaBroker("localhost:9092")
-nats_broker = NatsBroker("nats://localhost:4222")
-
-app = FastStream(kafka_broker, nats_broker)
-
-@kafka_broker.subscriber("incoming")
-@nats_broker.publisher("outgoing")
-async def from_kafka(msg: str) -> str:
-    # Bridge the message from Kafka to NATS
-    return msg
-
-@nats_broker.subscriber("outgoing")
-async def from_nats(msg: str) -> None:
-    print(f"Received from NATS: {msg}")
-```
-
----
-
-#### 🗄️ Redis Cluster Support
-
-FastStream's Redis broker now has a dedicated `RedisClusterBroker` that connects to a Redis Cluster with automatic node discovery. It is a drop-in replacement for `RedisBroker` — just change the class name and point it at any cluster node.
-
-```python
-from faststream import FastStream
-from faststream.redis import RedisClusterBroker
-
-# A single URL is enough — the cluster auto-discovers all remaining nodes
-broker = RedisClusterBroker("redis://node1:7000")
-app = FastStream(broker)
-
-@broker.subscriber("events")
-async def handle_event(msg: str) -> None:
-    print(f"Received: {msg}")
-
-@app.after_startup
-async def publish_event() -> None:
-    await broker.publish("hello from cluster", "events")
-```
-
----
-
-### ⚠️ Breaking Changes
-
-#### AsyncAPIRoute parameter renames (PR #2894)
-
-The `AsyncAPIRoute` class (used in ASGI hosting) has had two parameters renamed:
-
-| Before | After | Notes |
-|--------|-------|-------|
-| `try_it_out=False` | `try_it_out_path=None` | Disabling try-it-out now uses `None` instead of `False` |
-| `try_it_out_url="..."` | `try_it_out_path="..."` | Parameter renamed for clarity |
-
-```python
-# Before
-AsyncAPIRoute("/docs/asyncapi", try_it_out=False)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_url="https://api.example.com/asyncapi/try")
-
-# After
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path="https://api.example.com/asyncapi/try")
-```
-
-Additionally, a new `asyncapi_json_path` parameter was added (defaults to `<path>.json`) and its position in the signature changed — use keyword arguments to avoid surprises.
-
----
-
-#### RabbitMQ: `durable=True` is now the default (PR #2892)
-
-`RabbitQueue` and `RabbitExchange` now default to `durable=True` (previously `False`). This aligns with RabbitMQ 4.3+ which disables transient non-exclusive queues by default.
-
-**Impact:** if you already have a transient (non-durable) queue or exchange of the same name declared on your broker, re-declaration will raise a `PRECONDITION_FAILED` mismatch error. To opt out, pass `durable=False` explicitly:
-
-```python
-from faststream.rabbit import RabbitQueue
-
-# To keep the old transient behavior:
-queue = RabbitQueue("my-queue", durable=False)
-```
-
----
-
-#### Deprecated items removed
-## 0.7.4
-
-### What's Changed
-* fix(TestClient-redis): [#2963] Fixed groups for TestRedisBroker by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2965](https://github.com/ag2ai/faststream/pull/2965){.external-link target="_blank"}
-* bug(kafka): [#2943] Added sinchronization for key's indexes by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2951](https://github.com/ag2ai/faststream/pull/2951){.external-link target="_blank"}
-* Update Release Notes for 0.7.3 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2964](https://github.com/ag2ai/faststream/pull/2964){.external-link target="_blank"}
-* fix (fastapi): skip init=False fields when copying Dependant by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2966](https://github.com/ag2ai/faststream/pull/2966){.external-link target="_blank"}
-* feat(rabbit): support EXTERNAL authentication by [@WellFREEEzZ](https://github.com/WellFREEzZ){.external-link target="_blank"} in [#2953](https://github.com/ag2ai/faststream/pull/2953){.external-link target="_blank"}
-* fix(cli): make supervisor signal handling portable by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2967](https://github.com/ag2ai/faststream/pull/2967){.external-link target="_blank"}
-* refactor: use queue fixture and RedisClusterTestcaseConfig by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2973](https://github.com/ag2ai/faststream/pull/2973){.external-link target="_blank"}
-* refactor: typing.Iterator has been replaced by typing.Generator in al… by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2970](https://github.com/ag2ai/faststream/pull/2970){.external-link target="_blank"}
-* feat: #2683 Add `ws_connection_headers` and `reconnect_to_server_handler` params" by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2971](https://github.com/ag2ai/faststream/pull/2971){.external-link target="_blank"}
-* refactor: using a fixture event, instead of creating an asyncio.Event by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2972](https://github.com/ag2ai/faststream/pull/2972){.external-link target="_blank"}
-* refactor: fix type hints for BaseTestcaseConfig.patch_broker by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2974](https://github.com/ag2ai/faststream/pull/2974){.external-link target="_blank"}
-* chore(deps): bump the github-actions group with 5 updates by @dependabot[bot] in [#2985](https://github.com/ag2ai/faststream/pull/2985){.external-link target="_blank"}
-* bug(kafka/confluent): batch per-message key alignment raises when a Response isn't first, or on duplicate bodies by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2983](https://github.com/ag2ai/faststream/pull/2983){.external-link target="_blank"}
-* fix: prevent handler exceptions leaking under AnyIO by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2984](https://github.com/ag2ai/faststream/pull/2984){.external-link target="_blank"}
-* bug(nats): [#2674] faststream raises authentication error by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2981](https://github.com/ag2ai/faststream/pull/2981){.external-link target="_blank"}
-* fix(cli): relax Typer version upper bound by [@arimu1](https://github.com/arimu1){.external-link target="_blank"} in [#2994](https://github.com/ag2ai/faststream/pull/2994){.external-link target="_blank"}
-* chore: Bump zmqtt to 0.1 and fix compat by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2997](https://github.com/ag2ai/faststream/pull/2997){.external-link target="_blank"}
-
-### New Contributors
-* [@WellFREEEzZ](https://github.com/WellFREEzZ){.external-link target="_blank"} made their first contribution in [#2953](https://github.com/ag2ai/faststream/pull/2953){.external-link target="_blank"}
-* [@arimu1](https://github.com/arimu1){.external-link target="_blank"} made their first contribution in [#2994](https://github.com/ag2ai/faststream/pull/2994){.external-link target="_blank"}
-
-**Full Changelog**: [#0.7.3...0.7.4](https://github.com/ag2ai/faststream/compare/0.7.3...0.7.4){.external-link target="_blank"}
-
-## 0.7.3
-
-### What's Changed
-* chore(rabbit): allow aio-pika 10 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2938](https://github.com/ag2ai/faststream/pull/2938){.external-link target="_blank"}
-* fix(testing): TestKafkaBroker should mock a real tombstone too by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2939](https://github.com/ag2ai/faststream/pull/2939){.external-link target="_blank"}
-* docs: fix path to app with export asyncapi by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2942](https://github.com/ag2ai/faststream/pull/2942){.external-link target="_blank"}
-* Feature/deprecate fastapi plugin by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2944](https://github.com/ag2ai/faststream/pull/2944){.external-link target="_blank"}
-* feat: add support zmqtt 0.0.6 by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2962](https://github.com/ag2ai/faststream/pull/2962){.external-link target="_blank"}
-* fix(fastapi): support FastAPI 0.140 Dependant by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2961](https://github.com/ag2ai/faststream/pull/2961){.external-link target="_blank"}
-* feat: add `typing.Required` hints for sentinel redis by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2955](https://github.com/ag2ai/faststream/pull/2955){.external-link target="_blank"}
-* refactor(redis): replace deprecated args: lib_name, lib_version to driver_in… by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2956](https://github.com/ag2ai/faststream/pull/2956){.external-link target="_blank"}
-* chore: bump redis-py version to 8.0.1 by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2952](https://github.com/ag2ai/faststream/pull/2952){.external-link target="_blank"}
-* feat(redis): add retry in redis integration (#2797) by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2954](https://github.com/ag2ai/faststream/pull/2954){.external-link target="_blank"}
-
-### New Contributors
-* [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} made their first contribution in [#2961](https://github.com/ag2ai/faststream/pull/2961){.external-link target="_blank"}
-
-**Full Changelog**: [#0.7.2...0.7.3](https://github.com/ag2ai/faststream/compare/0.7.2...0.7.3){.external-link target="_blank"}
-
-## 0.7.2
-
-### What's Changed
-
-* feat(redis): add Redis Sentinel support by [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-* feat: surface mqtt_connect_timeout on MQTTBroker by @Jsyvanen-algo in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
-* feat: add support async context managers in subscribers by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2576](https://github.com/ag2ai/faststream/pull/2576){.external-link target="_blank"}
-* fix: Forward group_instance_id from the FastAPI Kafka router by @00yhj22-debug in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
-* fix(confluent): publish(None) should send a real Kafka tombstone by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
-* fix(mqtt): installing mqtt by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2936](https://github.com/ag2ai/faststream/pull/2936){.external-link target="_blank"}
-* fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2935](https://github.com/ag2ai/faststream/pull/2935){.external-link target="_blank"}
-* docs: batch example by [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
-* docs: update Trendshift badge by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2905](https://github.com/ag2ai/faststream/pull/2905){.external-link target="_blank"}
-* docs: document Redis JSON fallback and non-FastStream interop by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2906](https://github.com/ag2ai/faststream/pull/2906){.external-link target="_blank"}
-* chore: add agent skills pinning repository development conventions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2912](https://github.com/ag2ai/faststream/pull/2912){.external-link target="_blank"}
-
-### New Contributors
-* @Jsyvanen-algo made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
-* [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} made their first contribution in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
-* [@aradng](https://github.com/aradng){.external-link target="_blank"} made their first contribution in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
-* [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} made their first contribution in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-
-**Full Changelog**: [#0.7.1...0.7.2](https://github.com/ag2ai/faststream/compare/0.7.1...0.7.2){.external-link target="_blank"}
-
-## 0.7.1
-
-### What's Changed
-
-TestBroker.__aenter__ was typed to return Broker | list[Broker]. That union is wrong for both usage shapes: mypy rejects .publish() on the single-broker result (the list arm has no such method) and rejects unpacking the multi-broker result (the Broker arm is not iterable).
-
-```python
-# Before — both lines fail under `mypy`:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    await br.publish(None, "test")
-    # error: Item "list[KafkaBroker]" of "KafkaBroker | list[KafkaBroker]" has no attribute "publish"  [union-attr]
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    # error: "KafkaBroker" object is not iterable  [misc]
-    ...
-
-# After — mypy infers the precise type:
-async with TestKafkaBroker(KafkaBroker()) as br:
-    reveal_type(br)            # KafkaBroker
-    await br.publish(None, "test")
-
-async with TestKafkaBroker(KafkaBroker(), KafkaBroker()) as (br1, br2):
-    reveal_type(br1)           # tuple[KafkaBroker, ...] -> KafkaBroker
-    await br1.publish(None, "test")
-    await br2.publish(None, "test")
-```
-
-* fix(testing): type TestBroker context result via __init__ overloads by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2903](https://github.com/ag2ai/faststream/pull/2903){.external-link target="_blank"}
-* fix(docs): export *ParserType aliases at runtime by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2898](https://github.com/ag2ai/faststream/pull/2898){.external-link target="_blank"}
-* docs: Clarify FastStream description by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2901](https://github.com/ag2ai/faststream/pull/2901){.external-link target="_blank"}
-
-
-
-**Full Changelog**: [#0.7.0...0.7.1](https://github.com/ag2ai/faststream/compare/0.7.0...0.7.1){.external-link target="_blank"}
-
-## 0.7.0
-
-### What's Changed
-
-#### 🚀 [MQTT Support](https://faststream.ag2.ai/latest/mqtt/)
-
-FastStream now includes a full-featured MQTT broker, installable via `pip install faststream[mqtt]`. It supports wildcard topic filters, path parameter capture via `Path()`, QoS levels, per-subscriber `ack_policy`, and AsyncAPI schema generation.
-
-```python
-from faststream import FastStream, Path
-from faststream.mqtt import MQTTBroker, MQTTMessage, QoS
-
-broker = MQTTBroker("localhost:1883")
-app = FastStream(broker)
-
-@broker.subscriber(
-    "sensors/{device_id}/temperature",
-    qos=QoS.AT_LEAST_ONCE,
-)
-async def on_temperature(body: str, device_id: Annotated[str, Path()]) -> None:
-    print(device_id, body)
-
-@app.after_startup
-async def publish_demo() -> None:
-    await broker.publish(21.5, "sensors/room1/temperature", qos=QoS.AT_LEAST_ONCE)
-```
-
----
-
-#### 🔀 Multi-broker Support
-
-A single FastStream application can now run multiple brokers at the same time. Pass all the brokers directly to the `FastStream` constructor — each keeps its own subscribers and publishers, and the app starts and stops all of them together. A common use case is bridging two systems: consume from one broker and re-publish to another.
-
-```python
-from faststream import FastStream
-from faststream.kafka import KafkaBroker
-from faststream.nats import NatsBroker
-
-kafka_broker = KafkaBroker("localhost:9092")
-nats_broker = NatsBroker("nats://localhost:4222")
-
-app = FastStream(kafka_broker, nats_broker)
-
-@kafka_broker.subscriber("incoming")
-@nats_broker.publisher("outgoing")
-async def from_kafka(msg: str) -> str:
-    # Bridge the message from Kafka to NATS
-    return msg
-
-@nats_broker.subscriber("outgoing")
-async def from_nats(msg: str) -> None:
-    print(f"Received from NATS: {msg}")
-```
-
----
-
-#### 🗄️ Redis Cluster Support
-
-FastStream's Redis broker now has a dedicated `RedisClusterBroker` that connects to a Redis Cluster with automatic node discovery. It is a drop-in replacement for `RedisBroker` — just change the class name and point it at any cluster node.
-
-```python
-from faststream import FastStream
-from faststream.redis import RedisClusterBroker
-
-# A single URL is enough — the cluster auto-discovers all remaining nodes
-broker = RedisClusterBroker("redis://node1:7000")
-app = FastStream(broker)
-
-@broker.subscriber("events")
-async def handle_event(msg: str) -> None:
-    print(f"Received: {msg}")
-
-@app.after_startup
-async def publish_event() -> None:
-    await broker.publish("hello from cluster", "events")
-```
-
----
-
-### ⚠️ Breaking Changes
-
-#### AsyncAPIRoute parameter renames (PR #2894)
-
-The `AsyncAPIRoute` class (used in ASGI hosting) has had two parameters renamed:
-
-| Before | After | Notes |
-|--------|-------|-------|
-| `try_it_out=False` | `try_it_out_path=None` | Disabling try-it-out now uses `None` instead of `False` |
-| `try_it_out_url="..."` | `try_it_out_path="..."` | Parameter renamed for clarity |
-
-```python
-# Before
-AsyncAPIRoute("/docs/asyncapi", try_it_out=False)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_url="https://api.example.com/asyncapi/try")
-
-# After
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path=None)
-AsyncAPIRoute("/docs/asyncapi", try_it_out_path="https://api.example.com/asyncapi/try")
-```
-
-Additionally, a new `asyncapi_json_path` parameter was added (defaults to `<path>.json`) and its position in the signature changed — use keyword arguments to avoid surprises.
-
----
-
-#### RabbitMQ: `durable=True` is now the default (PR #2892)
-
-`RabbitQueue` and `RabbitExchange` now default to `durable=True` (previously `False`). This aligns with RabbitMQ 4.3+ which disables transient non-exclusive queues by default.
-
-**Impact:** if you already have a transient (non-durable) queue or exchange of the same name declared on your broker, re-declaration will raise a `PRECONDITION_FAILED` mismatch error. To opt out, pass `durable=False` explicitly:
-
-```python
-from faststream.rabbit import RabbitQueue
-
-# To keep the old transient behavior:
-queue = RabbitQueue("my-queue", durable=False)
-```
-
----
-
-#### Deprecated items removed
 ## 0.7.5
 
 ### What's Changed
 * Update Release Notes for 0.7.4 by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2998](https://github.com/ag2ai/faststream/pull/2998){.external-link target="_blank"}
 * feat(redis): add batch stream message annotation by [@Sehat1137](https://github.com/Sehat1137){.external-link target="_blank"} in [#3007](https://github.com/ag2ai/faststream/pull/3007){.external-link target="_blank"}
 * Feature: correlation_id factory function at broker creation time, e.g. for ulids by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2995](https://github.com/ag2ai/faststream/pull/2995){.external-link target="_blank"}
-* fix: skip ack action on handler cancellation by @Arseniy-Popov in [#3010](https://github.com/ag2ai/faststream/pull/3010){.external-link target="_blank"}
+* fix: skip ack action on handler cancellation by [@Arseniy-Popov](https://github.com/Arseniy-Popov){.external-link target="_blank"} in [#3010](https://github.com/ag2ai/faststream/pull/3010){.external-link target="_blank"}
 * docs: expand RabbitMQ Streams guide by [@Himanshuagrawal4](https://github.com/Himanshuagrawal4){.external-link target="_blank"} in [#3006](https://github.com/ag2ai/faststream/pull/3006){.external-link target="_blank"}
 * fix(redis): consume existing entries in new groups by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2976](https://github.com/ag2ai/faststream/pull/2976){.external-link target="_blank"}
 * feat: Add mqtt dsn as alternative to direct url attributes by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#3012](https://github.com/ag2ai/faststream/pull/3012){.external-link target="_blank"}
@@ -809,7 +54,7 @@ queue = RabbitQueue("my-queue", durable=False)
 * feat: #2683 Add `ws_connection_headers` and `reconnect_to_server_handler` params" by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2971](https://github.com/ag2ai/faststream/pull/2971){.external-link target="_blank"}
 * refactor: using a fixture event, instead of creating an asyncio.Event by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2972](https://github.com/ag2ai/faststream/pull/2972){.external-link target="_blank"}
 * refactor: fix type hints for BaseTestcaseConfig.patch_broker by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2974](https://github.com/ag2ai/faststream/pull/2974){.external-link target="_blank"}
-* chore(deps): bump the github-actions group with 5 updates by @dependabot[bot] in [#2985](https://github.com/ag2ai/faststream/pull/2985){.external-link target="_blank"}
+* chore(deps): bump the github-actions group with 5 updates by [@dependabot](https://github.com/dependabot){.external-link target="_blank"}[bot] in [#2985](https://github.com/ag2ai/faststream/pull/2985){.external-link target="_blank"}
 * bug(kafka/confluent): batch per-message key alignment raises when a Response isn't first, or on duplicate bodies by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2983](https://github.com/ag2ai/faststream/pull/2983){.external-link target="_blank"}
 * fix: prevent handler exceptions leaking under AnyIO by [@dk3yyyy](https://github.com/dk3yyyy){.external-link target="_blank"} in [#2984](https://github.com/ag2ai/faststream/pull/2984){.external-link target="_blank"}
 * bug(nats): [#2674] faststream raises authentication error by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2981](https://github.com/ag2ai/faststream/pull/2981){.external-link target="_blank"}
@@ -846,9 +91,9 @@ queue = RabbitQueue("my-queue", durable=False)
 ### What's Changed
 
 * feat(redis): add Redis Sentinel support by [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
-* feat: surface mqtt_connect_timeout on MQTTBroker by @Jsyvanen-algo in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* feat: surface mqtt_connect_timeout on MQTTBroker by [@Jsyvanen-algo](https://github.com/Jsyvanen-algo){.external-link target="_blank"} in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
 * feat: add support async context managers in subscribers by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2576](https://github.com/ag2ai/faststream/pull/2576){.external-link target="_blank"}
-* fix: Forward group_instance_id from the FastAPI Kafka router by @00yhj22-debug in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
+* fix: Forward group_instance_id from the FastAPI Kafka router by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2882](https://github.com/ag2ai/faststream/pull/2882){.external-link target="_blank"}
 * fix(confluent): publish(None) should send a real Kafka tombstone by [@aradng](https://github.com/aradng){.external-link target="_blank"} in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
 * fix(mqtt): installing mqtt by [@IvanKirpichnikov](https://github.com/IvanKirpichnikov){.external-link target="_blank"} in [#2936](https://github.com/ag2ai/faststream/pull/2936){.external-link target="_blank"}
 * fix(redis): RedisClusterBroker silently drops TLS config from BaseSecurity by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2935](https://github.com/ag2ai/faststream/pull/2935){.external-link target="_blank"}
@@ -858,7 +103,7 @@ queue = RabbitQueue("my-queue", durable=False)
 * chore: add agent skills pinning repository development conventions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2912](https://github.com/ag2ai/faststream/pull/2912){.external-link target="_blank"}
 
 ### New Contributors
-* @Jsyvanen-algo made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
+* [@Jsyvanen-algo](https://github.com/Jsyvanen-algo){.external-link target="_blank"} made their first contribution in [#2911](https://github.com/ag2ai/faststream/pull/2911){.external-link target="_blank"}
 * [@musecollaboration](https://github.com/musecollaboration){.external-link target="_blank"} made their first contribution in [#2914](https://github.com/ag2ai/faststream/pull/2914){.external-link target="_blank"}
 * [@aradng](https://github.com/aradng){.external-link target="_blank"} made their first contribution in [#2932](https://github.com/ag2ai/faststream/pull/2932){.external-link target="_blank"}
 * [@PAzter1101](https://github.com/PAzter1101){.external-link target="_blank"} made their first contribution in [#2895](https://github.com/ag2ai/faststream/pull/2895){.external-link target="_blank"}
@@ -1030,370 +275,70 @@ The following APIs that were deprecated in earlier 0.x releases have been fully 
 
 #### Features
 
-* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
-* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
-* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
-* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
-* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
-* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
-* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
-* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
-* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
-* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
-* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
-* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
+* feat: FastStream[mqtt] by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2819](https://github.com/ag2ai/faststream/pull/2819){.external-link target="_blank"}
+* feat: support broker-level ack_policy with per-subscriber override by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2827](https://github.com/ag2ai/faststream/pull/2827){.external-link target="_blank"}
+* feat: codec wiring unification by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2841](https://github.com/ag2ai/faststream/pull/2841){.external-link target="_blank"}
+* feat: add mqtt path support by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2873](https://github.com/ag2ai/faststream/pull/2873){.external-link target="_blank"}
+* feat: expose client_rack option on the Kafka broker by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2871](https://github.com/ag2ai/faststream/pull/2871){.external-link target="_blank"}
+* feat: allow aiokafka 0.14 by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2884](https://github.com/ag2ai/faststream/pull/2884){.external-link target="_blank"}
+* feat: add fastapi mqtt router by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2887](https://github.com/ag2ai/faststream/pull/2887){.external-link target="_blank"}
+* feat: add consumer_only flag to KafkaBroker by [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} in [#2883](https://github.com/ag2ai/faststream/pull/2883){.external-link target="_blank"}
+* feat: add Redis Cluster broker support by [@powersemmi](https://github.com/powersemmi){.external-link target="_blank"} in [#2854](https://github.com/ag2ai/faststream/pull/2854){.external-link target="_blank"}
+* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2850](https://github.com/ag2ai/faststream/pull/2850){.external-link target="_blank"}
+* feat: add multibrokers support by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2867](https://github.com/ag2ai/faststream/pull/2867){.external-link target="_blank"}
+* feat: add json endpoint and fix content-type header by [@Cool-Cat09](https://github.com/Cool-Cat09){.external-link target="_blank"} in [#2894](https://github.com/ag2ai/faststream/pull/2894){.external-link target="_blank"}
 
 #### Bug Fixes
 
-* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
-* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
-* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
-* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
-* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
-* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
-* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
-* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
-* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
-* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
-* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
-* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
+* fix: include pattern subscribers in AsyncAPI specification by [@aazmv](https://github.com/aazmv){.external-link target="_blank"} in [#2813](https://github.com/ag2ai/faststream/pull/2813){.external-link target="_blank"}
+* fix: cli preserve import errors by [@vovkka](https://github.com/vovkka){.external-link target="_blank"} in [#2817](https://github.com/ag2ai/faststream/pull/2817){.external-link target="_blank"}
+* fix: security parsing for mqtt broker by [@lemmehoop](https://github.com/lemmehoop){.external-link target="_blank"} in [#2832](https://github.com/ag2ai/faststream/pull/2832){.external-link target="_blank"}
+* fix: propagate outer context to nested StreamRouter on include by [@lesnik512](https://github.com/lesnik512){.external-link target="_blank"} in [#2828](https://github.com/ag2ai/faststream/pull/2828){.external-link target="_blank"}
+* fix: parsing pydantic models by [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} in [#2847](https://github.com/ag2ai/faststream/pull/2847){.external-link target="_blank"}
+* fix: try-it-out request timeout and NATS fake subscriber stream by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2853](https://github.com/ag2ai/faststream/pull/2853){.external-link target="_blank"}
+* fix: handle NOGROUP error on Redis stream subscriber by [@powersemmi](https://github.com/powersemmi){.external-link target="_blank"} in [#2855](https://github.com/ag2ai/faststream/pull/2855){.external-link target="_blank"}
+* fix: logger not passed to Confluent Producer and AdminClient by [@mara-werils](https://github.com/mara-werils){.external-link target="_blank"} in [#2859](https://github.com/ag2ai/faststream/pull/2859){.external-link target="_blank"}
+* fix: encode unsafe AsyncAPI reference path parts, including {} and / by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2872](https://github.com/ag2ai/faststream/pull/2872){.external-link target="_blank"}
+* fix: register POST {schema_url}/try for AsyncAPI try-it-out by [@sfrangulov](https://github.com/sfrangulov){.external-link target="_blank"} in [#2876](https://github.com/ag2ai/faststream/pull/2876){.external-link target="_blank"}
+* fix: consistent hashing and equality for RabbitMQ schemas by [@RinZ27](https://github.com/RinZ27){.external-link target="_blank"} in [#2796](https://github.com/ag2ai/faststream/pull/2796){.external-link target="_blank"}
+* fix: default RabbitQueue and RabbitExchange to durable=True by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2892](https://github.com/ag2ai/faststream/pull/2892){.external-link target="_blank"}
 
 #### Documentation
 
-* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
-* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
-* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
-* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
-* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
-* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
-* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
+* docs: images generation in release notes by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2792](https://github.com/ag2ai/faststream/pull/2792){.external-link target="_blank"}
+* docs: add multiple topics registration with a single call by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2814](https://github.com/ag2ai/faststream/pull/2814){.external-link target="_blank"}
+* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2815](https://github.com/ag2ai/faststream/pull/2815){.external-link target="_blank"}
+* docs: change polling_interval units (seconds -> milliseconds) by [@MikhailWar](https://github.com/MikhailWar){.external-link target="_blank"} in [#2821](https://github.com/ag2ai/faststream/pull/2821){.external-link target="_blank"}
+* docs: document per-message attributes via KafkaPublishMessage in publish_batch by [@Bazarovinc](https://github.com/Bazarovinc){.external-link target="_blank"} in [#2851](https://github.com/ag2ai/faststream/pull/2851){.external-link target="_blank"}
+* docs: cover mqtt examples by tests by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2888](https://github.com/ag2ai/faststream/pull/2888){.external-link target="_blank"}
+* docs: add multiple brokers support page by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2896](https://github.com/ag2ai/faststream/pull/2896){.external-link target="_blank"}
 
 #### Chore / CI
 
-* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
-* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
-* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
-* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
-* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
-* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
+* chore: test basic 3.14 by [@vvlrff](https://github.com/vvlrff){.external-link target="_blank"} in [#2795](https://github.com/ag2ai/faststream/pull/2795){.external-link target="_blank"}
+* chore: prepare 0.7.0 update by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2822](https://github.com/ag2ai/faststream/pull/2822){.external-link target="_blank"}
+* chore: add MQTT code ownership for borisalekseev by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2825](https://github.com/ag2ai/faststream/pull/2825){.external-link target="_blank"}
+* chore: add MQTT AsyncAPI tests by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2830](https://github.com/ag2ai/faststream/pull/2830){.external-link target="_blank"}
+* chore: parser codec protocols by [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} in [#2839](https://github.com/ag2ai/faststream/pull/2839){.external-link target="_blank"}
+* chore: merge schema by [@aligeromachine](https://github.com/aligeromachine){.external-link target="_blank"} in [#2849](https://github.com/ag2ai/faststream/pull/2849){.external-link target="_blank"}
 
 ### New Contributors
-* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
-* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
-* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
-* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
-* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
-* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
-* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
-* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
-* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
-* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
-* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
-* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
-* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
-* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
+* [@aazmv](https://github.com/aazmv){.external-link target="_blank"} made their first contribution in [#2813](https://github.com/ag2ai/faststream/pull/2813){.external-link target="_blank"}
+* [@vovkka](https://github.com/vovkka){.external-link target="_blank"} made their first contribution in [#2817](https://github.com/ag2ai/faststream/pull/2817){.external-link target="_blank"}
+* [@benaduo](https://github.com/benaduo){.external-link target="_blank"} made their first contribution in [#2814](https://github.com/ag2ai/faststream/pull/2814){.external-link target="_blank"}
+* [@MikhailWar](https://github.com/MikhailWar){.external-link target="_blank"} made their first contribution in [#2821](https://github.com/ag2ai/faststream/pull/2821){.external-link target="_blank"}
+* [@ce1ebrimbor](https://github.com/ce1ebrimbor){.external-link target="_blank"} made their first contribution in [#2827](https://github.com/ag2ai/faststream/pull/2827){.external-link target="_blank"}
+* [@lemmehoop](https://github.com/lemmehoop){.external-link target="_blank"} made their first contribution in [#2832](https://github.com/ag2ai/faststream/pull/2832){.external-link target="_blank"}
+* [@lesnik512](https://github.com/lesnik512){.external-link target="_blank"} made their first contribution in [#2828](https://github.com/ag2ai/faststream/pull/2828){.external-link target="_blank"}
+* [@ApusBerliozi](https://github.com/ApusBerliozi){.external-link target="_blank"} made their first contribution in [#2847](https://github.com/ag2ai/faststream/pull/2847){.external-link target="_blank"}
+* [@Bazarovinc](https://github.com/Bazarovinc){.external-link target="_blank"} made their first contribution in [#2851](https://github.com/ag2ai/faststream/pull/2851){.external-link target="_blank"}
+* [@mara-werils](https://github.com/mara-werils){.external-link target="_blank"} made their first contribution in [#2859](https://github.com/ag2ai/faststream/pull/2859){.external-link target="_blank"}
+* [@00yhj22-debug](https://github.com/00yhj22-debug){.external-link target="_blank"} made their first contribution in [#2871](https://github.com/ag2ai/faststream/pull/2871){.external-link target="_blank"}
+* [@sfrangulov](https://github.com/sfrangulov){.external-link target="_blank"} made their first contribution in [#2876](https://github.com/ag2ai/faststream/pull/2876){.external-link target="_blank"}
+* [@RinZ27](https://github.com/RinZ27){.external-link target="_blank"} made their first contribution in [#2796](https://github.com/ag2ai/faststream/pull/2796){.external-link target="_blank"}
+* [@Cool-Cat09](https://github.com/Cool-Cat09){.external-link target="_blank"} made their first contribution in [#2894](https://github.com/ag2ai/faststream/pull/2894){.external-link target="_blank"}
 
-**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
-
-
-The following APIs that were deprecated in earlier 0.x releases have been fully removed in 0.7.0:
-
-- **Publisher/subscriber-level middlewares** — use broker-level or app-level middlewares instead.
-- **`ack_first`**, **`no_ack`** and related subscriber options — replaced by `ack_policy=AckPolicy.*`
-- **`RedisJSONMessageParser`** — removed. All Redis services must now use the binary message format.
-- **`broker.close()`** — removed. Use `broker.stop()` instead.
-
-#### Features
-
-* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
-* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
-* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
-* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
-* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
-* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
-* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
-* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
-* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
-* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
-* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
-* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
-
-#### Bug Fixes
-
-* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
-* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
-* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
-* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
-* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
-* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
-* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
-* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
-* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
-* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
-* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
-* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
-
-#### Documentation
-
-* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
-* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
-* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
-* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
-* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
-* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
-* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
-
-#### Chore / CI
-
-* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
-* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
-* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
-* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
-* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
-* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
-
-### New Contributors
-* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
-* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
-* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
-* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
-* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
-* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
-* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
-* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
-* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
-* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
-* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
-* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
-* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
-* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
-
-**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
-
-
-The following APIs that were deprecated in earlier 0.x releases have been fully removed in 0.7.0:
-
-- **Publisher/subscriber-level middlewares** — use broker-level or app-level middlewares instead.
-- **`ack_first`**, **`no_ack`** and related subscriber options — replaced by `ack_policy=AckPolicy.*`
-- **`RedisJSONMessageParser`** — removed. All Redis services must now use the binary message format.
-- **`broker.close()`** — removed. Use `broker.stop()` instead.
-
-#### Features
-
-* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
-* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
-* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
-* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
-* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
-* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
-* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
-* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
-* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
-* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
-* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
-* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
-
-#### Bug Fixes
-
-* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
-* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
-* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
-* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
-* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
-* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
-* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
-* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
-* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
-* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
-* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
-* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
-
-#### Documentation
-
-* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
-* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
-* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
-* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
-* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
-* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
-* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
-
-#### Chore / CI
-
-* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
-* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
-* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
-* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
-* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
-* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
-
-### New Contributors
-* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
-* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
-* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
-* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
-* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
-* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
-* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
-* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
-* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
-* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
-* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
-* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
-* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
-* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
-
-**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
-
-
-The following APIs that were deprecated in earlier 0.x releases have been fully removed in 0.7.0:
-
-- **Publisher/subscriber-level middlewares** — use broker-level or app-level middlewares instead.
-- **`ack_first`**, **`no_ack`** and related subscriber options — replaced by `ack_policy=AckPolicy.*`
-- **`RedisJSONMessageParser`** — removed. All Redis services must now use the binary message format.
-- **`broker.close()`** — removed. Use `broker.stop()` instead.
-
-#### Features
-
-* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
-* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
-* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
-* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
-* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
-* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
-* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
-* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
-* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
-* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
-* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
-* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
-
-#### Bug Fixes
-
-* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
-* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
-* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
-* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
-* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
-* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
-* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
-* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
-* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
-* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
-* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
-* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
-
-#### Documentation
-
-* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
-* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
-* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
-* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
-* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
-* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
-* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
-
-#### Chore / CI
-
-* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
-* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
-* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
-* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
-* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
-* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
-
-### New Contributors
-* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
-* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
-* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
-* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
-* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
-* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
-* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
-* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
-* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
-* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
-* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
-* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
-* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
-* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
-
-**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
-
-
-The following APIs that were deprecated in earlier 0.x releases have been fully removed in 0.7.0:
-
-- **Publisher/subscriber-level middlewares** — use broker-level or app-level middlewares instead.
-- **`ack_first`**, **`no_ack`** and related subscriber options — replaced by `ack_policy=AckPolicy.*`
-- **`RedisJSONMessageParser`** — removed. All Redis services must now use the binary message format.
-- **`broker.close()`** — removed. Use `broker.stop()` instead.
-
-#### Features
-
-* feat: FastStream[mqtt] by @borisalekseev in https://github.com/ag2ai/faststream/pull/2819
-* feat: support broker-level ack_policy with per-subscriber override by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2827
-* feat: codec wiring unification by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2841
-* feat: add mqtt path support by @borisalekseev in https://github.com/ag2ai/faststream/pull/2873
-* feat: expose client_rack option on the Kafka broker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2871
-* feat: allow aiokafka 0.14 by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2884
-* feat: add fastapi mqtt router by @borisalekseev in https://github.com/ag2ai/faststream/pull/2887
-* feat: add consumer_only flag to KafkaBroker by @00yhj22-debug in https://github.com/ag2ai/faststream/pull/2883
-* feat: add Redis Cluster broker support by @powersemmi in https://github.com/ag2ai/faststream/pull/2854
-* feat: wire codec.encode into all producers, add BatchCodecProto for batch-aware encoding by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2850
-* feat: add multibrokers support by @Lancetnik in https://github.com/ag2ai/faststream/pull/2867
-* feat: add json endpoint and fix content-type header by @Cool-Cat09 in https://github.com/ag2ai/faststream/pull/2894
-
-#### Bug Fixes
-
-* fix: include pattern subscribers in AsyncAPI specification by @aazmv in https://github.com/ag2ai/faststream/pull/2813
-* fix: cli preserve import errors by @vovkka in https://github.com/ag2ai/faststream/pull/2817
-* fix: security parsing for mqtt broker by @lemmehoop in https://github.com/ag2ai/faststream/pull/2832
-* fix: propagate outer context to nested StreamRouter on include by @lesnik512 in https://github.com/ag2ai/faststream/pull/2828
-* fix: parsing pydantic models by @ApusBerliozi in https://github.com/ag2ai/faststream/pull/2847
-* fix: try-it-out request timeout and NATS fake subscriber stream by @Lancetnik in https://github.com/ag2ai/faststream/pull/2853
-* fix: handle NOGROUP error on Redis stream subscriber by @powersemmi in https://github.com/ag2ai/faststream/pull/2855
-* fix: logger not passed to Confluent Producer and AdminClient by @mara-werils in https://github.com/ag2ai/faststream/pull/2859
-* fix: encode unsafe AsyncAPI reference path parts, including {} and / by @borisalekseev in https://github.com/ag2ai/faststream/pull/2872
-* fix: register POST {schema_url}/try for AsyncAPI try-it-out by @sfrangulov in https://github.com/ag2ai/faststream/pull/2876
-* fix: consistent hashing and equality for RabbitMQ schemas by @RinZ27 in https://github.com/ag2ai/faststream/pull/2796
-* fix: default RabbitQueue and RabbitExchange to durable=True by @Lancetnik in https://github.com/ag2ai/faststream/pull/2892
-
-#### Documentation
-
-* docs: images generation in release notes by @Lancetnik in https://github.com/ag2ai/faststream/pull/2792
-* docs: add multiple topics registration with a single call by @benaduo in https://github.com/ag2ai/faststream/pull/2814
-* docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by @benaduo in https://github.com/ag2ai/faststream/pull/2815
-* docs: change polling_interval units (seconds -> milliseconds) by @MikhailWar in https://github.com/ag2ai/faststream/pull/2821
-* docs: document per-message attributes via KafkaPublishMessage in publish_batch by @Bazarovinc in https://github.com/ag2ai/faststream/pull/2851
-* docs: cover mqtt examples by tests by @borisalekseev in https://github.com/ag2ai/faststream/pull/2888
-* docs: add multiple brokers support page by @Lancetnik in https://github.com/ag2ai/faststream/pull/2896
-
-#### Chore / CI
-
-* chore: test basic 3.14 by @vvlrff in https://github.com/ag2ai/faststream/pull/2795
-* chore: prepare 0.7.0 update by @borisalekseev in https://github.com/ag2ai/faststream/pull/2822
-* chore: add MQTT code ownership for borisalekseev by @Lancetnik in https://github.com/ag2ai/faststream/pull/2825
-* chore: add MQTT AsyncAPI tests by @Lancetnik in https://github.com/ag2ai/faststream/pull/2830
-* chore: parser codec protocols by @ce1ebrimbor in https://github.com/ag2ai/faststream/pull/2839
-* chore: merge schema by @aligeromachine in https://github.com/ag2ai/faststream/pull/2849
-
-### New Contributors
-* @aazmv made their first contribution in https://github.com/ag2ai/faststream/pull/2813
-* @vovkka made their first contribution in https://github.com/ag2ai/faststream/pull/2817
-* @benaduo made their first contribution in https://github.com/ag2ai/faststream/pull/2814
-* @MikhailWar made their first contribution in https://github.com/ag2ai/faststream/pull/2821
-* @ce1ebrimbor made their first contribution in https://github.com/ag2ai/faststream/pull/2827
-* @lemmehoop made their first contribution in https://github.com/ag2ai/faststream/pull/2832
-* @lesnik512 made their first contribution in https://github.com/ag2ai/faststream/pull/2828
-* @ApusBerliozi made their first contribution in https://github.com/ag2ai/faststream/pull/2847
-* @Bazarovinc made their first contribution in https://github.com/ag2ai/faststream/pull/2851
-* @mara-werils made their first contribution in https://github.com/ag2ai/faststream/pull/2859
-* @00yhj22-debug made their first contribution in https://github.com/ag2ai/faststream/pull/2871
-* @sfrangulov made their first contribution in https://github.com/ag2ai/faststream/pull/2876
-* @RinZ27 made their first contribution in https://github.com/ag2ai/faststream/pull/2796
-* @Cool-Cat09 made their first contribution in https://github.com/ag2ai/faststream/pull/2894
-
-**Full Changelog**: https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0
+**Full Changelog**: [#0.6.7...0.7.0](https://github.com/ag2ai/faststream/compare/0.6.7...0.7.0){.external-link target="_blank"}
 
 ## 0.7.0rc1
 
@@ -1414,9 +359,9 @@ The following APIs that were deprecated in earlier 0.x releases have been fully 
 
 ### What's Changed
 
-Just two main changes:
+Just two main changes: 
 
-1. `from faststream.mqtt import MQTTBroker` (thanks @borisalekseev)
+1. `from faststream.mqtt import MQTTBroker` (thanks [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"})
 2. All deprecations removed:
     - publisher/subscriber-level middlewares
     - ack_policy now replaces several deprecated options
@@ -1432,11 +377,11 @@ uv add --pre "faststream[mqtt]==0.7.0rc0"
 ```
 
 We will release a stable version as soon as we test `MQTTBroker` with production services (in a few weeks).
-
+   
 * feat: FastStream[mqtt] by [@borisalekseev](https://github.com/borisalekseev){.external-link target="_blank"} in [#2819](https://github.com/ag2ai/faststream/pull/2819){.external-link target="_blank"}
-* docs: fix images generation in release notes by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2792](https://github.com/ag2ai/faststream/pull/2792){.external-link target="_blank"}
 * fix: include pattern subscribers in AsyncAPI specification by [@aazmv](https://github.com/aazmv){.external-link target="_blank"} in [#2813](https://github.com/ag2ai/faststream/pull/2813){.external-link target="_blank"}
 * fix: cli preserve import errors by [@vovkka](https://github.com/vovkka){.external-link target="_blank"} in [#2817](https://github.com/ag2ai/faststream/pull/2817){.external-link target="_blank"}
+* docs: fix images generation in release notes by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#2792](https://github.com/ag2ai/faststream/pull/2792){.external-link target="_blank"}
 * docs: add multiple topics registration with a single call by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2814](https://github.com/ag2ai/faststream/pull/2814){.external-link target="_blank"}
 * docs: add How-To section placeholders for RabbitMQ, Confluent, and Redis by [@benaduo](https://github.com/benaduo){.external-link target="_blank"} in [#2815](https://github.com/ag2ai/faststream/pull/2815){.external-link target="_blank"}
 * docs: change polling_interval units (seconds -> milliseconds) by [@MikhailWar](https://github.com/MikhailWar){.external-link target="_blank"} in [#2821](https://github.com/ag2ai/faststream/pull/2821){.external-link target="_blank"}

--- a/docs/update_releases.py
+++ b/docs/update_releases.py
@@ -9,12 +9,13 @@ def find_metablock(lines: List[str]) -> Tuple[List[str], List[str]]:
     if lines[0] != "---":
         return [], lines
 
-    index: int = 0
+    # The metablock ends at the *first* closing "---": later ones are just
+    # horizontal rules inside release bodies.
     for i in range(1, len(lines)):
         if lines[i] == "---":
-            index = i + 1
+            return lines[: i + 1], lines[i + 1 :]
 
-    return lines[:index], lines[index:]
+    return [], lines
 
 
 def find_header(lines: List[str]) -> Tuple[str, List[str]]:
@@ -54,41 +55,73 @@ def normalize_img_tag(match: re.Match) -> str:
     return "<img " + " ".join(parts) + ">"
 
 
+IMG_PATTERN = re.compile(r"<img\s+([^>]+)>", re.IGNORECASE)
+
+# Fragments that must survive untouched: whatever is already a link, markup or
+# code. Everything outside them is plain text we are free to rewrite.
+PROTECTED_PATTERN = re.compile(
+    "|".join((
+        r"```.*?```",  # fenced code block
+        r"`[^`\n]+`",  # inline code
+        r"<https?://[^>\s]+>",  # autolink
+        r"</?[A-Za-z][^>\n]*>",  # HTML tag, <img ...> included
+        r"!?\[[^\]\n]*\]\([^)\n]*\)(?:\{[^}\n]*\})?",  # markdown link/image
+        r"^\[[^\]\n]+\]:\s*\S+",  # markdown link definition
+    )),
+    re.DOTALL | re.MULTILINE,
+)
+
+URL_PATTERN = re.compile(r"https?://[^\s<>()\[\]]+")
+
+# A GitHub mention, as opposed to a Python decorator (@app.get, @broker(...))
+# or the local part of an e-mail address.
+USERNAME_PATTERN = re.compile(
+    r"(?<![\w.\-/])@([A-Za-z\d](?:[A-Za-z\d-]{0,37}[A-Za-z\d])?)(?![\w-])(?!\.\w)(?!\()",
+)
+
+EXTERNAL_LINK_ATTRS = '{.external-link target="_blank"}'
+
+
+def link_url(match: re.Match) -> str:
+    url = match.group(0)
+    # Trailing punctuation belongs to the sentence, not to the URL
+    trailing = ""
+    while url and url[-1] in ".,;:!?'\"":
+        url, trailing = url[:-1], url[-1] + trailing
+    if not url:
+        return match.group(0)
+    name = url.rstrip("/").rsplit("/", 1)[-1] or url
+    return f"[#{name}]({url}){EXTERNAL_LINK_ATTRS}{trailing}"
+
+
+def link_username(match: re.Match) -> str:
+    username = match.group(1)
+    return f"[@{username}](https://github.com/{username}){EXTERNAL_LINK_ATTRS}"
+
+
 def convert_links_and_usernames(text: str) -> str:
-    # Replace <img ...> tags with placeholders so their URLs are not wrapped as links
-    img_pattern = re.compile(r"<img\s+([^>]+)>")
-    img_placeholders: List[str] = []
+    protected: List[str] = []
 
-    def stash_img(match: re.Match) -> str:
-        img_placeholders.append(normalize_img_tag(match))
-        return f"\x00IMG_PLACEHOLDER_{len(img_placeholders) - 1}\x00"
+    def stash(match: re.Match) -> str:
+        fragment = match.group(0)
+        if img := IMG_PATTERN.fullmatch(fragment):
+            fragment = normalize_img_tag(img)
+        protected.append(fragment)
+        return f"\x00PROTECTED_{len(protected) - 1}\x00"
 
-    text = img_pattern.sub(stash_img, text)
+    text = PROTECTED_PATTERN.sub(stash, text)
 
-    if "](" not in text:
-        # Convert HTTP/HTTPS links (img tags already stashed, so their URLs are not matched)
-        text = re.sub(
-            r"(https?://.*\/(.*))",
-            r'[#\2](\1){.external-link target="_blank"}',
-            text,
-        )
+    text = URL_PATTERN.sub(link_url, text)
+    text = USERNAME_PATTERN.sub(link_username, text)
 
-        # Convert GitHub usernames to links
-        text = re.sub(
-            r"@(\w+) ",
-            r'[@\1](https://github.com/\1){.external-link target="_blank"} ',
-            text,
-        )
-
-    # Restore normalized img tags
-    for i, img in enumerate(img_placeholders):
-        text = text.replace(f"\x00IMG_PLACEHOLDER_{i}\x00", img)
+    for i, fragment in enumerate(protected):
+        text = text.replace(f"\x00PROTECTED_{i}\x00", fragment)
 
     return text
 
 
 def collect_already_published_versions(text: str) -> List[str]:
-    data: List[str] = re.findall(r"## (\d.\d.\d.*)", text)
+    data: List[str] = re.findall(r"^## (\d+\.\d+\.\d+.*)", text, re.MULTILINE)
     return data
 
 

--- a/docs/update_releases.py
+++ b/docs/update_releases.py
@@ -120,6 +120,11 @@ def convert_links_and_usernames(text: str) -> str:
     return text
 
 
+def strip_trailing_whitespace(text: str) -> str:
+    """Drop trailing spaces GitHub keeps in release bodies: pre-commit strips them."""
+    return "\n".join(line.rstrip() for line in text.splitlines()).strip()
+
+
 def collect_already_published_versions(text: str) -> List[str]:
     data: List[str] = re.findall(r"^## (\d+\.\d+\.\d+.*)", text, re.MULTILINE)
     return data
@@ -144,6 +149,7 @@ def update_release_notes(release_notes_path: Path):
     ):
         body = body.replace("##", "###")
         body = convert_links_and_usernames(body)
+        body = strip_trailing_whitespace(body)
         version_changelog = f"## {version}\n\n{body}\n\n"
         changelog = version_changelog + changelog
         added_versions.append(version)


### PR DESCRIPTION
## Problem

`docs/docs/en/release.md` had every `0.7.*` section repeated up to **five times**, and several copies were truncated or had a duplicated tail glued onto them.

Two bugs in `docs/update_releases.py`:

1. **`find_metablock` looked for the *last* `---` in the file**, not for the closing delimiter of the front matter. As soon as a release body contained horizontal rules (the 0.7.0 notes have plenty — 27 `---` lines were in the file), everything above the last one was treated as metadata. `collect_already_published_versions` then only saw the tail of the changelog, found no 0.7.* there, and re-added all of them on every run. `find_header` additionally dropped the lines between that `---` and the next heading, which is what corrupted the bodies.

2. **Link conversion bailed out on the whole body** when it already contained a markdown link (`if "](" not in text`). GitHub now renders PR references as markdown in generated release bodies, so for recent releases nothing was converted at all and `@username` mentions stayed bare.

## Fix

* `find_metablock` returns at the first closing `---`.
* `collect_already_published_versions` anchors its regex at line start (`^## `, `re.MULTILINE`) so `###` headings inside release bodies can no longer be mistaken for published versions.
* `convert_links_and_usernames` now works per fragment instead of all-or-nothing: fenced/inline code, HTML tags, autolinks and existing markdown links are stashed away, and only the remaining plain text is rewritten. Along the way:
  * bare URLs no longer swallow the rest of the line (the old greedy `(https?://.*\/(.*))`), and trailing sentence punctuation stays outside the link;
  * Python decorators (`@app.after_startup`, `@broker.subscriber(...)`) and e-mail addresses are no longer turned into GitHub profile links;
  * mention matching follows GitHub's username rules and no longer requires a trailing space.
* `docs/docs/en/release.md`: all duplicated 0.7.* sections dropped and regenerated by the fixed script.

## Verification

* First run after cleaning: `Added release versions: 0.7.0rc0, 0.7.0rc1, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.7.4, 0.7.5`.
* Second run: `No new versions to add`, and the file is byte-identical to the first run's output.
* All 110 sections for 0.6.7 and older are untouched, front matter is unchanged, no duplicate headings remain.
* `convert_links_and_usernames` is idempotent on its own output, and the only remaining bare URLs/mentions in the regenerated sections are inside code blocks, where they belong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)