### PR TITLE
feat(redis): expose stream delivery count

### DIFF
--- a/docs/docs/en/redis/message.md
+++ b/docs/docs/en/redis/message.md
@@ -60,25 +60,25 @@ The `Context` object lets you reference message attributes directly, making your
 ## Redis Stream Delivery Count
 
 For a single stream message consumed through a consumer group, call
-`await message.get_delivery_count()` on `RedisStreamMessage` to read its current
-delivery count from the Redis [Pending Entries List](https://redis.io/docs/latest/develop/data-types/streams/#viewing-pending-messages){.external-link target="_blank"}.
+`await message.get_delivery_count(redis, group)` on `RedisStreamMessage` to read
+its current delivery count from the Redis [Pending Entries List](https://redis.io/docs/latest/develop/data-types/streams/#viewing-pending-messages){.external-link target="_blank"}.
 
 ```python
-from faststream.redis import RedisStreamMessage, StreamSub
+from faststream.redis import Redis, RedisStreamMessage, StreamSub
 
 @broker.subscriber(
     stream=StreamSub("orders", group="workers", consumer="worker-1")
 )
-async def handle_order(message: RedisStreamMessage) -> None:
-    delivery_count = await message.get_delivery_count()
+async def handle_order(message: RedisStreamMessage, redis: Redis) -> None:
+    delivery_count = await message.get_delivery_count(redis, "workers")
 ```
 
 Each call performs an exact-ID `XPENDING RANGE` query, so the value is a live
 snapshot rather than cached message metadata. A newly delivered message returns
 `1`, and `XAUTOCLAIM` increments the count before the claimed message reaches
-the handler. If the message is not associated with a consumer group, has no
-Redis message ID, or is no longer pending after acknowledgment, the method
-returns `1`. Redis errors such as a missing consumer group are propagated.
+the handler. If the message has no Redis message ID or is no longer pending
+after acknowledgment, the method returns `1`. Redis errors such as a missing
+consumer group are propagated.
 
 This method is available on `RedisStreamMessage`, not on batched stream
 messages. It adds one Redis round trip per call.

--- a/docs/docs/en/redis/message.md
+++ b/docs/docs/en/redis/message.md
@@ -56,3 +56,29 @@ async def stream_handler(
 ```
 
 The `Context` object lets you reference message attributes directly, making your handler functions neater and reducing the amount of boilerplate code needed.
+
+## Redis Stream Delivery Count
+
+For a single stream message consumed through a consumer group, call
+`await message.get_delivery_count()` on `RedisStreamMessage` to read its current
+delivery count from the Redis [Pending Entries List](https://redis.io/docs/latest/develop/data-types/streams/#viewing-pending-messages){.external-link target="_blank"}.
+
+```python
+from faststream.redis import RedisStreamMessage, StreamSub
+
+@broker.subscriber(
+    stream=StreamSub("orders", group="workers", consumer="worker-1")
+)
+async def handle_order(message: RedisStreamMessage) -> None:
+    delivery_count = await message.get_delivery_count()
+```
+
+Each call performs an exact-ID `XPENDING RANGE` query, so the value is a live
+snapshot rather than cached message metadata. A newly delivered message returns
+`1`, and `XAUTOCLAIM` increments the count before the claimed message reaches
+the handler. If the message is not associated with a consumer group, has no
+Redis message ID, or is no longer pending after acknowledgment, the method
+returns `1`. Redis errors such as a missing consumer group are propagated.
+
+This method is available on `RedisStreamMessage`, not on batched stream
+messages. It adds one Redis round trip per call.

--- a/faststream/redis/message.py
+++ b/faststream/redis/message.py
@@ -12,6 +12,8 @@ from typing_extensions import NotRequired, TypedDict, override
 from faststream.message import StreamMessage as BrokerStreamMessage
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from redis.asyncio import Redis
 
     from faststream._internal.basic_types import DecodedMessage
@@ -146,7 +148,36 @@ class _RedisStreamMessageMixin(BrokerStreamMessage[_StreamMsgType]):
 
 
 class RedisStreamMessage(_RedisStreamMessageMixin[DefaultStreamMessage]):
-    pass
+    _redis: Optional["Callable[[], Redis[bytes]]"] = None
+    _group: str | None = None
+
+    def _set_delivery_count_context(
+        self,
+        redis: Optional["Callable[[], Redis[bytes]]"],
+        group: str | None,
+    ) -> None:
+        self._redis = redis
+        self._group = group
+
+    async def get_delivery_count(self) -> int:
+        """Return this message's current delivery count from the Redis PEL.
+
+        The count is queried on every call. Messages without lookup context or
+        a pending entry, including acknowledged messages, return ``1``.
+        """
+        message_ids = self.raw_message["message_ids"]
+        if self._redis is None or not self._group or not message_ids:
+            return 1
+
+        message_id = message_ids[0]
+        entries = await self._redis().xpending_range(
+            name=self.raw_message["channel"],
+            groupname=self._group,
+            min=message_id,
+            max=message_id,
+            count=1,
+        )
+        return int(entries[0]["times_delivered"]) if entries else 1
 
 
 class RedisBatchStreamMessage(_RedisStreamMessageMixin[BatchStreamMessage]):

--- a/faststream/redis/message.py
+++ b/faststream/redis/message.py
@@ -12,8 +12,6 @@ from typing_extensions import NotRequired, TypedDict, override
 from faststream.message import StreamMessage as BrokerStreamMessage
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from redis.asyncio import Redis
 
     from faststream._internal.basic_types import DecodedMessage
@@ -148,31 +146,24 @@ class _RedisStreamMessageMixin(BrokerStreamMessage[_StreamMsgType]):
 
 
 class RedisStreamMessage(_RedisStreamMessageMixin[DefaultStreamMessage]):
-    _redis: Optional["Callable[[], Redis[bytes]]"] = None
-    _group: str | None = None
-
-    def _set_delivery_count_context(
+    async def get_delivery_count(
         self,
-        redis: Optional["Callable[[], Redis[bytes]]"],
-        group: str | None,
-    ) -> None:
-        self._redis = redis
-        self._group = group
-
-    async def get_delivery_count(self) -> int:
+        redis: "Redis[bytes]",
+        group: str,
+    ) -> int:
         """Return this message's current delivery count from the Redis PEL.
 
-        The count is queried on every call. Messages without lookup context or
-        a pending entry, including acknowledged messages, return ``1``.
+        The count is queried on every call. Messages without an ID or a pending
+        entry, including acknowledged messages, return ``1``.
         """
         message_ids = self.raw_message["message_ids"]
-        if self._redis is None or not self._group or not message_ids:
+        if not message_ids:
             return 1
 
         message_id = message_ids[0]
-        entries = await self._redis().xpending_range(
+        entries = await redis.xpending_range(
             name=self.raw_message["channel"],
-            groupname=self._group,
+            groupname=group,
             min=message_id,
             max=message_id,
             count=1,

--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -10,7 +10,6 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.subscriber.mixins import ConcurrentMixin
 from faststream._internal.endpoint.utils import process_msg
-from faststream._internal.types import AsyncCallable
 from faststream.redis.exceptions import StreamGroupNotFoundError
 from faststream.redis.message import (
     BatchStreamMessage,
@@ -31,7 +30,6 @@ if TYPE_CHECKING:
     from faststream._internal.endpoint.subscriber.call_item import (
         CallsCollection,
     )
-    from faststream._internal.types import CustomCallable
     from faststream.message import StreamMessage as BrokerStreamMessage
     from faststream.redis.schemas import StreamSub
     from faststream.redis.subscriber.config import RedisSubscriberConfig
@@ -352,30 +350,6 @@ class StreamSubscriber(_StreamHandlerMixin):
         config.decoder = parser.decode_message
         config.parser = parser.parse_message
         super().__init__(config, specification, calls)
-
-    @override
-    def _get_parser_and_decoder(
-        self,
-        item_parser: Optional["CustomCallable"] = None,
-        item_decoder: Optional["CustomCallable"] = None,
-    ) -> tuple[AsyncCallable, AsyncCallable]:
-        parser, decoder = super()._get_parser_and_decoder(
-            item_parser,
-            item_decoder,
-        )
-
-        async def parse_with_delivery_count_context(
-            message: Any,
-        ) -> "BrokerStreamMessage[Any]":
-            parsed: BrokerStreamMessage[Any] = await parser(message)
-            if isinstance(parsed, RedisStreamMessage):
-                parsed._set_delivery_count_context(
-                    redis=lambda: self._client,
-                    group=self.stream_sub.group,
-                )
-            return parsed
-
-        return parse_with_delivery_count_context, decoder
 
     async def _get_msgs(
         self,

--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.subscriber.mixins import ConcurrentMixin
 from faststream._internal.endpoint.utils import process_msg
+from faststream._internal.types import AsyncCallable
 from faststream.redis.exceptions import StreamGroupNotFoundError
 from faststream.redis.message import (
     BatchStreamMessage,
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
     from faststream._internal.endpoint.subscriber.call_item import (
         CallsCollection,
     )
+    from faststream._internal.types import CustomCallable
     from faststream.message import StreamMessage as BrokerStreamMessage
     from faststream.redis.schemas import StreamSub
     from faststream.redis.subscriber.config import RedisSubscriberConfig
@@ -350,6 +352,30 @@ class StreamSubscriber(_StreamHandlerMixin):
         config.decoder = parser.decode_message
         config.parser = parser.parse_message
         super().__init__(config, specification, calls)
+
+    @override
+    def _get_parser_and_decoder(
+        self,
+        item_parser: Optional["CustomCallable"] = None,
+        item_decoder: Optional["CustomCallable"] = None,
+    ) -> tuple[AsyncCallable, AsyncCallable]:
+        parser, decoder = super()._get_parser_and_decoder(
+            item_parser,
+            item_decoder,
+        )
+
+        async def parse_with_delivery_count_context(
+            message: Any,
+        ) -> "BrokerStreamMessage[Any]":
+            parsed: BrokerStreamMessage[Any] = await parser(message)
+            if isinstance(parsed, RedisStreamMessage):
+                parsed._set_delivery_count_context(
+                    redis=lambda: self._client,
+                    group=self.stream_sub.group,
+                )
+            return parsed
+
+        return parse_with_delivery_count_context, decoder
 
     async def _get_msgs(
         self,

--- a/tests/brokers/redis/test_delivery_count.py
+++ b/tests/brokers/redis/test_delivery_count.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from redis.asyncio import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from faststream.redis import (
+    RedisBroker,
+    RedisStreamMessage as AnnotatedRedisStreamMessage,
+    StreamSub,
+    TestRedisBroker,
+)
+from faststream.redis.message import DefaultStreamMessage, RedisStreamMessage
+from faststream.redis.parser import BinaryMessageFormatV1
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.redis,
+]
+
+
+def make_message(
+    redis: Callable[[], Redis[bytes]] | None,
+    *,
+    group: str | None = "workers",
+    message_ids: list[bytes] | None = None,
+) -> RedisStreamMessage:
+    raw_message = DefaultStreamMessage(
+        type="stream",
+        channel="orders",
+        message_ids=[b"123-0"] if message_ids is None else message_ids,
+        data={},
+    )
+    message = RedisStreamMessage(
+        raw_message=raw_message,
+        body=b"",
+    )
+    message._set_delivery_count_context(redis=redis, group=group)
+    return message
+
+
+async def test_get_delivery_count_queries_exact_message() -> None:
+    client = AsyncMock(spec=Redis)
+    client.xpending_range = AsyncMock(return_value=[{"times_delivered": 3}])
+    get_client = MagicMock(return_value=client)
+
+    message = make_message(get_client)
+
+    assert await message.get_delivery_count() == 3
+    get_client.assert_called_once_with()
+    client.xpending_range.assert_awaited_once_with(
+        name="orders",
+        groupname="workers",
+        min=b"123-0",
+        max=b"123-0",
+        count=1,
+    )
+
+
+async def test_get_delivery_count_defaults_when_message_is_not_pending() -> None:
+    client = AsyncMock(spec=Redis)
+    client.xpending_range = AsyncMock(return_value=[])
+
+    message = make_message(lambda: client)
+
+    assert await message.get_delivery_count() == 1
+
+
+@pytest.mark.parametrize(
+    ("redis", "group", "message_ids"),
+    (
+        pytest.param(None, "workers", [b"123-0"], id="no-client"),
+        pytest.param(MagicMock(), None, [b"123-0"], id="no-group"),
+        pytest.param(MagicMock(), "workers", [], id="no-message-id"),
+    ),
+)
+async def test_get_delivery_count_defaults_without_pending_context(
+    redis: Callable[[], Redis[bytes]] | None,
+    group: str | None,
+    message_ids: list[bytes],
+) -> None:
+    message = make_message(redis, group=group, message_ids=message_ids)
+
+    assert await message.get_delivery_count() == 1
+    if redis is not None:
+        redis.assert_not_called()  # type: ignore[attr-defined]
+
+
+async def test_get_delivery_count_propagates_redis_errors() -> None:
+    client = AsyncMock(spec=Redis)
+    client.xpending_range = AsyncMock(
+        side_effect=RedisConnectionError("Redis unavailable")
+    )
+
+    message = make_message(lambda: client)
+
+    with pytest.raises(RedisConnectionError, match="Redis unavailable"):
+        await message.get_delivery_count()
+
+
+async def test_stream_subscriber_uses_current_client_for_delivery_count() -> None:
+    original_client = AsyncMock(spec=Redis)
+    original_client.xpending_range = AsyncMock()
+    current_client = AsyncMock(spec=Redis)
+    current_client.xpending_range = AsyncMock(return_value=[{"times_delivered": 2}])
+    raw_data = await BinaryMessageFormatV1.encode(
+        message="hello",
+        reply_to=None,
+        headers=None,
+        correlation_id="correlation-id",
+    )
+    broker = RedisBroker()
+    subscriber = broker.subscriber(
+        stream=StreamSub("orders", group="workers", consumer="worker-1")
+    )
+    broker.config.broker_config.connection._client = original_client
+    parser, _ = subscriber._get_parser_and_decoder()
+
+    message = await parser(
+        DefaultStreamMessage(
+            type="stream",
+            channel="orders",
+            message_ids=[b"123-0"],
+            data={b"__data__": raw_data},
+        )
+    )
+
+    broker.config.broker_config.connection._client = current_client
+
+    assert isinstance(message, RedisStreamMessage)
+    assert await message.get_delivery_count() == 2
+    original_client.xpending_range.assert_not_awaited()
+    current_client.xpending_range.assert_awaited_once()
+
+
+@pytest.mark.parametrize("parser_scope", ("broker", "subscriber", "handler"))
+async def test_custom_stream_parser_preserves_delivery_count_context(
+    parser_scope: str,
+) -> None:
+    client = AsyncMock(spec=Redis)
+    client.xpending_range = AsyncMock(return_value=[{"times_delivered": 7}])
+
+    async def custom_parser(message: DefaultStreamMessage) -> RedisStreamMessage:
+        return RedisStreamMessage(raw_message=message, body=b"")
+
+    broker = RedisBroker(
+        parser=custom_parser if parser_scope == "broker" else None,
+    )
+    subscriber = broker.subscriber(
+        stream=StreamSub("orders", group="workers", consumer="worker-1"),
+        parser=custom_parser if parser_scope == "subscriber" else None,
+    )
+    broker.config.broker_config.connection._client = client
+    parser, _ = subscriber._get_parser_and_decoder(
+        custom_parser if parser_scope == "handler" else None
+    )
+
+    message = await parser(
+        DefaultStreamMessage(
+            type="stream",
+            channel="orders",
+            message_ids=[b"123-0"],
+            data={},
+        )
+    )
+
+    assert isinstance(message, RedisStreamMessage)
+    assert await message.get_delivery_count() == 7
+
+
+async def test_test_broker_message_defaults_without_redis_id() -> None:
+    broker = RedisBroker()
+    counts: list[int] = []
+
+    @broker.subscriber(stream=StreamSub("orders", group="workers", consumer="worker-1"))
+    async def handler(message: AnnotatedRedisStreamMessage) -> None:
+        counts.append(await message.get_delivery_count())
+
+    async with TestRedisBroker(broker) as test_broker:
+        await test_broker.publish("hello", stream="orders")
+
+    assert counts == [1]
+
+
+@pytest.mark.connected()
+async def test_delivery_count_for_new_message(queue: str) -> None:
+    group = "workers"
+    broker = RedisBroker()
+    subscriber = broker.subscriber(
+        stream=StreamSub(queue, group=group, consumer="worker-1")
+    )
+
+    async with broker:
+        await broker.start()
+        await broker.publish("hello", stream=queue)
+
+        message = await subscriber.get_one(timeout=3)
+
+        assert message is not None
+        assert await message.get_delivery_count() == 1
+
+
+@pytest.mark.connected()
+async def test_delivery_count_after_xautoclaim_and_ack(queue: str) -> None:
+    group = "workers"
+    broker = RedisBroker()
+
+    async with broker:
+        await broker.start()
+        await broker.publish("hello", stream=queue)
+        await broker._connection.xgroup_create(queue, group, id="0")
+        await broker._connection.xreadgroup(
+            groupname=group,
+            consumername="worker-1",
+            streams={queue: ">"},
+            count=1,
+        )
+
+        subscriber = broker.subscriber(
+            stream=StreamSub(
+                queue,
+                group=group,
+                consumer="worker-2",
+                min_idle_time=0,
+            )
+        )
+        message = await subscriber.get_one(timeout=3)
+
+        assert message is not None
+        assert await message.get_delivery_count() == 2
+
+        await message.ack(redis=broker._connection, group=group)
+        assert await message.get_delivery_count() == 1

--- a/tests/brokers/redis/test_delivery_count.py
+++ b/tests/brokers/redis/test_delivery_count.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -15,14 +16,14 @@ class TestDeliveryCount(RedisTestcaseConfig):
         self,
         queue: str,
         event: asyncio.Event,
+        mock: MagicMock,
     ) -> None:
         group = f"{queue}-workers"
         broker = self.get_broker(apply_types=True)
-        counts: list[int] = []
 
         @broker.subscriber(stream=StreamSub(queue, group=group, consumer="worker-1"))
         async def handler(message: RedisStreamMessage, redis: Redis) -> None:
-            counts.append(await message.get_delivery_count(redis, group))
+            mock(await message.get_delivery_count(redis, group))
             event.set()
 
         async with self.patch_broker(broker) as br:
@@ -30,16 +31,17 @@ class TestDeliveryCount(RedisTestcaseConfig):
             await br.publish("hello", stream=queue)
             await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
-        assert counts == [1]
+        mock.assert_called_once_with(1)
 
     async def test_delivery_count_after_xautoclaim_and_ack(
         self,
         queue: str,
         event: asyncio.Event,
+        mock: MagicMock,
+        mock2: MagicMock,
     ) -> None:
         group = f"{queue}-workers"
         broker = self.get_broker(apply_types=True)
-        counts: list[int] = []
 
         @broker.subscriber(
             stream=StreamSub(
@@ -50,9 +52,9 @@ class TestDeliveryCount(RedisTestcaseConfig):
             )
         )
         async def handler(message: RedisStreamMessage, redis: Redis) -> None:
-            counts.append(await message.get_delivery_count(redis, group))
+            mock(await message.get_delivery_count(redis, group))
             await message.ack(redis=redis, group=group)
-            counts.append(await message.get_delivery_count(redis, group))
+            mock2(await message.get_delivery_count(redis, group))
             event.set()
 
         async with self.patch_broker(broker) as br:
@@ -67,4 +69,5 @@ class TestDeliveryCount(RedisTestcaseConfig):
             await br.start()
             await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
-        assert counts == [2, 1]
+        mock.assert_called_once_with(2)
+        mock2.assert_called_once_with(1)

--- a/tests/brokers/redis/test_delivery_count.py
+++ b/tests/brokers/redis/test_delivery_count.py
@@ -1,23 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from redis.asyncio import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from faststream.redis import (
+    Redis as AnnotatedRedis,
     RedisBroker,
     RedisStreamMessage as AnnotatedRedisStreamMessage,
     StreamSub,
     TestRedisBroker,
 )
 from faststream.redis.message import DefaultStreamMessage, RedisStreamMessage
-from faststream.redis.parser import BinaryMessageFormatV1
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -26,36 +22,48 @@ pytestmark = [
 
 
 def make_message(
-    redis: Callable[[], Redis[bytes]] | None,
     *,
-    group: str | None = "workers",
+    stream: str = "orders",
     message_ids: list[bytes] | None = None,
 ) -> RedisStreamMessage:
+    ids = [b"123-0"] if message_ids is None else message_ids
     raw_message = DefaultStreamMessage(
         type="stream",
-        channel="orders",
-        message_ids=[b"123-0"] if message_ids is None else message_ids,
+        channel=stream,
+        message_ids=ids,
         data={},
     )
-    message = RedisStreamMessage(
+    return RedisStreamMessage(
         raw_message=raw_message,
         body=b"",
     )
-    message._set_delivery_count_context(redis=redis, group=group)
-    return message
 
 
 async def test_get_delivery_count_queries_exact_message() -> None:
     client = AsyncMock(spec=Redis)
     client.xpending_range = AsyncMock(return_value=[{"times_delivered": 3}])
-    get_client = MagicMock(return_value=client)
 
-    message = make_message(get_client)
+    message = make_message()
 
-    assert await message.get_delivery_count() == 3
-    get_client.assert_called_once_with()
+    assert await message.get_delivery_count(client, "workers") == 3
     client.xpending_range.assert_awaited_once_with(
         name="orders",
+        groupname="workers",
+        min=b"123-0",
+        max=b"123-0",
+        count=1,
+    )
+
+
+async def test_get_delivery_count_supports_empty_stream_name() -> None:
+    client = AsyncMock(spec=Redis)
+    client.xpending_range = AsyncMock(return_value=[{"times_delivered": 2}])
+
+    message = make_message(stream="")
+
+    assert await message.get_delivery_count(client, "workers") == 2
+    client.xpending_range.assert_awaited_once_with(
+        name="",
         groupname="workers",
         min=b"123-0",
         max=b"123-0",
@@ -67,29 +75,17 @@ async def test_get_delivery_count_defaults_when_message_is_not_pending() -> None
     client = AsyncMock(spec=Redis)
     client.xpending_range = AsyncMock(return_value=[])
 
-    message = make_message(lambda: client)
+    message = make_message()
 
-    assert await message.get_delivery_count() == 1
+    assert await message.get_delivery_count(client, "workers") == 1
 
 
-@pytest.mark.parametrize(
-    ("redis", "group", "message_ids"),
-    (
-        pytest.param(None, "workers", [b"123-0"], id="no-client"),
-        pytest.param(MagicMock(), None, [b"123-0"], id="no-group"),
-        pytest.param(MagicMock(), "workers", [], id="no-message-id"),
-    ),
-)
-async def test_get_delivery_count_defaults_without_pending_context(
-    redis: Callable[[], Redis[bytes]] | None,
-    group: str | None,
-    message_ids: list[bytes],
-) -> None:
-    message = make_message(redis, group=group, message_ids=message_ids)
+async def test_get_delivery_count_defaults_without_message_id() -> None:
+    client = AsyncMock(spec=Redis)
+    message = make_message(message_ids=[])
 
-    assert await message.get_delivery_count() == 1
-    if redis is not None:
-        redis.assert_not_called()  # type: ignore[attr-defined]
+    assert await message.get_delivery_count(client, "workers") == 1
+    client.xpending_range.assert_not_called()
 
 
 async def test_get_delivery_count_propagates_redis_errors() -> None:
@@ -98,80 +94,10 @@ async def test_get_delivery_count_propagates_redis_errors() -> None:
         side_effect=RedisConnectionError("Redis unavailable")
     )
 
-    message = make_message(lambda: client)
+    message = make_message()
 
     with pytest.raises(RedisConnectionError, match="Redis unavailable"):
-        await message.get_delivery_count()
-
-
-async def test_stream_subscriber_uses_current_client_for_delivery_count() -> None:
-    original_client = AsyncMock(spec=Redis)
-    original_client.xpending_range = AsyncMock()
-    current_client = AsyncMock(spec=Redis)
-    current_client.xpending_range = AsyncMock(return_value=[{"times_delivered": 2}])
-    raw_data = await BinaryMessageFormatV1.encode(
-        message="hello",
-        reply_to=None,
-        headers=None,
-        correlation_id="correlation-id",
-    )
-    broker = RedisBroker()
-    subscriber = broker.subscriber(
-        stream=StreamSub("orders", group="workers", consumer="worker-1")
-    )
-    broker.config.broker_config.connection._client = original_client
-    parser, _ = subscriber._get_parser_and_decoder()
-
-    message = await parser(
-        DefaultStreamMessage(
-            type="stream",
-            channel="orders",
-            message_ids=[b"123-0"],
-            data={b"__data__": raw_data},
-        )
-    )
-
-    broker.config.broker_config.connection._client = current_client
-
-    assert isinstance(message, RedisStreamMessage)
-    assert await message.get_delivery_count() == 2
-    original_client.xpending_range.assert_not_awaited()
-    current_client.xpending_range.assert_awaited_once()
-
-
-@pytest.mark.parametrize("parser_scope", ("broker", "subscriber", "handler"))
-async def test_custom_stream_parser_preserves_delivery_count_context(
-    parser_scope: str,
-) -> None:
-    client = AsyncMock(spec=Redis)
-    client.xpending_range = AsyncMock(return_value=[{"times_delivered": 7}])
-
-    async def custom_parser(message: DefaultStreamMessage) -> RedisStreamMessage:
-        return RedisStreamMessage(raw_message=message, body=b"")
-
-    broker = RedisBroker(
-        parser=custom_parser if parser_scope == "broker" else None,
-    )
-    subscriber = broker.subscriber(
-        stream=StreamSub("orders", group="workers", consumer="worker-1"),
-        parser=custom_parser if parser_scope == "subscriber" else None,
-    )
-    broker.config.broker_config.connection._client = client
-    parser, _ = subscriber._get_parser_and_decoder(
-        custom_parser if parser_scope == "handler" else None
-    )
-
-    message = await parser(
-        DefaultStreamMessage(
-            type="stream",
-            channel="orders",
-            message_ids=[b"123-0"],
-            data={},
-        )
-    )
-
-    assert isinstance(message, RedisStreamMessage)
-    assert await message.get_delivery_count() == 7
+        await message.get_delivery_count(client, "workers")
 
 
 async def test_test_broker_message_defaults_without_redis_id() -> None:
@@ -179,8 +105,11 @@ async def test_test_broker_message_defaults_without_redis_id() -> None:
     counts: list[int] = []
 
     @broker.subscriber(stream=StreamSub("orders", group="workers", consumer="worker-1"))
-    async def handler(message: AnnotatedRedisStreamMessage) -> None:
-        counts.append(await message.get_delivery_count())
+    async def handler(
+        message: AnnotatedRedisStreamMessage,
+        redis: AnnotatedRedis,
+    ) -> None:
+        counts.append(await message.get_delivery_count(redis, "workers"))
 
     async with TestRedisBroker(broker) as test_broker:
         await test_broker.publish("hello", stream="orders")
@@ -203,7 +132,7 @@ async def test_delivery_count_for_new_message(queue: str) -> None:
         message = await subscriber.get_one(timeout=3)
 
         assert message is not None
-        assert await message.get_delivery_count() == 1
+        assert await message.get_delivery_count(broker._connection, group) == 1
 
 
 @pytest.mark.connected()
@@ -233,7 +162,7 @@ async def test_delivery_count_after_xautoclaim_and_ack(queue: str) -> None:
         message = await subscriber.get_one(timeout=3)
 
         assert message is not None
-        assert await message.get_delivery_count() == 2
+        assert await message.get_delivery_count(broker._connection, group) == 2
 
         await message.ack(redis=broker._connection, group=group)
-        assert await message.get_delivery_count() == 1
+        assert await message.get_delivery_count(broker._connection, group) == 1

--- a/tests/brokers/redis/test_delivery_count.py
+++ b/tests/brokers/redis/test_delivery_count.py
@@ -1,157 +1,47 @@
-from __future__ import annotations
-
-from unittest.mock import AsyncMock
+import asyncio
 
 import pytest
-from redis.asyncio import Redis
-from redis.exceptions import ConnectionError as RedisConnectionError
 
-from faststream.redis import (
-    Redis as AnnotatedRedis,
-    RedisBroker,
-    RedisStreamMessage as AnnotatedRedisStreamMessage,
-    StreamSub,
-    TestRedisBroker,
-)
-from faststream.redis.message import DefaultStreamMessage, RedisStreamMessage
+from faststream.redis import Redis, RedisStreamMessage, StreamSub
 
-pytestmark = [
-    pytest.mark.asyncio,
-    pytest.mark.redis,
-]
+from .basic import RedisTestcaseConfig
 
 
-def make_message(
-    *,
-    stream: str = "orders",
-    message_ids: list[bytes] | None = None,
-) -> RedisStreamMessage:
-    ids = [b"123-0"] if message_ids is None else message_ids
-    raw_message = DefaultStreamMessage(
-        type="stream",
-        channel=stream,
-        message_ids=ids,
-        data={},
-    )
-    return RedisStreamMessage(
-        raw_message=raw_message,
-        body=b"",
-    )
-
-
-async def test_get_delivery_count_queries_exact_message() -> None:
-    client = AsyncMock(spec=Redis)
-    client.xpending_range = AsyncMock(return_value=[{"times_delivered": 3}])
-
-    message = make_message()
-
-    assert await message.get_delivery_count(client, "workers") == 3
-    client.xpending_range.assert_awaited_once_with(
-        name="orders",
-        groupname="workers",
-        min=b"123-0",
-        max=b"123-0",
-        count=1,
-    )
-
-
-async def test_get_delivery_count_supports_empty_stream_name() -> None:
-    client = AsyncMock(spec=Redis)
-    client.xpending_range = AsyncMock(return_value=[{"times_delivered": 2}])
-
-    message = make_message(stream="")
-
-    assert await message.get_delivery_count(client, "workers") == 2
-    client.xpending_range.assert_awaited_once_with(
-        name="",
-        groupname="workers",
-        min=b"123-0",
-        max=b"123-0",
-        count=1,
-    )
-
-
-async def test_get_delivery_count_defaults_when_message_is_not_pending() -> None:
-    client = AsyncMock(spec=Redis)
-    client.xpending_range = AsyncMock(return_value=[])
-
-    message = make_message()
-
-    assert await message.get_delivery_count(client, "workers") == 1
-
-
-async def test_get_delivery_count_defaults_without_message_id() -> None:
-    client = AsyncMock(spec=Redis)
-    message = make_message(message_ids=[])
-
-    assert await message.get_delivery_count(client, "workers") == 1
-    client.xpending_range.assert_not_called()
-
-
-async def test_get_delivery_count_propagates_redis_errors() -> None:
-    client = AsyncMock(spec=Redis)
-    client.xpending_range = AsyncMock(
-        side_effect=RedisConnectionError("Redis unavailable")
-    )
-
-    message = make_message()
-
-    with pytest.raises(RedisConnectionError, match="Redis unavailable"):
-        await message.get_delivery_count(client, "workers")
-
-
-async def test_test_broker_message_defaults_without_redis_id() -> None:
-    broker = RedisBroker()
-    counts: list[int] = []
-
-    @broker.subscriber(stream=StreamSub("orders", group="workers", consumer="worker-1"))
-    async def handler(
-        message: AnnotatedRedisStreamMessage,
-        redis: AnnotatedRedis,
+@pytest.mark.connected()
+@pytest.mark.redis()
+@pytest.mark.asyncio()
+class TestDeliveryCount(RedisTestcaseConfig):
+    async def test_delivery_count_for_new_message(
+        self,
+        queue: str,
+        event: asyncio.Event,
     ) -> None:
-        counts.append(await message.get_delivery_count(redis, "workers"))
+        group = f"{queue}-workers"
+        broker = self.get_broker(apply_types=True)
+        counts: list[int] = []
 
-    async with TestRedisBroker(broker) as test_broker:
-        await test_broker.publish("hello", stream="orders")
+        @broker.subscriber(stream=StreamSub(queue, group=group, consumer="worker-1"))
+        async def handler(message: RedisStreamMessage, redis: Redis) -> None:
+            counts.append(await message.get_delivery_count(redis, group))
+            event.set()
 
-    assert counts == [1]
+        async with self.patch_broker(broker) as br:
+            await br.start()
+            await br.publish("hello", stream=queue)
+            await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
+        assert counts == [1]
 
-@pytest.mark.connected()
-async def test_delivery_count_for_new_message(queue: str) -> None:
-    group = "workers"
-    broker = RedisBroker()
-    subscriber = broker.subscriber(
-        stream=StreamSub(queue, group=group, consumer="worker-1")
-    )
+    async def test_delivery_count_after_xautoclaim_and_ack(
+        self,
+        queue: str,
+        event: asyncio.Event,
+    ) -> None:
+        group = f"{queue}-workers"
+        broker = self.get_broker(apply_types=True)
+        counts: list[int] = []
 
-    async with broker:
-        await broker.start()
-        await broker.publish("hello", stream=queue)
-
-        message = await subscriber.get_one(timeout=3)
-
-        assert message is not None
-        assert await message.get_delivery_count(broker._connection, group) == 1
-
-
-@pytest.mark.connected()
-async def test_delivery_count_after_xautoclaim_and_ack(queue: str) -> None:
-    group = "workers"
-    broker = RedisBroker()
-
-    async with broker:
-        await broker.start()
-        await broker.publish("hello", stream=queue)
-        await broker._connection.xgroup_create(queue, group, id="0")
-        await broker._connection.xreadgroup(
-            groupname=group,
-            consumername="worker-1",
-            streams={queue: ">"},
-            count=1,
-        )
-
-        subscriber = broker.subscriber(
+        @broker.subscriber(
             stream=StreamSub(
                 queue,
                 group=group,
@@ -159,10 +49,22 @@ async def test_delivery_count_after_xautoclaim_and_ack(queue: str) -> None:
                 min_idle_time=0,
             )
         )
-        message = await subscriber.get_one(timeout=3)
+        async def handler(message: RedisStreamMessage, redis: Redis) -> None:
+            counts.append(await message.get_delivery_count(redis, group))
+            await message.ack(redis=redis, group=group)
+            counts.append(await message.get_delivery_count(redis, group))
+            event.set()
 
-        assert message is not None
-        assert await message.get_delivery_count(broker._connection, group) == 2
+        async with self.patch_broker(broker) as br:
+            await br.publish("hello", stream=queue)
+            await br._connection.xgroup_create(queue, group, id="0")
+            await br._connection.xreadgroup(
+                groupname=group,
+                consumername="worker-1",
+                streams={queue: ">"},
+                count=1,
+            )
+            await br.start()
+            await asyncio.wait_for(event.wait(), timeout=self.timeout)
 
-        await message.ack(redis=broker._connection, group=group)
-        assert await message.get_delivery_count(broker._connection, group) == 1
+        assert counts == [2, 1]

--- a/tests/mypy/redis.py
+++ b/tests/mypy/redis.py
@@ -403,6 +403,8 @@ async def check_stream_subscriber_message_type(
 
     message = await subscriber.get_one()
     assert_type(message, RedisStreamMessage | None)
+    if message is not None:
+        assert_type(await message.get_delivery_count(), int)
 
     async for msg in subscriber:
         assert_type(msg, RedisStreamMessage)

--- a/tests/mypy/redis.py
+++ b/tests/mypy/redis.py
@@ -7,6 +7,7 @@ from faststream._internal.basic_types import DecodedMessage
 from faststream.redis import (
     ListSub,
     PubSub,
+    Redis,
     RedisBroker,
     RedisChannelMessage,
     RedisListMessage,
@@ -398,13 +399,14 @@ async def check_channel_subscriber_message_type(
 
 async def check_stream_subscriber_message_type(
     broker: RedisBroker | RedisRouter | FastAPIRouter,
+    redis: Redis,
 ) -> None:
     subscriber = broker.subscriber(stream=StreamSub("test"))
 
     message = await subscriber.get_one()
     assert_type(message, RedisStreamMessage | None)
     if message is not None:
-        assert_type(await message.get_delivery_count(), int)
+        assert_type(await message.get_delivery_count(redis, "group"), int)
 
     async for msg in subscriber:
         assert_type(msg, RedisStreamMessage)


### PR DESCRIPTION
# Description

Redis stream users currently need a manual exact-ID `XPENDING RANGE` query to enforce retry limits.

This adds `await RedisStreamMessage.get_delivery_count(redis, group)`. The caller supplies the Redis client and consumer group, matching the existing `ack` and `delete` message APIs; handlers can receive the client through FastStream's public `Redis` annotation. Each call reads the current PEL `times_delivered` value, returns `1` when the message has no Redis ID or is no longer pending, and propagates Redis errors.

This is intentionally separate from #3049's optional `delivery_counts` raw metadata. That field reports previous deliveries for Redis 8.4 `XREADGROUP CLAIM`, while this method reads the current PEL state for existing consumer-group flows. Batch stream messages remain unchanged, and each call adds one Redis round trip.

Fixes #3064

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Validation

- `pytest tests/brokers/redis/test_delivery_count.py -m connected` — 2 passed against Redis 7.0.15 using real broker subscribers and no Redis client mocks
- `pytest tests/brokers/redis -m "not connected"` — 379 passed, 6 skipped, 1 xfailed
- Ruff format and lint checks
- Mypy — 516 source files, 0 errors
- Pyright — 0 errors
- Bandit and Semgrep — 0 findings
- Changed-file pre-commit hooks, including typos and detect-secrets

The full GitHub test matrix is pending on the current head.

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary documentation changes
- [x] My changes do not generate new warnings
- [x] I have added tests to validate the feature
- [ ] Both new and existing unit tests pass locally with `just test-coverage`
- [x] Static analysis passes
- [x] I have included a usage example