### PR TITLE
docs: warn that --log-file CLI flag is not available in v0.5

### DIFF
--- a/docs/docs/en/getting-started/observability/logging.md
+++ b/docs/docs/en/getting-started/observability/logging.md
@@ -65,6 +65,13 @@ broker = RabbitBroker(log_level=logging.DEBUG)
 
 ## Setting logging configuration from file
 
+!!! warning "CLI flag availability"
+    The `--log-file` CLI flag shown below is **not available in FastStream 0.5**.
+    It was documented in the release notes for a later version; running
+    `faststream run serve:app --log-file config.json` on 0.5 fails with an
+    "unrecognized arguments" error. Verify your installed version
+    (`faststream --version`) before relying on it.
+
 If you use **FastStream CLI**, you have the option to use a file to configure your logging of the entire application directly from the command line.
 
 === "JSON"


### PR DESCRIPTION
## Summary

Per #3047: the "Setting logging configuration from file" section of the observability docs presents `faststream run serve:app --log-file config.json` as generally available, but the `--log-file` flag is **not available in FastStream 0.5** (it was documented in release notes for a later version). On 0.5 the command fails with an "unrecognized arguments" error.

## Fix

Added a MkDocs `!!! warning` callout at the top of the section that:
- States the flag is not available in 0.5
- Explains the failure mode on 0.5
- Tells readers to verify their installed version (`faststream --version`) first

## Changes

- `docs/docs/en/getting-started/observability/logging.md`: added the warning callout; example commands unchanged