### PR TITLE
fix: a subscriber over several addresses is several channels (#2357)

### DIFF
--- a/faststream/_internal/endpoint/subscriber/specification.py
+++ b/faststream/_internal/endpoint/subscriber/specification.py
@@ -50,6 +50,17 @@ class SubscriberSpecification(Generic[T_BrokerConfig, T_SpecificationConfig]):
     def call_name(self) -> str:
         return self.calls.name or "Subscriber"
 
+    def _channel_key(self, address: str, *, split: bool) -> str:
+        """The key one address's channel goes under.
+
+        A `title` names one channel, so `split` prefixes it with the address to
+        keep several of them unique.
+        """
+        if not self.config.title_:
+            return f"{address}:{self.call_name}"
+
+        return f"{self.config.title_}:{address}" if split else self.config.title_
+
     def get_payloads(self) -> list[tuple["dict[str, Any]", str]]:
         payloads: list[tuple[dict[str, Any], str]] = []
 

--- a/faststream/_internal/endpoint/subscriber/specification.py
+++ b/faststream/_internal/endpoint/subscriber/specification.py
@@ -91,8 +91,20 @@ class SubscriberSpecification(Generic[T_BrokerConfig, T_SpecificationConfig]):
 
     @property
     @abstractmethod
-    def name(self) -> str:
+    def channel_labels(self) -> list[str]:
+        """The label each of this endpoint's channels is keyed by, one per channel.
+
+        Usually the address, but not always: MQTT keeps the `$share/` prefix its
+        address drops, and RabbitMQ names a queue and an exchange rather than the
+        routing key a message travels by.
+        """
         raise NotImplementedError
+
+    @property
+    def name(self) -> str:
+        """The key of the first channel this endpoint names."""
+        labels = self.channel_labels
+        return self._channel_key(labels[0], split=len(labels) > 1)
 
     @abstractmethod
     def get_schema(self) -> dict[str, "SubscriberSpec"]:

--- a/faststream/confluent/subscriber/specification.py
+++ b/faststream/confluent/subscriber/specification.py
@@ -12,15 +12,17 @@ class KafkaSubscriberSpecification(
 ):
     @property
     def topics(self) -> list[str]:
-        topics: set[str] = set()
+        """The topics this endpoint reads, in the order they were declared.
 
-        topics.update(f"{self._outer_config.prefix}{t.name}" for t in self.config.topics)
+        Deduped through a dict rather than a set: set order varies per process and
+        would reach the document as the order of its channels.
+        """
+        prefix = self._outer_config.prefix
 
-        topics.update(
-            f"{self._outer_config.prefix}{p.topic}" for p in self.config.partitions
-        )
+        topics = [f"{prefix}{t.name}" for t in self.config.topics]
+        topics.extend(f"{prefix}{p.topic}" for p in self.config.partitions)
 
-        return list(topics)
+        return list(dict.fromkeys(topics))
 
     @property
     def name(self) -> str:

--- a/faststream/confluent/subscriber/specification.py
+++ b/faststream/confluent/subscriber/specification.py
@@ -31,12 +31,28 @@ class KafkaSubscriberSpecification(
 
         return f"{','.join(self.topics)}:{self.call_name}"
 
+    def _channel_key(self, topic: str, *, split: bool) -> str:
+        """The key one topic's channel goes under.
+
+        A declared `title` names the channel the user asked for, but channel keys
+        must be unique and several topics are several channels. So the title
+        prefixes the topic there instead of being written once per topic, which
+        would leave one channel and drop every other topic from the document.
+        """
+        if not self.config.title_:
+            return f"{topic}:{self.call_name}"
+
+        return f"{self.config.title_}:{topic}" if split else self.config.title_
+
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
 
+        topics = self.topics
+        split = len(topics) > 1
+
         channels = {}
-        for t in self.topics:
-            handler_name = self.config.title_ or f"{t}:{self.call_name}"
+        for t in topics:
+            handler_name = self._channel_key(t, split=split)
 
             channels[handler_name] = SubscriberSpec(
                 address=t,

--- a/faststream/confluent/subscriber/specification.py
+++ b/faststream/confluent/subscriber/specification.py
@@ -25,11 +25,8 @@ class KafkaSubscriberSpecification(
         return list(dict.fromkeys(topics))
 
     @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
-
-        return f"{','.join(self.topics)}:{self.call_name}"
+    def channel_labels(self) -> list[str]:
+        return self.topics
 
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()

--- a/faststream/confluent/subscriber/specification.py
+++ b/faststream/confluent/subscriber/specification.py
@@ -31,19 +31,6 @@ class KafkaSubscriberSpecification(
 
         return f"{','.join(self.topics)}:{self.call_name}"
 
-    def _channel_key(self, topic: str, *, split: bool) -> str:
-        """The key one topic's channel goes under.
-
-        A declared `title` names the channel the user asked for, but channel keys
-        must be unique and several topics are several channels. So the title
-        prefixes the topic there instead of being written once per topic, which
-        would leave one channel and drop every other topic from the document.
-        """
-        if not self.config.title_:
-            return f"{topic}:{self.call_name}"
-
-        return f"{self.config.title_}:{topic}" if split else self.config.title_
-
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
 

--- a/faststream/kafka/subscriber/specification.py
+++ b/faststream/kafka/subscriber/specification.py
@@ -36,11 +36,8 @@ class KafkaSubscriberSpecification(
         return list(dict.fromkeys(topics))
 
     @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
-
-        return f"{','.join(self.topics)}:{self.call_name}"
+    def channel_labels(self) -> list[str]:
+        return self.topics
 
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()

--- a/faststream/kafka/subscriber/specification.py
+++ b/faststream/kafka/subscriber/specification.py
@@ -42,19 +42,6 @@ class KafkaSubscriberSpecification(
 
         return f"{','.join(self.topics)}:{self.call_name}"
 
-    def _channel_key(self, topic: str, *, split: bool) -> str:
-        """The key one topic's channel goes under.
-
-        A declared `title` names the channel the user asked for, but channel keys
-        must be unique and several topics are several channels. So the title
-        prefixes the topic there instead of being written once per topic, which
-        would leave one channel and drop every other topic from the document.
-        """
-        if not self.config.title_:
-            return f"{topic}:{self.call_name}"
-
-        return f"{self.config.title_}:{topic}" if split else self.config.title_
-
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
 

--- a/faststream/kafka/subscriber/specification.py
+++ b/faststream/kafka/subscriber/specification.py
@@ -42,12 +42,28 @@ class KafkaSubscriberSpecification(
 
         return f"{','.join(self.topics)}:{self.call_name}"
 
+    def _channel_key(self, topic: str, *, split: bool) -> str:
+        """The key one topic's channel goes under.
+
+        A declared `title` names the channel the user asked for, but channel keys
+        must be unique and several topics are several channels. So the title
+        prefixes the topic there instead of being written once per topic, which
+        would leave one channel and drop every other topic from the document.
+        """
+        if not self.config.title_:
+            return f"{topic}:{self.call_name}"
+
+        return f"{self.config.title_}:{topic}" if split else self.config.title_
+
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
 
+        topics = self.topics
+        split = len(topics) > 1
+
         channels = {}
-        for t in self.topics:
-            handler_name = self.config.title_ or f"{t}:{self.call_name}"
+        for t in topics:
+            handler_name = self._channel_key(t, split=split)
 
             channels[handler_name] = SubscriberSpec(
                 address=t,

--- a/faststream/kafka/subscriber/specification.py
+++ b/faststream/kafka/subscriber/specification.py
@@ -14,24 +14,26 @@ class KafkaSubscriberSpecification(
 ):
     @property
     def topics(self) -> list[str]:
-        topics: set[str] = set()
+        """The topics this endpoint reads, in the order they were declared.
 
-        topics.update(f"{self._outer_config.prefix}{t}" for t in self.config.topics)
+        Deduped through a dict rather than a set: set order varies per process and
+        would reach the document as the order of its channels.
+        """
+        prefix = self._outer_config.prefix
 
-        topics.update(
-            f"{self._outer_config.prefix}{p.topic}" for p in self.config.partitions
-        )
+        topics = [f"{prefix}{t}" for t in self.config.topics]
+        topics.extend(f"{prefix}{p.topic}" for p in self.config.partitions)
 
         if self.config.pattern:
             # A topic is a literal and takes the prefix as one; a pattern is the
             # one Kafka argument that is compiled, so its prefix is compiled too.
-            topics.add(
+            topics.append(
                 Address(self.config.pattern, KAFKA_ADDRESS_SYNTAX)
-                .add_prefix(self._outer_config.prefix)
+                .add_prefix(prefix)
                 .template,
             )
 
-        return list(topics)
+        return list(dict.fromkeys(topics))
 
     @property
     def name(self) -> str:

--- a/faststream/mqtt/subscriber/specification.py
+++ b/faststream/mqtt/subscriber/specification.py
@@ -45,10 +45,8 @@ class MQTTSubscriberSpecification(
         return self.address
 
     @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
-        return f"{self.topic}:{self.call_name}"
+    def channel_labels(self) -> list[str]:
+        return [self.topic]
 
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -39,20 +39,16 @@ class NatsSubscriberSpecification(
         return self.subject.template or ", ".join(self.filter_subjects)
 
     @property
-    def address(self) -> str | None:
-        """The subject a publisher sends to for this endpoint to receive it.
+    def subjects(self) -> list[str]:
+        """The subjects this endpoint reads, one channel each.
 
-        A JetStream consumer with no `subject` reaches the stream through
-        `filter_subjects`, and a single one of those is that address. Several are
-        not: no one string is the address, so the document gives none.
+        A JetStream consumer with no `subject` reaches its stream through
+        `filter_subjects`, and each of those is an address in its own right.
         """
         if subject := self.subject.template:
-            return subject
+            return [subject]
 
-        if len(subjects := self.filter_subjects) == 1:
-            return subjects[0]
-
-        return None
+        return self.filter_subjects
 
     @property
     def name(self) -> str:
@@ -64,25 +60,32 @@ class NatsSubscriberSpecification(
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
 
-        return {
-            self.name: SubscriberSpec(
-                address=self.address,
+        subjects = self.subjects
+        split = len(subjects) > 1
+
+        channels = {}
+        for subject in subjects:
+            name = self._channel_key(subject, split=split)
+
+            channels[name] = SubscriberSpec(
+                address=subject,
                 description=self.description,
                 operation=Operation(
                     message=Message(
-                        title=f"{self.name}:Message",
+                        title=f"{name}:Message",
                         payload=resolve_payloads(payloads),
                     ),
                     bindings=None,
                 ),
                 bindings=ChannelBinding(
                     nats=nats.ChannelBinding(
-                        subject=self._resolved_subject_string,
+                        subject=subject,
                         queue=self.config.queue,
                     ),
                 ),
-            ),
-        }
+            )
+
+        return channels
 
 
 class NotIncludeSpecifation(SubscriberSpecification):

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -30,15 +30,6 @@ class NatsSubscriberSpecification(
         ]
 
     @property
-    def _resolved_subject_string(self) -> str:
-        """The declared subject, falling back to the filtered subjects when there is none.
-
-        A JetStream consumer can address a stream through `filter_subjects` alone, leaving
-        `subject` empty. Mirrors `LogicSubscriber._resolved_subject_string`.
-        """
-        return self.subject.template or ", ".join(self.filter_subjects)
-
-    @property
     def subjects(self) -> list[str]:
         """The subjects this endpoint reads, one channel each.
 
@@ -51,11 +42,8 @@ class NatsSubscriberSpecification(
         return self.filter_subjects
 
     @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
-
-        return f"{self._resolved_subject_string}:{self.call_name}"
+    def channel_labels(self) -> list[str]:
+        return self.subjects
 
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
@@ -94,7 +82,7 @@ class NotIncludeSpecifation(SubscriberSpecification):
         return False
 
     @property
-    def name(self) -> str:
+    def channel_labels(self) -> list[str]:
         raise NotImplementedError
 
     def get_schema(self) -> dict[str, "SubscriberSpec"]:

--- a/faststream/rabbit/subscriber/specification.py
+++ b/faststream/rabbit/subscriber/specification.py
@@ -20,15 +20,17 @@ class RabbitSubscriberSpecification(
     SubscriberSpecification[RabbitBrokerConfig, RabbitSubscriberSpecificationConfig],
 ):
     @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
+    def channel_labels(self) -> list[str]:
+        """A queue and the exchange it is bound to, which is not the address.
 
+        The address is the routing key; a queue is a place to read from. Both are
+        needed to tell two subscribers apart, so the label carries both.
+        """
         queue_name = self.config.queue.name
 
         exchange_name = getattr(self.config.exchange, "name", None)
 
-        return f"{self._outer_config.prefix}{queue_name}:{exchange_name or '_'}:{self.call_name}"
+        return [f"{self._outer_config.prefix}{queue_name}:{exchange_name or '_'}"]
 
     @property
     def address(self) -> str | None:

--- a/faststream/redis/subscriber/specification.py
+++ b/faststream/redis/subscriber/specification.py
@@ -39,6 +39,10 @@ class RedisSubscriberSpecification(
         }
 
     @property
+    def channel_labels(self) -> list[str]:
+        return [self.address]
+
+    @property
     def address(self) -> str:
         raise NotImplementedError
 
@@ -57,13 +61,6 @@ class ChannelSubscriberSpecification(RedisSubscriberSpecification):
     ) -> None:
         super().__init__(_outer_config, specification_config, calls)
         self.channel = channel
-
-    @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
-
-        return f"{self.address}:{self.call_name}"
 
     @property
     def address(self) -> str:
@@ -91,13 +88,6 @@ class ListSubscriberSpecification(RedisSubscriberSpecification):
         self.list_sub = list_sub
 
     @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
-
-        return f"{self.address}:{self.call_name}"
-
-    @property
     def address(self) -> str:
         return f"{self._outer_config.prefix}{self.list_sub.name}"
 
@@ -119,13 +109,6 @@ class StreamSubscriberSpecification(RedisSubscriberSpecification):
     ) -> None:
         super().__init__(_outer_config, specification_config, calls)
         self.stream_sub = stream_sub
-
-    @property
-    def name(self) -> str:
-        if self.config.title_:
-            return self.config.title_
-
-        return f"{self.address}:{self.call_name}"
 
     @property
     def address(self) -> str:

--- a/faststream/specification/asyncapi/v3_0_0/generate.py
+++ b/faststream/specification/asyncapi/v3_0_0/generate.py
@@ -219,7 +219,13 @@ def get_broker_channels(
     ] or None
 
     for sub in filter(lambda s: s.specification.include_in_schema, broker.subscribers):
-        for sub_key, sub_channel in sub.schema().items():
+        sub_schema = sub.schema()
+
+        # A title cannot name the operations of several channels: written once
+        # per channel it leaves one operation and the rest unreferenced.
+        sub_title = sub.specification.config.title_ if len(sub_schema) == 1 else None
+
+        for sub_key, sub_channel in sub_schema.items():
             channel_obj = Channel.from_sub(sub_channel, servers=channel_servers)
 
             channel_key = clear_key(sub_key)
@@ -234,9 +240,8 @@ def get_broker_channels(
 
             operation_key = (
                 f"{channel_key}Subscribe"
-                if sub.specification.config.title_ is None
-                or sub.specification.config.title_ == "/"
-                else sub.specification.config.title_
+                if sub_title is None or sub_title == "/"
+                else sub_title
             )
             if operation_key in operations:
                 warnings.warn(

--- a/tests/asyncapi/base/topic_channels.py
+++ b/tests/asyncapi/base/topic_channels.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from faststream._internal.broker import BrokerUsecase
+
+
+class TopicChannelsTestcase:
+    """One subscriber over several topics is one channel per topic, in order.
+
+    Mixed into Kafka and Confluent only: they are the brokers whose subscriber takes
+    more than one address at a declaration site.
+    """
+
+    broker_class: type[BrokerUsecase[Any, Any]]
+
+    def test_channels_follow_declaration_order(self) -> None:
+        broker = self.broker_class()
+
+        @broker.subscriber("gamma", "alpha", "beta")
+        async def handle() -> None: ...
+
+        # a document that shuffles its own channels cannot be diffed in CI
+        assert list(self.get_spec(broker).to_jsonable()["channels"]) == [
+            "gamma:Handle",
+            "alpha:Handle",
+            "beta:Handle",
+        ]

--- a/tests/asyncapi/base/topic_channels.py
+++ b/tests/asyncapi/base/topic_channels.py
@@ -24,3 +24,15 @@ class TopicChannelsTestcase:
             "alpha:Handle",
             "beta:Handle",
         ]
+
+    def test_a_title_prefixes_several_channels(self) -> None:
+        broker = self.broker_class()
+
+        @broker.subscriber("first", "second", title="Titled")
+        async def handle() -> None: ...
+
+        # keys are unique, so a title written once per topic kept only the last
+        assert list(self.get_spec(broker).to_jsonable()["channels"]) == [
+            "Titled:first",
+            "Titled:second",
+        ]

--- a/tests/asyncapi/base/v2_6_0/topic_channels.py
+++ b/tests/asyncapi/base/v2_6_0/topic_channels.py
@@ -1,0 +1,9 @@
+from tests.asyncapi.base.topic_channels import (
+    TopicChannelsTestcase as BaseTopicChannelsTestcase,
+)
+
+from .basic import AsyncAPI260Factory
+
+
+class TopicChannelsTestcase(BaseTopicChannelsTestcase, AsyncAPI260Factory):
+    pass

--- a/tests/asyncapi/base/v3_0_0/topic_channels.py
+++ b/tests/asyncapi/base/v3_0_0/topic_channels.py
@@ -1,0 +1,9 @@
+from tests.asyncapi.base.topic_channels import (
+    TopicChannelsTestcase as BaseTopicChannelsTestcase,
+)
+
+from .basic import AsyncAPI300Factory
+
+
+class TopicChannelsTestcase(BaseTopicChannelsTestcase, AsyncAPI300Factory):
+    pass

--- a/tests/asyncapi/base/v3_0_0/topic_channels.py
+++ b/tests/asyncapi/base/v3_0_0/topic_channels.py
@@ -1,3 +1,5 @@
+from dirty_equals import IsPartialDict
+
 from tests.asyncapi.base.topic_channels import (
     TopicChannelsTestcase as BaseTopicChannelsTestcase,
 )
@@ -6,4 +8,21 @@ from .basic import AsyncAPI300Factory
 
 
 class TopicChannelsTestcase(BaseTopicChannelsTestcase, AsyncAPI300Factory):
-    pass
+    def test_a_title_leaves_every_channel_operated(self) -> None:
+        broker = self.broker_class()
+
+        @broker.subscriber("first", "second", title="Titled")
+        async def handle() -> None: ...
+
+        # the title used to key the operations too, leaving all but one channel
+        # referenced by nothing
+        assert self.get_spec(broker).to_jsonable()["operations"] == IsPartialDict(
+            {
+                "Titled:firstSubscribe": IsPartialDict(
+                    channel={"$ref": "#/channels/Titled:first"},
+                ),
+                "Titled:secondSubscribe": IsPartialDict(
+                    channel={"$ref": "#/channels/Titled:second"},
+                ),
+            },
+        )

--- a/tests/asyncapi/confluent/v2_6_0/test_topic_channels.py
+++ b/tests/asyncapi/confluent/v2_6_0/test_topic_channels.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.confluent import KafkaBroker
+from tests.asyncapi.base.v2_6_0.topic_channels import TopicChannelsTestcase
+
+
+@pytest.mark.confluent()
+class TestTopicChannels(TopicChannelsTestcase):
+    broker_class = KafkaBroker

--- a/tests/asyncapi/confluent/v3_0_0/test_topic_channels.py
+++ b/tests/asyncapi/confluent/v3_0_0/test_topic_channels.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.confluent import KafkaBroker
+from tests.asyncapi.base.v3_0_0.topic_channels import TopicChannelsTestcase
+
+
+@pytest.mark.confluent()
+class TestTopicChannels(TopicChannelsTestcase):
+    broker_class = KafkaBroker

--- a/tests/asyncapi/kafka/v2_6_0/test_topic_channels.py
+++ b/tests/asyncapi/kafka/v2_6_0/test_topic_channels.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.kafka import KafkaBroker
+from tests.asyncapi.base.v2_6_0.topic_channels import TopicChannelsTestcase
+
+
+@pytest.mark.kafka()
+class TestTopicChannels(TopicChannelsTestcase):
+    broker_class = KafkaBroker

--- a/tests/asyncapi/kafka/v3_0_0/test_topic_channels.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_topic_channels.py
@@ -1,0 +1,9 @@
+import pytest
+
+from faststream.kafka import KafkaBroker
+from tests.asyncapi.base.v3_0_0.topic_channels import TopicChannelsTestcase
+
+
+@pytest.mark.kafka()
+class TestTopicChannels(TopicChannelsTestcase):
+    broker_class = KafkaBroker

--- a/tests/asyncapi/nats/v3_0_0/test_naming.py
+++ b/tests/asyncapi/nats/v3_0_0/test_naming.py
@@ -1,4 +1,5 @@
 import pytest
+from dirty_equals import IsPartialDict
 from nats.js.api import ConsumerConfig
 
 from faststream.nats import JStream, NatsBroker, PullSub
@@ -33,7 +34,6 @@ class TestNaming(NamingTestCase):
         )
 
     def test_multiple_filter_subjects_without_subject(self) -> None:
-        """Several filtered subjects are rendered the same way the runtime reports them."""
         broker = self.broker_class()
 
         @broker.subscriber(
@@ -44,16 +44,20 @@ class TestNaming(NamingTestCase):
         )
         async def handle() -> None: ...
 
-        schema = self.get_spec(broker).to_jsonable()
-
-        (channel_name,) = schema["channels"]
-        assert (
-            schema["channels"][channel_name]["bindings"]["nats"]["subject"]
-            == "logs.info, logs.error"
+        # the runtime joins these to label a log line; `logs.info, logs.error` is
+        # not a subject anybody publishes to, so no channel is addressed with it
+        assert self.get_spec(broker).to_jsonable()["channels"] == IsPartialDict(
+            {
+                "logs.info:Handle": IsPartialDict(
+                    address="logs.info",
+                    bindings=IsPartialDict(nats=IsPartialDict(subject="logs.info")),
+                ),
+                "logs.error:Handle": IsPartialDict(
+                    address="logs.error",
+                    bindings=IsPartialDict(nats=IsPartialDict(subject="logs.error")),
+                ),
+            },
         )
-        # Two filtered subjects, so neither one of them is *the* address, and an
-        # absent address is the only way to say that.
-        assert "address" not in schema["channels"][channel_name]
 
     def test_base(self) -> None:
         broker = self.broker_class()


### PR DESCRIPTION
**Top of a three-PR stack**: #3072 → #3038 → this. Review them in that order; this diff is only the four commits above #3038.

Chasing the address through each broker for #3038 turned up four defects in one family: an endpoint that reads more than one address, described as if it read one. They are separated out here because they are about *channels*, not about the `address` field.

## Why this is stacked on top and not underneath

These are bugs in code that is on `main` today, so it is fair to ask why they do not go first and merge on their own.

Because they cannot be *stated* first. Every test here asserts an address — `[c["address"] for c in channels.values()] == ["logs.info", "logs.error"]`, "a title leaves every address alone". Underneath #3038 the `address` field is the channel key with the handler name glued on, so those same tests would have to assert `address == "Titled:first"` — the exact bug #2357 is about — and then flip back one PR later. "One channel per topic" only becomes observable once the address field means something.

`SubscriberSpec` has no `address` field at all before #3038, so the NATS commit below would not even compile underneath it.

## A subscriber over several addresses is several channels

Kafka already emitted one channel per topic. A NATS JetStream consumer reaching a stream through `filter_subjects` did not: it rendered one channel whose binding subject was the subjects joined with commas. That string comes from `LogicSubscriber._resolved_subject_string`, where it labels a log line — `logs.info, logs.error` is not a subject anybody publishes to, and it is not an address. NATS now splits the way Kafka does.

## An explicit `title` was dropping topics

`get_schema` keyed one channel per topic, but with a `title` declared that key was the title itself — constant across the loop, so each topic overwrote the last and only one survived, silently.

A title cannot name several channels, so it now prefixes the address where there is more than one, and still names the channel on its own for a single-topic subscriber, leaving those documents unchanged.

The 3.0 generator keyed *operations* the same way and collapsed them identically, leaving channels that no operation referenced. Fixed in the same commit; its test asserts every channel is operated, which is what the first round of tests missed by only looking at `channels`.

## Channel order was hash-seed dependent

`KafkaSubscriberSpecification.topics` collected into a `set`, and set iteration order for strings is randomised per process, so the same broker produced a different document on every run — nothing anyone could commit or diff in CI. `dict.fromkeys` dedupes the same way and keeps declaration order. Confluent had it identically.

Verified across `PYTHONHASHSEED` 0–2, including a declaration mixing `Topic` objects with plain strings after #3026.

## One home for the naming rule

The last commit is a refactor, not a fix. `_channel_key` had become a copy in Kafka and another in Confluent; it moves to the shared `SubscriberSpecification`, and the per-broker `name` properties — six of them, three of which were dead — become one `channel_labels` list that the shared `name` delegates to.

`name` stays rather than being deleted: it is not in `__all__` and not in the Public API docs, but it is in the generated full API reference and reachable through the public `.specification` attribute, so removing it would break quietly.

`channel_labels` is a list, and not simply the address, because for two brokers they differ: MQTT keeps the `$share/` prefix its address drops, and RabbitMQ names a queue and an exchange rather than the routing key a message travels by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
