### PR TITLE
docs: correct logging config CLI flag from --log-file to --log-config

### DIFF
--- a/docs/docs/en/getting-started/observability/logging.md
+++ b/docs/docs/en/getting-started/observability/logging.md
@@ -70,19 +70,19 @@ If you use **FastStream CLI**, you have the option to use a file to configure yo
 === "JSON"
 
     ```console
-    faststream run serve:app --log-file config.json
+    faststream run serve:app --log-config config.json
     ```
 
 === "TOML"
 
     ```console
-    faststream run serve:app --log-file config.toml
+    faststream run serve:app --log-config config.toml
     ```
 
 === "YAML"
 
     ```console
-    faststream run serve:app --log-file config.yaml
+    faststream run serve:app --log-config config.yaml
     ```
 
 Faststream supported few file formats to logging configure. See examples below:


### PR DESCRIPTION
# Description

The 0.5 logging docs show `faststream run serve:app --log-file config.json`, but
`--log-file` is not a real CLI flag. The actual option is `--log-config`, which is
present on the `run` command in both 0.5 and `main`, and it supports the same
JSON/TOML/YAML formats shown in the examples.

`--log-file` was never a valid flag: the docs added it in 0.5.42 (#2229), but the
CLI in that same release already used `--log-config`. I confirmed `--log-config`
loads all three config formats (JSON, TOML, YAML) correctly.

This corrects the flag name in the three example blocks on the logging page. No
other changes.

Fixes #3047

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings