### PR TITLE
fix(redis): allow MANUAL ack_policy with max_workers for stream subscribers

### DIFF
--- a/faststream/redis/subscriber/factory.py
+++ b/faststream/redis/subscriber/factory.py
@@ -156,10 +156,6 @@ def _validate_input_for_misconfigure(
 ) -> None:
     validate_options(channel=channel, list=list, stream=stream)
 
-    if stream and ack_policy is AckPolicy.MANUAL and max_workers > 1:
-        msg = "Max workers not work with manual no_ack mode."
-        raise SetupError(msg)
-
     if ack_policy is not EMPTY:
         if channel:
             warnings.warn(

--- a/tests/brokers/redis/test_misconfigure.py
+++ b/tests/brokers/redis/test_misconfigure.py
@@ -1,8 +1,51 @@
 import pytest
 
+from faststream import AckPolicy
 from faststream.exceptions import SetupError
 from faststream.nats import NatsRouter
-from faststream.redis import RedisBroker, RedisRouter
+from faststream.redis import RedisBroker, RedisRouter, StreamSub
+from faststream.redis.subscriber.usecases import StreamConcurrentSubscriber
+
+
+@pytest.mark.redis()
+def test_manual_ack_with_max_workers() -> None:
+    """`XACK` is per-entry, so acking manually from concurrent tasks cannot conflict.
+
+    The combination used to raise on the direct argument only. Declaring the same
+    policy as a router default already reached `StreamConcurrentSubscriber`, because
+    `ack_policy` is still `EMPTY` when the subscriber is validated.
+    """
+    broker = RedisBroker()
+
+    @broker.subscriber(
+        stream=StreamSub("stream", group="group", consumer="consumer"),
+        ack_policy=AckPolicy.MANUAL,
+        max_workers=2,
+    )
+    async def handle(msg: str) -> None: ...
+
+    (subscriber,) = broker.subscribers
+    assert isinstance(subscriber, StreamConcurrentSubscriber)
+    assert subscriber.ack_policy is AckPolicy.MANUAL
+
+
+@pytest.mark.redis()
+def test_manual_ack_with_max_workers_via_router_default() -> None:
+    """The router-default path reaches the same subscriber, and always did."""
+    router = RedisRouter(ack_policy=AckPolicy.MANUAL)
+
+    @router.subscriber(
+        stream=StreamSub("stream", group="group", consumer="consumer"),
+        max_workers=2,
+    )
+    async def handle(msg: str) -> None: ...
+
+    broker = RedisBroker()
+    broker.include_router(router)
+
+    (subscriber,) = broker.subscribers
+    assert isinstance(subscriber, StreamConcurrentSubscriber)
+    assert subscriber.ack_policy is AckPolicy.MANUAL
 
 
 @pytest.mark.redis()


### PR DESCRIPTION
# Description

Removes the `SetupError` raised when a Redis stream subscriber combines `ack_policy=AckPolicy.MANUAL` with `max_workers > 1`, and adds the real-Redis runtime verification that was requested in #3045 before a guard removal could be merged.

Fixes #3043

The patch and its tests are from #3045; this PR adds the runtime verification requested there.

**Why the guard can go** (the argument from #3043 / #3045): `XACK` is per-entry and carries no ordering semantics, so acknowledging manually from concurrent handler tasks cannot conflict. The Confluent check this guard was modelled on protects cumulative offset commits, which Redis streams have no equivalent of. The check was also only half-applied: when `AckPolicy.MANUAL` comes from a router or broker default, `ack_policy` is still `EMPTY` at validation time, so the same combination already reached `StreamConcurrentSubscriber` and ran. Both paths are pinned by the new tests — the direct-argument test fails on `main`, the router-default one already passes there.

**Runtime verification** (as requested in #3045)

Environment: Redis 8.10.1 (Docker, localhost), redis-py 8.0.1, this branch. Setup: one stream subscriber with `ack_policy=AckPolicy.MANUAL` and `max_workers=4`; 200 messages published with `XADD`; each handler sleeps 10–100 ms (deterministic, derived from the message number) so completion order interleaves, then acks its own entry with `await msg.ack(redis=redis, group=GROUP)`.

```
redis server         : 8.10.1
subscriber           : ack_policy=MANUAL, max_workers=4
messages published   : 200
messages processed   : 200
lost entries         : 0
processed twice      : 0
max concurrent tasks : 4
PEL mid-run          : 12 pending
PEL after drain      : 0 pending
drain wall time      : 2.56s
```

- No entries lost, none processed twice: each of the 200 ids was handled exactly once.
- The PEL actually filled while handlers were busy (12 pending mid-run) and drained to 0 after the manual acks.
- Handlers genuinely overlapped: 4 concurrent tasks, the `max_workers` cap.

<details>
<summary>Verification script</summary>

```python
"""Runtime verification for ag2ai/faststream#3043 (re: closed PR #3045).

Maintainer's request (PR #3045 comment): a stream subscriber with
`ack_policy=AckPolicy.MANUAL` and `max_workers > 1`, several messages in
flight, `XACK` called manually from concurrent handlers — verify:
  1. no entries lost
  2. none processed twice
  3. the pending list draining as expected

Runs against a real Redis on localhost:6379 with the guard-removal patch
from #3045 applied to the local faststream checkout.
"""

import asyncio
import time
from collections import Counter

from redis.asyncio import Redis

from faststream import AckPolicy, FastStream
from faststream.redis import RedisBroker, StreamSub
from faststream.redis.annotations import Redis as InjectedRedis, RedisStreamMessage

STREAM = "manual-ack-max-workers-check"
GROUP = "check-group"
CONSUMER = "check-consumer"
MAX_WORKERS = 4
N_MESSAGES = 200

broker = RedisBroker("redis://localhost:6379")
app = FastStream(broker)

processed: Counter[str] = Counter()  # message id -> times handled
in_flight = 0
max_overlap = 0
done = asyncio.Event()


@broker.subscriber(
    stream=StreamSub(STREAM, group=GROUP, consumer=CONSUMER),
    ack_policy=AckPolicy.MANUAL,
    max_workers=MAX_WORKERS,
)
async def handle(body: str, message: RedisStreamMessage, redis: InjectedRedis) -> None:
    global in_flight, max_overlap
    in_flight += 1
    max_overlap = max(max_overlap, in_flight)

    # deterministic 10-100 ms per message so completion order interleaves
    seq = int(body.removeprefix("msg-"))
    await asyncio.sleep(0.01 + (seq % 10) * 0.01)

    processed[message.raw_message["message_ids"][0].decode()] += 1
    await message.ack(redis=redis, group=GROUP)

    in_flight -= 1
    if sum(processed.values()) >= N_MESSAGES:
        done.set()


async def main() -> None:
    redis = Redis()
    await redis.delete(STREAM)

    async with broker:
        await broker.start()

        published = [
            (await redis.xadd(STREAM, {"__data__": f"msg-{i}"})).decode()
            for i in range(N_MESSAGES)
        ]

        # snapshot the PEL while handlers are busy: it must actually fill up
        await asyncio.sleep(0.3)
        pending_mid_run = (await redis.xpending(STREAM, GROUP))["pending"]

        t0 = time.monotonic()
        await asyncio.wait_for(done.wait(), timeout=60)
        elapsed = time.monotonic() - t0

        # let the last manual XACKs land, then read the final PEL
        await asyncio.sleep(0.5)
        pending_after = (await redis.xpending(STREAM, GROUP))["pending"]

    lost = [mid for mid in published if processed[mid] == 0]
    duplicated = {mid: n for mid, n in processed.items() if n > 1}
    server = (await redis.info("server"))["redis_version"]
    await redis.aclose()

    print(f"redis server         : {server}")
    print(f"subscriber           : ack_policy=MANUAL, max_workers={MAX_WORKERS}")
    print(f"messages published   : {len(published)}")
    print(f"messages processed   : {sum(processed.values())}")
    print(f"lost entries         : {len(lost)}")
    print(f"processed twice      : {len(duplicated)}")
    print(f"max concurrent tasks : {max_overlap}")
    print(f"PEL mid-run          : {pending_mid_run} pending")
    print(f"PEL after drain      : {pending_after} pending")
    print(f"drain wall time      : {elapsed:.2f}s")

    assert not lost, f"lost: {lost[:5]}"
    assert not duplicated, f"duplicated: {dict(list(duplicated.items())[:5])}"
    assert pending_mid_run > 0, "PEL never filled — nothing was actually pending"
    assert pending_after == 0, "PEL did not drain"
    assert max_overlap >= 2, "handlers never actually overlapped"
    print("ALL CHECKS PASSED")


if __name__ == "__main__":
    asyncio.run(main())
```

</details>

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications

<details>
<summary>Full run log</summary>

```
2026-08-28 17:07:13,129 INFO     - manual-ack-max-workers-check |            - `Handle` waiting for messages
2026-08-28 17:07:13,131 INFO     - manual-ack-max-workers-check | c0ad19b0-a - Received
2026-08-28 17:07:13,132 INFO     - manual-ack-max-workers-check | ff8e726a-1 - Received
2026-08-28 17:07:13,132 INFO     - manual-ack-max-workers-check | 7a92fa7c-0 - Received
2026-08-28 17:07:13,133 INFO     - manual-ack-max-workers-check | 80e6095e-5 - Received
2026-08-28 17:07:13,142 INFO     - manual-ack-max-workers-check | c0ad19b0-a - Processed
2026-08-28 17:07:13,143 INFO     - manual-ack-max-workers-check | 2c57c3b2-a - Received
2026-08-28 17:07:13,153 INFO     - manual-ack-max-workers-check | ff8e726a-1 - Processed
2026-08-28 17:07:13,153 INFO     - manual-ack-max-workers-check | 95fb3d9c-5 - Received
2026-08-28 17:07:13,163 INFO     - manual-ack-max-workers-check | 7a92fa7c-0 - Processed
2026-08-28 17:07:13,163 INFO     - manual-ack-max-workers-check | a47f8708-8 - Received
2026-08-28 17:07:13,173 INFO     - manual-ack-max-workers-check | 80e6095e-5 - Processed
2026-08-28 17:07:13,174 INFO     - manual-ack-max-workers-check | 4a393cd7-0 - Received
2026-08-28 17:07:13,194 INFO     - manual-ack-max-workers-check | 2c57c3b2-a - Processed
2026-08-28 17:07:13,195 INFO     - manual-ack-max-workers-check | 1d88631d-7 - Received
2026-08-28 17:07:13,215 INFO     - manual-ack-max-workers-check | 95fb3d9c-5 - Processed
2026-08-28 17:07:13,215 INFO     - manual-ack-max-workers-check | e5474059-b - Received
2026-08-28 17:07:13,235 INFO     - manual-ack-max-workers-check | a47f8708-8 - Processed
2026-08-28 17:07:13,235 INFO     - manual-ack-max-workers-check | 4eeed888-0 - Received
2026-08-28 17:07:13,247 INFO     - manual-ack-max-workers-check | 4eeed888-0 - Processed
2026-08-28 17:07:13,247 INFO     - manual-ack-max-workers-check | 746bc257-9 - Received
2026-08-28 17:07:13,255 INFO     - manual-ack-max-workers-check | 4a393cd7-0 - Processed
2026-08-28 17:07:13,255 INFO     - manual-ack-max-workers-check | bd8b9a77-d - Received
2026-08-28 17:07:13,269 INFO     - manual-ack-max-workers-check | 746bc257-9 - Processed
2026-08-28 17:07:13,269 INFO     - manual-ack-max-workers-check | 6f5c300f-0 - Received
2026-08-28 17:07:13,286 INFO     - manual-ack-max-workers-check | 1d88631d-7 - Processed
2026-08-28 17:07:13,287 INFO     - manual-ack-max-workers-check | 63fae956-9 - Received
2026-08-28 17:07:13,289 INFO     - manual-ack-max-workers-check | bd8b9a77-d - Processed
2026-08-28 17:07:13,289 INFO     - manual-ack-max-workers-check | 0fed14bb-8 - Received
2026-08-28 17:07:13,311 INFO     - manual-ack-max-workers-check | 6f5c300f-0 - Processed
2026-08-28 17:07:13,311 INFO     - manual-ack-max-workers-check | 3019ae67-d - Received
2026-08-28 17:07:13,316 INFO     - manual-ack-max-workers-check | e5474059-b - Processed
2026-08-28 17:07:13,316 INFO     - manual-ack-max-workers-check | 60907f48-2 - Received
2026-08-28 17:07:13,339 INFO     - manual-ack-max-workers-check | 63fae956-9 - Processed
2026-08-28 17:07:13,339 INFO     - manual-ack-max-workers-check | 9ddb3214-d - Received
2026-08-28 17:07:13,351 INFO     - manual-ack-max-workers-check | 0fed14bb-8 - Processed
2026-08-28 17:07:13,351 INFO     - manual-ack-max-workers-check | 16527b51-1 - Received
2026-08-28 17:07:13,384 INFO     - manual-ack-max-workers-check | 3019ae67-d - Processed
2026-08-28 17:07:13,384 INFO     - manual-ack-max-workers-check | 61557510-9 - Received
2026-08-28 17:07:13,396 INFO     - manual-ack-max-workers-check | 61557510-9 - Processed
2026-08-28 17:07:13,397 INFO     - manual-ack-max-workers-check | e7247d0d-b - Received
2026-08-28 17:07:13,398 INFO     - manual-ack-max-workers-check | 60907f48-2 - Processed
2026-08-28 17:07:13,398 INFO     - manual-ack-max-workers-check | a5a60bcb-f - Received
2026-08-28 17:07:13,419 INFO     - manual-ack-max-workers-check | e7247d0d-b - Processed
2026-08-28 17:07:13,419 INFO     - manual-ack-max-workers-check | 17eef4f3-4 - Received
2026-08-28 17:07:13,430 INFO     - manual-ack-max-workers-check | a5a60bcb-f - Processed
2026-08-28 17:07:13,430 INFO     - manual-ack-max-workers-check | 9ddb3214-d - Processed
2026-08-28 17:07:13,431 INFO     - manual-ack-max-workers-check | 56734b71-6 - Received
2026-08-28 17:07:13,431 INFO     - manual-ack-max-workers-check | b3860723-0 - Received
2026-08-28 17:07:13,454 INFO     - manual-ack-max-workers-check | 16527b51-1 - Processed
2026-08-28 17:07:13,454 INFO     - manual-ack-max-workers-check | cfa81a1d-c - Received
2026-08-28 17:07:13,461 INFO     - manual-ack-max-workers-check | 17eef4f3-4 - Processed
2026-08-28 17:07:13,462 INFO     - manual-ack-max-workers-check | 83dc2511-3 - Received
2026-08-28 17:07:13,483 INFO     - manual-ack-max-workers-check | 56734b71-6 - Processed
2026-08-28 17:07:13,483 INFO     - manual-ack-max-workers-check | 59086358-f - Received
2026-08-28 17:07:13,492 INFO     - manual-ack-max-workers-check | b3860723-0 - Processed
2026-08-28 17:07:13,493 INFO     - manual-ack-max-workers-check | 70314e38-6 - Received
2026-08-28 17:07:13,526 INFO     - manual-ack-max-workers-check | cfa81a1d-c - Processed
2026-08-28 17:07:13,527 INFO     - manual-ack-max-workers-check | d1e01764-b - Received
2026-08-28 17:07:13,539 INFO     - manual-ack-max-workers-check | d1e01764-b - Processed
2026-08-28 17:07:13,539 INFO     - manual-ack-max-workers-check | 1f42f6c7-3 - Received
2026-08-28 17:07:13,543 INFO     - manual-ack-max-workers-check | 83dc2511-3 - Processed
2026-08-28 17:07:13,543 INFO     - manual-ack-max-workers-check | b62abb68-c - Received
2026-08-28 17:07:13,561 INFO     - manual-ack-max-workers-check | 1f42f6c7-3 - Processed
2026-08-28 17:07:13,562 INFO     - manual-ack-max-workers-check | 4b7f49fe-9 - Received
2026-08-28 17:07:13,575 INFO     - manual-ack-max-workers-check | 59086358-f - Processed
2026-08-28 17:07:13,575 INFO     - manual-ack-max-workers-check | b62abb68-c - Processed
2026-08-28 17:07:13,575 INFO     - manual-ack-max-workers-check | c2ade113-5 - Received
2026-08-28 17:07:13,576 INFO     - manual-ack-max-workers-check | 5d0cee05-6 - Received
2026-08-28 17:07:13,595 INFO     - manual-ack-max-workers-check | 70314e38-6 - Processed
2026-08-28 17:07:13,595 INFO     - manual-ack-max-workers-check | 9c1b5863-1 - Received
2026-08-28 17:07:13,604 INFO     - manual-ack-max-workers-check | 4b7f49fe-9 - Processed
2026-08-28 17:07:13,604 INFO     - manual-ack-max-workers-check | 1f4f1b69-7 - Received
2026-08-28 17:07:13,628 INFO     - manual-ack-max-workers-check | c2ade113-5 - Processed
2026-08-28 17:07:13,629 INFO     - manual-ack-max-workers-check | fdea4ae0-a - Received
2026-08-28 17:07:13,640 INFO     - manual-ack-max-workers-check | 5d0cee05-6 - Processed
2026-08-28 17:07:13,641 INFO     - manual-ack-max-workers-check | e52a6ba4-2 - Received
2026-08-28 17:07:13,667 INFO     - manual-ack-max-workers-check | 9c1b5863-1 - Processed
2026-08-28 17:07:13,668 INFO     - manual-ack-max-workers-check | 15485ad9-9 - Received
2026-08-28 17:07:13,680 INFO     - manual-ack-max-workers-check | 15485ad9-9 - Processed
2026-08-28 17:07:13,681 INFO     - manual-ack-max-workers-check | 79b9a4e5-7 - Received
2026-08-28 17:07:13,686 INFO     - manual-ack-max-workers-check | 1f4f1b69-7 - Processed
2026-08-28 17:07:13,686 INFO     - manual-ack-max-workers-check | 1cf8c3f1-3 - Received
2026-08-28 17:07:13,702 INFO     - manual-ack-max-workers-check | 79b9a4e5-7 - Processed
2026-08-28 17:07:13,703 INFO     - manual-ack-max-workers-check | 49c45f8f-7 - Received
2026-08-28 17:07:13,719 INFO     - manual-ack-max-workers-check | 1cf8c3f1-3 - Processed
2026-08-28 17:07:13,719 INFO     - manual-ack-max-workers-check | 92003b0d-4 - Received
2026-08-28 17:07:13,720 INFO     - manual-ack-max-workers-check | fdea4ae0-a - Processed
2026-08-28 17:07:13,720 INFO     - manual-ack-max-workers-check | 239fcd08-5 - Received
2026-08-28 17:07:13,742 INFO     - manual-ack-max-workers-check | e52a6ba4-2 - Processed
2026-08-28 17:07:13,743 INFO     - manual-ack-max-workers-check | 6613b368-1 - Received
2026-08-28 17:07:13,744 INFO     - manual-ack-max-workers-check | 49c45f8f-7 - Processed
2026-08-28 17:07:13,744 INFO     - manual-ack-max-workers-check | a3684d80-3 - Received
2026-08-28 17:07:13,772 INFO     - manual-ack-max-workers-check | 92003b0d-4 - Processed
2026-08-28 17:07:13,773 INFO     - manual-ack-max-workers-check | 80151d09-6 - Received
2026-08-28 17:07:13,783 INFO     - manual-ack-max-workers-check | 239fcd08-5 - Processed
2026-08-28 17:07:13,783 INFO     - manual-ack-max-workers-check | 1c8e7089-b - Received
2026-08-28 17:07:13,815 INFO     - manual-ack-max-workers-check | 6613b368-1 - Processed
2026-08-28 17:07:13,816 INFO     - manual-ack-max-workers-check | 42d58f79-3 - Received
2026-08-28 17:07:13,826 INFO     - manual-ack-max-workers-check | a3684d80-3 - Processed
2026-08-28 17:07:13,827 INFO     - manual-ack-max-workers-check | 2875816b-2 - Received
2026-08-28 17:07:13,828 INFO     - manual-ack-max-workers-check | 42d58f79-3 - Processed
2026-08-28 17:07:13,828 INFO     - manual-ack-max-workers-check | 448b79ec-5 - Received
2026-08-28 17:07:13,850 INFO     - manual-ack-max-workers-check | 2875816b-2 - Processed
2026-08-28 17:07:13,850 INFO     - manual-ack-max-workers-check | f339a8aa-3 - Received
2026-08-28 17:07:13,860 INFO     - manual-ack-max-workers-check | 448b79ec-5 - Processed
2026-08-28 17:07:13,861 INFO     - manual-ack-max-workers-check | 08773316-a - Received
2026-08-28 17:07:13,864 INFO     - manual-ack-max-workers-check | 80151d09-6 - Processed
2026-08-28 17:07:13,865 INFO     - manual-ack-max-workers-check | 69935a31-6 - Received
2026-08-28 17:07:13,886 INFO     - manual-ack-max-workers-check | 1c8e7089-b - Processed
2026-08-28 17:07:13,886 INFO     - manual-ack-max-workers-check | 3fb4186d-0 - Received
2026-08-28 17:07:13,892 INFO     - manual-ack-max-workers-check | f339a8aa-3 - Processed
2026-08-28 17:07:13,892 INFO     - manual-ack-max-workers-check | d593c5a3-3 - Received
2026-08-28 17:07:13,913 INFO     - manual-ack-max-workers-check | 08773316-a - Processed
2026-08-28 17:07:13,913 INFO     - manual-ack-max-workers-check | 5645182c-7 - Received
2026-08-28 17:07:13,927 INFO     - manual-ack-max-workers-check | 69935a31-6 - Processed
2026-08-28 17:07:13,927 INFO     - manual-ack-max-workers-check | b86e0364-4 - Received
2026-08-28 17:07:13,959 INFO     - manual-ack-max-workers-check | 3fb4186d-0 - Processed
2026-08-28 17:07:13,959 INFO     - manual-ack-max-workers-check | 1c82d34e-0 - Received
2026-08-28 17:07:13,972 INFO     - manual-ack-max-workers-check | 1c82d34e-0 - Processed
2026-08-28 17:07:13,972 INFO     - manual-ack-max-workers-check | fe7e0bd7-1 - Received
2026-08-28 17:07:13,973 INFO     - manual-ack-max-workers-check | d593c5a3-3 - Processed
2026-08-28 17:07:13,973 INFO     - manual-ack-max-workers-check | 2f0a605d-9 - Received
2026-08-28 17:07:13,995 INFO     - manual-ack-max-workers-check | fe7e0bd7-1 - Processed
2026-08-28 17:07:13,995 INFO     - manual-ack-max-workers-check | 6413f613-4 - Received
2026-08-28 17:07:14,005 INFO     - manual-ack-max-workers-check | 2f0a605d-9 - Processed
2026-08-28 17:07:14,006 INFO     - manual-ack-max-workers-check | 5645182c-7 - Processed
2026-08-28 17:07:14,006 INFO     - manual-ack-max-workers-check | 406e289e-7 - Received
2026-08-28 17:07:14,006 INFO     - manual-ack-max-workers-check | 4e6a4668-7 - Received
2026-08-28 17:07:14,029 INFO     - manual-ack-max-workers-check | b86e0364-4 - Processed
2026-08-28 17:07:14,030 INFO     - manual-ack-max-workers-check | 83977d18-5 - Received
2026-08-28 17:07:14,037 INFO     - manual-ack-max-workers-check | 6413f613-4 - Processed
2026-08-28 17:07:14,037 INFO     - manual-ack-max-workers-check | 93cf9e1d-b - Received
2026-08-28 17:07:14,059 INFO     - manual-ack-max-workers-check | 406e289e-7 - Processed
2026-08-28 17:07:14,059 INFO     - manual-ack-max-workers-check | 45c23c5f-3 - Received
2026-08-28 17:07:14,068 INFO     - manual-ack-max-workers-check | 4e6a4668-7 - Processed
2026-08-28 17:07:14,069 INFO     - manual-ack-max-workers-check | 39cf2e10-a - Received
2026-08-28 17:07:14,102 INFO     - manual-ack-max-workers-check | 83977d18-5 - Processed
2026-08-28 17:07:14,103 INFO     - manual-ack-max-workers-check | 7eca5d6b-b - Received
2026-08-28 17:07:14,115 INFO     - manual-ack-max-workers-check | 7eca5d6b-b - Processed
2026-08-28 17:07:14,115 INFO     - manual-ack-max-workers-check | 70e7c97a-d - Received
2026-08-28 17:07:14,118 INFO     - manual-ack-max-workers-check | 93cf9e1d-b - Processed
2026-08-28 17:07:14,119 INFO     - manual-ack-max-workers-check | b27fc3e0-3 - Received
2026-08-28 17:07:14,138 INFO     - manual-ack-max-workers-check | 70e7c97a-d - Processed
2026-08-28 17:07:14,138 INFO     - manual-ack-max-workers-check | b5c6e110-2 - Received
2026-08-28 17:07:14,151 INFO     - manual-ack-max-workers-check | 45c23c5f-3 - Processed
2026-08-28 17:07:14,152 INFO     - manual-ack-max-workers-check | b27fc3e0-3 - Processed
2026-08-28 17:07:14,152 INFO     - manual-ack-max-workers-check | 68885c9b-7 - Received
2026-08-28 17:07:14,152 INFO     - manual-ack-max-workers-check | 31607834-c - Received
2026-08-28 17:07:14,171 INFO     - manual-ack-max-workers-check | 39cf2e10-a - Processed
2026-08-28 17:07:14,172 INFO     - manual-ack-max-workers-check | 8e1e38c1-3 - Received
2026-08-28 17:07:14,188 INFO     - manual-ack-max-workers-check | b5c6e110-2 - Processed
2026-08-28 17:07:14,188 INFO     - manual-ack-max-workers-check | 1302af3a-3 - Received
2026-08-28 17:07:14,205 INFO     - manual-ack-max-workers-check | 68885c9b-7 - Processed
2026-08-28 17:07:14,205 INFO     - manual-ack-max-workers-check | ebcf616c-7 - Received
2026-08-28 17:07:14,215 INFO     - manual-ack-max-workers-check | 31607834-c - Processed
2026-08-28 17:07:14,215 INFO     - manual-ack-max-workers-check | 784172d7-1 - Received
2026-08-28 17:07:14,244 INFO     - manual-ack-max-workers-check | 8e1e38c1-3 - Processed
2026-08-28 17:07:14,244 INFO     - manual-ack-max-workers-check | 178669aa-6 - Received
2026-08-28 17:07:14,257 INFO     - manual-ack-max-workers-check | 178669aa-6 - Processed
2026-08-28 17:07:14,258 INFO     - manual-ack-max-workers-check | d2370db1-d - Received
2026-08-28 17:07:14,271 INFO     - manual-ack-max-workers-check | 1302af3a-3 - Processed
2026-08-28 17:07:14,271 INFO     - manual-ack-max-workers-check | 59b2c8ac-6 - Received
2026-08-28 17:07:14,279 INFO     - manual-ack-max-workers-check | d2370db1-d - Processed
2026-08-28 17:07:14,279 INFO     - manual-ack-max-workers-check | 12f5be28-f - Received
2026-08-28 17:07:14,297 INFO     - manual-ack-max-workers-check | ebcf616c-7 - Processed
2026-08-28 17:07:14,298 INFO     - manual-ack-max-workers-check | 4cc37a74-0 - Received
2026-08-28 17:07:14,303 INFO     - manual-ack-max-workers-check | 59b2c8ac-6 - Processed
2026-08-28 17:07:14,303 INFO     - manual-ack-max-workers-check | 8d6c7f1a-f - Received
2026-08-28 17:07:14,318 INFO     - manual-ack-max-workers-check | 784172d7-1 - Processed
2026-08-28 17:07:14,319 INFO     - manual-ack-max-workers-check | bb9e6919-f - Received
2026-08-28 17:07:14,321 INFO     - manual-ack-max-workers-check | 12f5be28-f - Processed
2026-08-28 17:07:14,321 INFO     - manual-ack-max-workers-check | 6bb1b23b-e - Received
2026-08-28 17:07:14,350 INFO     - manual-ack-max-workers-check | 4cc37a74-0 - Processed
2026-08-28 17:07:14,351 INFO     - manual-ack-max-workers-check | 7b5aff07-d - Received
2026-08-28 17:07:14,366 INFO     - manual-ack-max-workers-check | 8d6c7f1a-f - Processed
2026-08-28 17:07:14,366 INFO     - manual-ack-max-workers-check | e40d8cce-a - Received
2026-08-28 17:07:14,392 INFO     - manual-ack-max-workers-check | bb9e6919-f - Processed
2026-08-28 17:07:14,392 INFO     - manual-ack-max-workers-check | 6e90550f-8 - Received
2026-08-28 17:07:14,402 INFO     - manual-ack-max-workers-check | 6bb1b23b-e - Processed
2026-08-28 17:07:14,403 INFO     - manual-ack-max-workers-check | 51d7b2d0-7 - Received
2026-08-28 17:07:14,404 INFO     - manual-ack-max-workers-check | 6e90550f-8 - Processed
2026-08-28 17:07:14,404 INFO     - manual-ack-max-workers-check | 50e5c3dc-a - Received
2026-08-28 17:07:14,426 INFO     - manual-ack-max-workers-check | 51d7b2d0-7 - Processed
2026-08-28 17:07:14,427 INFO     - manual-ack-max-workers-check | 83286b1d-e - Received
2026-08-28 17:07:14,436 INFO     - manual-ack-max-workers-check | 50e5c3dc-a - Processed
2026-08-28 17:07:14,436 INFO     - manual-ack-max-workers-check | 1bac0979-5 - Received
2026-08-28 17:07:14,443 INFO     - manual-ack-max-workers-check | 7b5aff07-d - Processed
2026-08-28 17:07:14,443 INFO     - manual-ack-max-workers-check | 821c805a-3 - Received
2026-08-28 17:07:14,469 INFO     - manual-ack-max-workers-check | e40d8cce-a - Processed
2026-08-28 17:07:14,469 INFO     - manual-ack-max-workers-check | 83286b1d-e - Processed
2026-08-28 17:07:14,469 INFO     - manual-ack-max-workers-check | 59f9e3f1-2 - Received
2026-08-28 17:07:14,470 INFO     - manual-ack-max-workers-check | 214055fa-9 - Received
2026-08-28 17:07:14,489 INFO     - manual-ack-max-workers-check | 1bac0979-5 - Processed
2026-08-28 17:07:14,490 INFO     - manual-ack-max-workers-check | 275d51eb-8 - Received
2026-08-28 17:07:14,506 INFO     - manual-ack-max-workers-check | 821c805a-3 - Processed
2026-08-28 17:07:14,506 INFO     - manual-ack-max-workers-check | 9474bb5e-6 - Received
2026-08-28 17:07:14,544 INFO     - manual-ack-max-workers-check | 59f9e3f1-2 - Processed
2026-08-28 17:07:14,544 INFO     - manual-ack-max-workers-check | 0bd0a584-3 - Received
2026-08-28 17:07:14,553 INFO     - manual-ack-max-workers-check | 214055fa-9 - Processed
2026-08-28 17:07:14,553 INFO     - manual-ack-max-workers-check | 918ddace-0 - Received
2026-08-28 17:07:14,556 INFO     - manual-ack-max-workers-check | 0bd0a584-3 - Processed
2026-08-28 17:07:14,556 INFO     - manual-ack-max-workers-check | b412c393-a - Received
2026-08-28 17:07:14,576 INFO     - manual-ack-max-workers-check | 918ddace-0 - Processed
2026-08-28 17:07:14,576 INFO     - manual-ack-max-workers-check | de7eeaee-3 - Received
2026-08-28 17:07:14,581 INFO     - manual-ack-max-workers-check | 275d51eb-8 - Processed
2026-08-28 17:07:14,582 INFO     - manual-ack-max-workers-check | 01f594d0-1 - Received
2026-08-28 17:07:14,588 INFO     - manual-ack-max-workers-check | b412c393-a - Processed
2026-08-28 17:07:14,588 INFO     - manual-ack-max-workers-check | 394b1294-7 - Received
2026-08-28 17:07:14,609 INFO     - manual-ack-max-workers-check | 9474bb5e-6 - Processed
2026-08-28 17:07:14,609 INFO     - manual-ack-max-workers-check | 1466574c-3 - Received
2026-08-28 17:07:14,619 INFO     - manual-ack-max-workers-check | de7eeaee-3 - Processed
2026-08-28 17:07:14,619 INFO     - manual-ack-max-workers-check | 8a80d091-8 - Received
2026-08-28 17:07:14,635 INFO     - manual-ack-max-workers-check | 01f594d0-1 - Processed
2026-08-28 17:07:14,635 INFO     - manual-ack-max-workers-check | 4450acc5-4 - Received
2026-08-28 17:07:14,651 INFO     - manual-ack-max-workers-check | 394b1294-7 - Processed
2026-08-28 17:07:14,651 INFO     - manual-ack-max-workers-check | df951d36-c - Received
2026-08-28 17:07:14,682 INFO     - manual-ack-max-workers-check | 1466574c-3 - Processed
2026-08-28 17:07:14,683 INFO     - manual-ack-max-workers-check | 3b09e8cb-6 - Received
2026-08-28 17:07:14,695 INFO     - manual-ack-max-workers-check | 3b09e8cb-6 - Processed
2026-08-28 17:07:14,696 INFO     - manual-ack-max-workers-check | 3633723a-9 - Received
2026-08-28 17:07:14,701 INFO     - manual-ack-max-workers-check | 8a80d091-8 - Processed
2026-08-28 17:07:14,701 INFO     - manual-ack-max-workers-check | a757c81f-2 - Received
2026-08-28 17:07:14,718 INFO     - manual-ack-max-workers-check | 3633723a-9 - Processed
2026-08-28 17:07:14,719 INFO     - manual-ack-max-workers-check | f8c44a4f-d - Received
2026-08-28 17:07:14,728 INFO     - manual-ack-max-workers-check | 4450acc5-4 - Processed
2026-08-28 17:07:14,728 INFO     - manual-ack-max-workers-check | c3e3d8e4-9 - Received
2026-08-28 17:07:14,733 INFO     - manual-ack-max-workers-check | a757c81f-2 - Processed
2026-08-28 17:07:14,734 INFO     - manual-ack-max-workers-check | a18b4ce3-c - Received
2026-08-28 17:07:14,754 INFO     - manual-ack-max-workers-check | df951d36-c - Processed
2026-08-28 17:07:14,754 INFO     - manual-ack-max-workers-check | 5b52dd5f-e - Received
2026-08-28 17:07:14,761 INFO     - manual-ack-max-workers-check | f8c44a4f-d - Processed
2026-08-28 17:07:14,761 INFO     - manual-ack-max-workers-check | b6cf5768-8 - Received
2026-08-28 17:07:14,780 INFO     - manual-ack-max-workers-check | c3e3d8e4-9 - Processed
2026-08-28 17:07:14,781 INFO     - manual-ack-max-workers-check | 40611946-d - Received
2026-08-28 17:07:14,796 INFO     - manual-ack-max-workers-check | a18b4ce3-c - Processed
2026-08-28 17:07:14,796 INFO     - manual-ack-max-workers-check | f22053ba-1 - Received
2026-08-28 17:07:14,827 INFO     - manual-ack-max-workers-check | 5b52dd5f-e - Processed
2026-08-28 17:07:14,828 INFO     - manual-ack-max-workers-check | b2b8b856-0 - Received
2026-08-28 17:07:14,840 INFO     - manual-ack-max-workers-check | b2b8b856-0 - Processed
2026-08-28 17:07:14,841 INFO     - manual-ack-max-workers-check | cd4f2bdc-e - Received
2026-08-28 17:07:14,843 INFO     - manual-ack-max-workers-check | b6cf5768-8 - Processed
2026-08-28 17:07:14,843 INFO     - manual-ack-max-workers-check | 7e849207-a - Received
2026-08-28 17:07:14,863 INFO     - manual-ack-max-workers-check | cd4f2bdc-e - Processed
2026-08-28 17:07:14,864 INFO     - manual-ack-max-workers-check | 94355d6a-5 - Received
2026-08-28 17:07:14,873 INFO     - manual-ack-max-workers-check | 40611946-d - Processed
2026-08-28 17:07:14,873 INFO     - manual-ack-max-workers-check | db0677d3-9 - Received
2026-08-28 17:07:14,874 INFO     - manual-ack-max-workers-check | 7e849207-a - Processed
2026-08-28 17:07:14,874 INFO     - manual-ack-max-workers-check | 88e6fd9c-1 - Received
2026-08-28 17:07:14,899 INFO     - manual-ack-max-workers-check | f22053ba-1 - Processed
2026-08-28 17:07:14,899 INFO     - manual-ack-max-workers-check | 3ec8eb51-e - Received
2026-08-28 17:07:14,906 INFO     - manual-ack-max-workers-check | 94355d6a-5 - Processed
2026-08-28 17:07:14,907 INFO     - manual-ack-max-workers-check | 20476acf-2 - Received
2026-08-28 17:07:14,926 INFO     - manual-ack-max-workers-check | db0677d3-9 - Processed
2026-08-28 17:07:14,926 INFO     - manual-ack-max-workers-check | 143c718b-4 - Received
2026-08-28 17:07:14,936 INFO     - manual-ack-max-workers-check | 88e6fd9c-1 - Processed
2026-08-28 17:07:14,936 INFO     - manual-ack-max-workers-check | 2f9f91d8-4 - Received
2026-08-28 17:07:14,971 INFO     - manual-ack-max-workers-check | 3ec8eb51-e - Processed
2026-08-28 17:07:14,972 INFO     - manual-ack-max-workers-check | cae06236-e - Received
2026-08-28 17:07:14,985 INFO     - manual-ack-max-workers-check | cae06236-e - Processed
2026-08-28 17:07:14,985 INFO     - manual-ack-max-workers-check | 0b558a15-9 - Received
2026-08-28 17:07:14,988 INFO     - manual-ack-max-workers-check | 20476acf-2 - Processed
2026-08-28 17:07:14,988 INFO     - manual-ack-max-workers-check | b1e0b44d-7 - Received
2026-08-28 17:07:15,008 INFO     - manual-ack-max-workers-check | 0b558a15-9 - Processed
2026-08-28 17:07:15,008 INFO     - manual-ack-max-workers-check | ca322713-9 - Received
2026-08-28 17:07:15,019 INFO     - manual-ack-max-workers-check | 143c718b-4 - Processed
2026-08-28 17:07:15,019 INFO     - manual-ack-max-workers-check | f5653b29-3 - Received
2026-08-28 17:07:15,019 INFO     - manual-ack-max-workers-check | b1e0b44d-7 - Processed
2026-08-28 17:07:15,020 INFO     - manual-ack-max-workers-check | a3f175a8-2 - Received
2026-08-28 17:07:15,039 INFO     - manual-ack-max-workers-check | 2f9f91d8-4 - Processed
2026-08-28 17:07:15,039 INFO     - manual-ack-max-workers-check | 0df6ffe4-f - Received
2026-08-28 17:07:15,050 INFO     - manual-ack-max-workers-check | ca322713-9 - Processed
2026-08-28 17:07:15,050 INFO     - manual-ack-max-workers-check | 1fd9a872-e - Received
2026-08-28 17:07:15,072 INFO     - manual-ack-max-workers-check | f5653b29-3 - Processed
2026-08-28 17:07:15,072 INFO     - manual-ack-max-workers-check | b6f4591e-5 - Received
2026-08-28 17:07:15,082 INFO     - manual-ack-max-workers-check | a3f175a8-2 - Processed
2026-08-28 17:07:15,082 INFO     - manual-ack-max-workers-check | c4b2df77-c - Received
2026-08-28 17:07:15,111 INFO     - manual-ack-max-workers-check | 0df6ffe4-f - Processed
2026-08-28 17:07:15,111 INFO     - manual-ack-max-workers-check | 50198c73-3 - Received
2026-08-28 17:07:15,123 INFO     - manual-ack-max-workers-check | 50198c73-3 - Processed
2026-08-28 17:07:15,123 INFO     - manual-ack-max-workers-check | c733fc82-f - Received
2026-08-28 17:07:15,132 INFO     - manual-ack-max-workers-check | 1fd9a872-e - Processed
2026-08-28 17:07:15,132 INFO     - manual-ack-max-workers-check | 33d40ec8-0 - Received
2026-08-28 17:07:15,146 INFO     - manual-ack-max-workers-check | c733fc82-f - Processed
2026-08-28 17:07:15,146 INFO     - manual-ack-max-workers-check | 5d06ff81-f - Received
2026-08-28 17:07:15,164 INFO     - manual-ack-max-workers-check | b6f4591e-5 - Processed
2026-08-28 17:07:15,165 INFO     - manual-ack-max-workers-check | 33d40ec8-0 - Processed
2026-08-28 17:07:15,165 INFO     - manual-ack-max-workers-check | a33ef2e6-c - Received
2026-08-28 17:07:15,166 INFO     - manual-ack-max-workers-check | 997d9683-c - Received
2026-08-28 17:07:15,184 INFO     - manual-ack-max-workers-check | c4b2df77-c - Processed
2026-08-28 17:07:15,185 INFO     - manual-ack-max-workers-check | 2da05887-1 - Received
2026-08-28 17:07:15,187 INFO     - manual-ack-max-workers-check | 5d06ff81-f - Processed
2026-08-28 17:07:15,187 INFO     - manual-ack-max-workers-check | 66847aa2-4 - Received
2026-08-28 17:07:15,219 INFO     - manual-ack-max-workers-check | a33ef2e6-c - Processed
2026-08-28 17:07:15,219 INFO     - manual-ack-max-workers-check | 1020d40d-2 - Received
2026-08-28 17:07:15,228 INFO     - manual-ack-max-workers-check | 997d9683-c - Processed
2026-08-28 17:07:15,228 INFO     - manual-ack-max-workers-check | 4cabfc86-3 - Received
2026-08-28 17:07:15,257 INFO     - manual-ack-max-workers-check | 2da05887-1 - Processed
2026-08-28 17:07:15,257 INFO     - manual-ack-max-workers-check | 8393c192-c - Received
2026-08-28 17:07:15,271 INFO     - manual-ack-max-workers-check | 8393c192-c - Processed
2026-08-28 17:07:15,271 INFO     - manual-ack-max-workers-check | 66847aa2-4 - Processed
2026-08-28 17:07:15,271 INFO     - manual-ack-max-workers-check | 17b6217c-b - Received
2026-08-28 17:07:15,272 INFO     - manual-ack-max-workers-check | b398551b-3 - Received
2026-08-28 17:07:15,295 INFO     - manual-ack-max-workers-check | 17b6217c-b - Processed
2026-08-28 17:07:15,295 INFO     - manual-ack-max-workers-check | 8fb63366-d - Received
2026-08-28 17:07:15,304 INFO     - manual-ack-max-workers-check | b398551b-3 - Processed
2026-08-28 17:07:15,304 INFO     - manual-ack-max-workers-check | 012d1461-e - Received
2026-08-28 17:07:15,312 INFO     - manual-ack-max-workers-check | 1020d40d-2 - Processed
2026-08-28 17:07:15,313 INFO     - manual-ack-max-workers-check | a6c1be18-a - Received
2026-08-28 17:07:15,331 INFO     - manual-ack-max-workers-check | 4cabfc86-3 - Processed
2026-08-28 17:07:15,331 INFO     - manual-ack-max-workers-check | ba8d99c5-8 - Received
2026-08-28 17:07:15,337 INFO     - manual-ack-max-workers-check | 8fb63366-d - Processed
2026-08-28 17:07:15,338 INFO     - manual-ack-max-workers-check | 7617fbb7-c - Received
2026-08-28 17:07:15,357 INFO     - manual-ack-max-workers-check | 012d1461-e - Processed
2026-08-28 17:07:15,357 INFO     - manual-ack-max-workers-check | 66507812-b - Received
2026-08-28 17:07:15,375 INFO     - manual-ack-max-workers-check | a6c1be18-a - Processed
2026-08-28 17:07:15,376 INFO     - manual-ack-max-workers-check | 4c90461b-0 - Received
2026-08-28 17:07:15,404 INFO     - manual-ack-max-workers-check | ba8d99c5-8 - Processed
2026-08-28 17:07:15,405 INFO     - manual-ack-max-workers-check | d44b7dc6-b - Received
2026-08-28 17:07:15,417 INFO     - manual-ack-max-workers-check | d44b7dc6-b - Processed
2026-08-28 17:07:15,417 INFO     - manual-ack-max-workers-check | 24388eed-d - Received
2026-08-28 17:07:15,419 INFO     - manual-ack-max-workers-check | 7617fbb7-c - Processed
2026-08-28 17:07:15,419 INFO     - manual-ack-max-workers-check | 2d41a851-5 - Received
2026-08-28 17:07:15,440 INFO     - manual-ack-max-workers-check | 24388eed-d - Processed
2026-08-28 17:07:15,441 INFO     - manual-ack-max-workers-check | 58b69c54-9 - Received
2026-08-28 17:07:15,450 INFO     - manual-ack-max-workers-check | 66507812-b - Processed
2026-08-28 17:07:15,450 INFO     - manual-ack-max-workers-check | e482a2d8-2 - Received
2026-08-28 17:07:15,450 INFO     - manual-ack-max-workers-check | 2d41a851-5 - Processed
2026-08-28 17:07:15,451 INFO     - manual-ack-max-workers-check | abcaf062-7 - Received
2026-08-28 17:07:15,479 INFO     - manual-ack-max-workers-check | 4c90461b-0 - Processed
2026-08-28 17:07:15,479 INFO     - manual-ack-max-workers-check | 0e63cb6d-f - Received
2026-08-28 17:07:15,483 INFO     - manual-ack-max-workers-check | 58b69c54-9 - Processed
2026-08-28 17:07:15,483 INFO     - manual-ack-max-workers-check | b8649bdc-0 - Received
2026-08-28 17:07:15,503 INFO     - manual-ack-max-workers-check | e482a2d8-2 - Processed
2026-08-28 17:07:15,503 INFO     - manual-ack-max-workers-check | 12d0b40f-5 - Received
2026-08-28 17:07:15,513 INFO     - manual-ack-max-workers-check | abcaf062-7 - Processed
2026-08-28 17:07:15,513 INFO     - manual-ack-max-workers-check | 3f780836-4 - Received
2026-08-28 17:07:15,553 INFO     - manual-ack-max-workers-check | 0e63cb6d-f - Processed
2026-08-28 17:07:15,553 INFO     - manual-ack-max-workers-check | 31d75df4-6 - Received
2026-08-28 17:07:15,565 INFO     - manual-ack-max-workers-check | b8649bdc-0 - Processed
2026-08-28 17:07:15,565 INFO     - manual-ack-max-workers-check | 31d75df4-6 - Processed
2026-08-28 17:07:15,565 INFO     - manual-ack-max-workers-check | 3bf39215-6 - Received
2026-08-28 17:07:15,566 INFO     - manual-ack-max-workers-check | e491b086-2 - Received
2026-08-28 17:07:15,588 INFO     - manual-ack-max-workers-check | 3bf39215-6 - Processed
2026-08-28 17:07:15,588 INFO     - manual-ack-max-workers-check | 7949b37f-5 - Received
2026-08-28 17:07:15,595 INFO     - manual-ack-max-workers-check | 12d0b40f-5 - Processed
2026-08-28 17:07:15,596 INFO     - manual-ack-max-workers-check | ce9b39c7-a - Received
2026-08-28 17:07:15,597 INFO     - manual-ack-max-workers-check | e491b086-2 - Processed
2026-08-28 17:07:15,597 INFO     - manual-ack-max-workers-check | 26321bf6-8 - Received
2026-08-28 17:07:15,616 INFO     - manual-ack-max-workers-check | 3f780836-4 - Processed
2026-08-28 17:07:15,617 INFO     - manual-ack-max-workers-check | 8200a7b3-3 - Received
2026-08-28 17:07:15,630 INFO     - manual-ack-max-workers-check | 7949b37f-5 - Processed
2026-08-28 17:07:15,631 INFO     - manual-ack-max-workers-check | 49c0d22a-f - Received
2026-08-28 17:07:15,648 INFO     - manual-ack-max-workers-check | ce9b39c7-a - Processed
2026-08-28 17:07:15,648 INFO     - manual-ack-max-workers-check | 134a0cbb-b - Received
2026-08-28 17:07:15,659 INFO     - manual-ack-max-workers-check | 26321bf6-8 - Processed
2026-08-28 17:07:15,659 INFO     - manual-ack-max-workers-check | 12c59b98-a - Received
2026-08-28 17:07:15,689 INFO     - manual-ack-max-workers-check | 8200a7b3-3 - Processed
2026-08-28 17:07:15,690 INFO     - manual-ack-max-workers-check | 1aa01bcf-c - Received
2026-08-28 17:07:15,703 INFO     - manual-ack-max-workers-check | 1aa01bcf-c - Processed
2026-08-28 17:07:15,703 INFO     - manual-ack-max-workers-check | 9dba023c-f - Received
2026-08-28 17:07:15,714 INFO     - manual-ack-max-workers-check | 49c0d22a-f - Processed
2026-08-28 17:07:15,714 INFO     - manual-ack-max-workers-check | 81cfda80-6 - Received
2026-08-28 17:07:15,726 INFO     - manual-ack-max-workers-check | 9dba023c-f - Processed
2026-08-28 17:07:15,726 INFO     - manual-ack-max-workers-check | 06904917-3 - Received
2026-08-28 17:07:15,741 INFO     - manual-ack-max-workers-check | 134a0cbb-b - Processed
2026-08-28 17:07:15,742 INFO     - manual-ack-max-workers-check | c60b28ea-6 - Received
2026-08-28 17:07:15,746 INFO     - manual-ack-max-workers-check | 81cfda80-6 - Processed
2026-08-28 17:07:15,747 INFO     - manual-ack-max-workers-check | f472f5d9-4 - Received
2026-08-28 17:07:15,761 INFO     - manual-ack-max-workers-check | 12c59b98-a - Processed
2026-08-28 17:07:15,762 INFO     - manual-ack-max-workers-check | f266abb2-4 - Received
2026-08-28 17:07:15,769 INFO     - manual-ack-max-workers-check | 06904917-3 - Processed
2026-08-28 17:07:15,769 INFO     - manual-ack-max-workers-check | a3a67af3-6 - Received
2026-08-28 17:07:15,794 INFO     - manual-ack-max-workers-check | c60b28ea-6 - Processed
2026-08-28 17:07:15,795 INFO     - manual-ack-max-workers-check | 3296f988-7 - Received
2026-08-28 17:07:15,809 INFO     - manual-ack-max-workers-check | f472f5d9-4 - Processed
2026-08-28 17:07:15,810 INFO     - manual-ack-max-workers-check | c04826f6-0 - Received
2026-08-28 17:07:15,835 INFO     - manual-ack-max-workers-check | f266abb2-4 - Processed
2026-08-28 17:07:15,836 INFO     - manual-ack-max-workers-check | 7c5e5513-1 - Received
2026-08-28 17:07:15,849 INFO     - manual-ack-max-workers-check | 7c5e5513-1 - Processed
2026-08-28 17:07:15,849 INFO     - manual-ack-max-workers-check | cdb59f38-c - Received
2026-08-28 17:07:15,850 INFO     - manual-ack-max-workers-check | a3a67af3-6 - Processed
2026-08-28 17:07:15,851 INFO     - manual-ack-max-workers-check | 7c3e2571-b - Received
2026-08-28 17:07:15,872 INFO     - manual-ack-max-workers-check | cdb59f38-c - Processed
2026-08-28 17:07:15,873 INFO     - manual-ack-max-workers-check | fe153f29-3 - Received
2026-08-28 17:07:15,883 INFO     - manual-ack-max-workers-check | 7c3e2571-b - Processed
2026-08-28 17:07:15,883 INFO     - manual-ack-max-workers-check | e3c9f39a-0 - Received
2026-08-28 17:07:15,887 INFO     - manual-ack-max-workers-check | 3296f988-7 - Processed
2026-08-28 17:07:15,887 INFO     - manual-ack-max-workers-check | 304424cf-7 - Received
2026-08-28 17:07:15,911 INFO     - manual-ack-max-workers-check | c04826f6-0 - Processed
2026-08-28 17:07:15,912 INFO     - manual-ack-max-workers-check | d7bf4a69-d - Received
2026-08-28 17:07:15,914 INFO     - manual-ack-max-workers-check | fe153f29-3 - Processed
2026-08-28 17:07:15,914 INFO     - manual-ack-max-workers-check | dc01cac7-4 - Received
2026-08-28 17:07:15,936 INFO     - manual-ack-max-workers-check | e3c9f39a-0 - Processed
2026-08-28 17:07:15,936 INFO     - manual-ack-max-workers-check | d8828200-3 - Received
2026-08-28 17:07:15,949 INFO     - manual-ack-max-workers-check | 304424cf-7 - Processed
2026-08-28 17:07:15,949 INFO     - manual-ack-max-workers-check | 4ba2dc84-c - Received
2026-08-28 17:07:15,985 INFO     - manual-ack-max-workers-check | d7bf4a69-d - Processed
2026-08-28 17:07:15,997 INFO     - manual-ack-max-workers-check | dc01cac7-4 - Processed
2026-08-28 17:07:16,029 INFO     - manual-ack-max-workers-check | d8828200-3 - Processed
2026-08-28 17:07:16,051 INFO     - manual-ack-max-workers-check | 4ba2dc84-c - Processed
2026-08-28 17:07:16,554 INFO     -                              |            - callback for Task-2 is being executed...
2026-08-28 17:07:16,554 INFO     -                              |            - callback for Task-3 is being executed...
redis server         : 8.10.1
subscriber           : ack_policy=MANUAL, max_workers=4
messages published   : 200
messages processed   : 200
lost entries         : 0
processed twice      : 0
max concurrent tasks : 4
PEL mid-run          : 12 pending
PEL after drain      : 0 pending
drain wall time      : 2.56s
ALL CHECKS PASSED
```

</details>
