### PR TITLE
fix(docs): repair the 404 link to the documentation contribution guide

### DIFF
--- a/docs/docs/en/getting-started/contributing/CONTRIBUTING.md
+++ b/docs/docs/en/getting-started/contributing/CONTRIBUTING.md
@@ -196,7 +196,7 @@ just pre-commit-all
 
 ## Documentation
 
-For detailed instructions on building and serving the documentation, please refer to the [documentation contribution guide](/getting-started/contributing/docs){.internal-link}.
+For detailed instructions on building and serving the documentation, please refer to the [documentation contribution guide](./docs.md){.internal-link}.
 
 ## Commits
 

--- a/docs/docs/en/getting-started/contributing/docs.md
+++ b/docs/docs/en/getting-started/contributing/docs.md
@@ -60,9 +60,9 @@ After making all the changes, you can issue a `PR` with them - and we will gladl
 
     (e.g [**Propan**](https://github.com/lancetnik/propan){.external-link target="_blank"} - `[**Propan**](https://github.com/lancetnik/propan){.external-link target="_blank"}`)
 
-- Internal links need to mark `{.internal-link}`
+- Internal links need to mark `{.internal-link}` and point to a relative path of the target `.md` file (root-absolute paths like `/getting-started/...` break, because the site is served under a version prefix such as `/latest/`)
 
-    (e.g [contribution page](/getting-started/contributing/contributing){.internal-link} - `[contribution page](/getting-started/contributing/contributing){.internal-link}`)
+    (e.g [contribution page](./CONTRIBUTING.md){.internal-link} - `[contribution page](./CONTRIBUTING.md){.internal-link}`)
 
 - A lot of links going in a row doesn't need to mark both `{.external_link}` and `{.internal_link}`. In this case use only `{target="_blank"}` for external links
 


### PR DESCRIPTION
# Description

The Documentation section of CONTRIBUTING linked to the docs guide with a root-absolute path, `/getting-started/contributing/docs`. MkDocs does not resolve those — it emits them into the HTML verbatim. The site is versioned with mike and served under a `/latest/` prefix, so the browser landed on `https://faststream.ag2.ai/getting-started/contributing/docs` and got a 404.

The example in the docs guide's own link guidelines had the same bug, plus a second one: it pointed at `contributing`, while the page is `CONTRIBUTING.md`. Both now use relative paths to the target `.md` file, the way every other internal link in the docs already does.

Also spell out in the guideline itself that internal links must be relative, so the rule no longer teaches the pattern that broke.

Fixes #3058

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings