### PR TITLE
refactor: a config carries the address it was declared with

### DIFF
--- a/faststream/confluent/path.py
+++ b/faststream/confluent/path.py
@@ -1,18 +1,6 @@
 import re
 
-from faststream._internal.utils.path import AddressSyntax
 from faststream.exceptions import SetupError
-
-KAFKA_ADDRESS_SYNTAX = AddressSyntax(
-    replace_symbol=".*",
-    patch_regex=lambda x: x.replace(r"\*", ".*"),
-)
-"""How a Kafka `pattern=` spells a Path parameter.
-
-`pattern=` is the one Kafka argument that is compiled; a topic is a literal
-and never meets the parameter parser.
-"""
-
 
 MAX_TOPIC_NAME_LENGTH = 249
 

--- a/faststream/confluent/publisher/factory.py
+++ b/faststream/confluent/publisher/factory.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Union
 
+from faststream.confluent.path import validate_topic_name
 from faststream.confluent.schemas import Topic
 
 from .config import KafkaPublisherConfig, KafkaPublisherSpecificationConfig
@@ -32,6 +33,7 @@ def create_publisher(
 ) -> BatchPublisher | DefaultPublisher:
     # Publishers never declare topics, so only the name is meaningful here.
     topic_name = Topic.validate(topic).name
+    validate_topic_name(topic_name)
 
     publisher_config = KafkaPublisherConfig(
         key=key,

--- a/faststream/confluent/subscriber/factory.py
+++ b/faststream/confluent/subscriber/factory.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 from faststream._internal.constants import EMPTY
 from faststream._internal.endpoint.subscriber.call_item import CallsCollection
+from faststream.confluent.path import validate_topic_name
 from faststream.confluent.schemas import Topic
 from faststream.exceptions import SetupError
 from faststream.middlewares import AckPolicy
@@ -100,6 +101,12 @@ def _validate_input_for_misconfigure(
     group_id: str | None,
     partitions: Iterable["TopicPartition"],
 ) -> None:
+    for topic in topics:
+        validate_topic_name(topic.name)
+
+    for partition in partitions:
+        validate_topic_name(partition.topic)
+
     effective_ack = AckPolicy.ACK_FIRST if ack_policy is EMPTY else ack_policy
     if effective_ack is AckPolicy.REJECT_ON_ERROR:
         warnings.warn(

--- a/faststream/kafka/path.py
+++ b/faststream/kafka/path.py
@@ -1,0 +1,11 @@
+from faststream._internal.utils.path import AddressSyntax
+
+KAFKA_ADDRESS_SYNTAX = AddressSyntax(
+    replace_symbol=".*",
+    patch_regex=lambda x: x.replace(r"\*", ".*"),
+)
+"""How a Kafka `pattern=` spells a Path parameter.
+
+`pattern=` is the one Kafka argument that is compiled; a topic is a literal
+and never meets the parameter parser.
+"""

--- a/faststream/kafka/publisher/factory.py
+++ b/faststream/kafka/publisher/factory.py
@@ -4,6 +4,8 @@ from typing import (
     Any,
 )
 
+from faststream.kafka.path import validate_topic_name
+
 from .config import KafkaPublisherConfig, KafkaPublisherSpecificationConfig
 from .specification import KafkaPublisherSpecification
 from .usecase import BatchPublisher, DefaultPublisher
@@ -31,6 +33,8 @@ def create_publisher(
     description_: str | None,
     include_in_schema: bool,
 ) -> BatchPublisher | DefaultPublisher:
+    validate_topic_name(topic)
+
     publisher_config = KafkaPublisherConfig(
         key=key,
         topic=topic,

--- a/faststream/kafka/subscriber/config.py
+++ b/faststream/kafka/subscriber/config.py
@@ -7,6 +7,7 @@ from faststream._internal.configs import (
     SubscriberUsecaseConfig,
 )
 from faststream._internal.constants import EMPTY
+from faststream._internal.utils.path import Address
 from faststream.kafka.configs import KafkaBrokerConfig
 from faststream.middlewares import AckPolicy
 
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
 class KafkaSubscriberSpecificationConfig(SubscriberSpecificationConfig):
     topics: Sequence[str] = field(default_factory=list)
     partitions: Iterable["TopicPartition"] = field(default_factory=list)
-    pattern: str | None = None
+    pattern: Address | None = None
 
 
 @dataclass(kw_only=True)
@@ -30,7 +31,7 @@ class KafkaSubscriberConfig(SubscriberUsecaseConfig):
     group_id: str | None = None
     connection_args: dict[str, Any] = field(default_factory=dict)
     listener: Optional["ConsumerRebalanceListener"] = None
-    pattern: str | None = None
+    pattern: Address | None = None
     partitions: Iterable["TopicPartition"] = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/faststream/kafka/subscriber/factory.py
+++ b/faststream/kafka/subscriber/factory.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from faststream._internal.constants import EMPTY
 from faststream._internal.endpoint.subscriber.call_item import CallsCollection
+from faststream._internal.utils.path import Address
 from faststream.exceptions import SetupError
+from faststream.kafka.path import KAFKA_ADDRESS_SYNTAX
 from faststream.middlewares import AckPolicy
 
 from .config import KafkaSubscriberConfig, KafkaSubscriberSpecificationConfig
@@ -57,13 +59,15 @@ def create_subscriber(
         max_workers=max_workers,
     )
 
+    address = Address(pattern, KAFKA_ADDRESS_SYNTAX) if pattern else None
+
     subscriber_config = KafkaSubscriberConfig(
         topics=topics,
         partitions=partitions,
         connection_args=connection_args,
         group_id=group_id,
         listener=listener,
-        pattern=pattern,
+        pattern=address,
         no_reply=no_reply,
         _outer_config=config,
         _ack_policy=ack_policy,
@@ -77,7 +81,7 @@ def create_subscriber(
         specification_config=KafkaSubscriberSpecificationConfig(
             topics=topics,
             partitions=partitions,
-            pattern=pattern,
+            pattern=address,
             title_=title_,
             description_=description_,
             include_in_schema=include_in_schema,

--- a/faststream/kafka/subscriber/factory.py
+++ b/faststream/kafka/subscriber/factory.py
@@ -6,7 +6,7 @@ from faststream._internal.constants import EMPTY
 from faststream._internal.endpoint.subscriber.call_item import CallsCollection
 from faststream._internal.utils.path import Address
 from faststream.exceptions import SetupError
-from faststream.kafka.path import KAFKA_ADDRESS_SYNTAX
+from faststream.kafka.path import KAFKA_ADDRESS_SYNTAX, validate_topic_name
 from faststream.middlewares import AckPolicy
 
 from .config import KafkaSubscriberConfig, KafkaSubscriberSpecificationConfig
@@ -124,6 +124,12 @@ def _validate_input_for_misconfigure(
     pattern: str | None,
     partitions: Iterable["TopicPartition"],
 ) -> None:
+    for topic in topics:
+        validate_topic_name(topic)
+
+    for partition in partitions:
+        validate_topic_name(partition.topic)
+
     effective_ack = AckPolicy.ACK_FIRST if ack_policy is EMPTY else ack_policy
     if effective_ack is AckPolicy.REJECT_ON_ERROR:
         warnings.warn(

--- a/faststream/kafka/subscriber/specification.py
+++ b/faststream/kafka/subscriber/specification.py
@@ -1,7 +1,5 @@
 from faststream._internal.endpoint.subscriber import SubscriberSpecification
-from faststream._internal.utils.path import Address
 from faststream.kafka.configs import KafkaBrokerConfig
-from faststream.kafka.subscriber.usecase import KAFKA_ADDRESS_SYNTAX
 from faststream.specification.asyncapi.utils import resolve_payloads
 from faststream.specification.schema import Message, Operation, SubscriberSpec
 from faststream.specification.schema.bindings import ChannelBinding, kafka
@@ -26,9 +24,7 @@ class KafkaSubscriberSpecification(
             # A topic is a literal and takes the prefix as one; a pattern is the
             # one Kafka argument that is compiled, so its prefix is compiled too.
             topics.add(
-                Address(self.config.pattern, KAFKA_ADDRESS_SYNTAX)
-                .add_prefix(self._outer_config.prefix)
-                .template,
+                self.config.pattern.add_prefix(self._outer_config.prefix).template,
             )
 
         return list(topics)

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -13,7 +13,6 @@ from faststream._internal.endpoint.subscriber.mixins import ConcurrentMixin, Tas
 from faststream._internal.endpoint.subscriber.usecase import SubscriberUsecase
 from faststream._internal.endpoint.utils import process_msg
 from faststream._internal.types import MsgType
-from faststream._internal.utils.path import Address, AddressSyntax
 from faststream.kafka.helpers import make_logging_listener
 from faststream.kafka.message import KafkaAckableMessage, KafkaMessage, KafkaRawMessage
 from faststream.kafka.parser import AioKafkaBatchParser, AioKafkaParser
@@ -25,16 +24,11 @@ if TYPE_CHECKING:
     from faststream._internal.endpoint.publisher import PublisherProto
     from faststream._internal.endpoint.subscriber import SubscriberSpecification
     from faststream._internal.endpoint.subscriber.call_item import CallsCollection
+    from faststream._internal.utils.path import Address
     from faststream.kafka.configs import KafkaBrokerConfig
     from faststream.message import StreamMessage
 
     from .config import KafkaSubscriberConfig
-
-
-KAFKA_ADDRESS_SYNTAX = AddressSyntax(
-    replace_symbol=".*",
-    patch_regex=lambda x: x.replace(r"\*", ".*"),
-)
 
 
 class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
@@ -66,14 +60,12 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
         self.consumer = None
 
     @property
-    def pattern(self) -> Address | None:
+    def pattern(self) -> Optional["Address"]:
         """The pattern this Subscriber was declared with, and its Broker address."""
         if not self._pattern:
             return None
 
-        return Address(self._pattern, KAFKA_ADDRESS_SYNTAX).add_prefix(
-            self._outer_config.prefix,
-        )
+        return self._pattern.add_prefix(self._outer_config.prefix)
 
     @property
     def topics(self) -> list[str]:
@@ -283,15 +275,9 @@ class DefaultSubscriber(LogicSubscriber["ConsumerRecord"]):
         specification: "SubscriberSpecification[Any, Any]",
         calls: "CallsCollection[ConsumerRecord]",
     ) -> None:
-        reg = (
-            Address(config.pattern, KAFKA_ADDRESS_SYNTAX).regex
-            if config.pattern
-            else None
-        )
-
         self.parser = AioKafkaParser(
             msg_class=KafkaMessage if config.ack_first else KafkaAckableMessage,
-            regex=reg,
+            regex=config.pattern.regex if config.pattern else None,
         )
         config.parser = self.parser.parse_message
         config.decoder = self.parser.decode_message
@@ -326,15 +312,9 @@ class BatchSubscriber(LogicSubscriber[tuple["ConsumerRecord", ...]]):
         batch_timeout_ms: int,
         max_records: int | None,
     ) -> None:
-        reg = (
-            Address(config.pattern, KAFKA_ADDRESS_SYNTAX).regex
-            if config.pattern
-            else None
-        )
-
         self.parser = AioKafkaBatchParser(
             msg_class=KafkaMessage if config.ack_first else KafkaAckableMessage,
-            regex=reg,
+            regex=config.pattern.regex if config.pattern else None,
         )
         config.decoder = self.parser.decode_batch
         config.parser = self.parser.parse_batch

--- a/faststream/nats/parser.py
+++ b/faststream/nats/parser.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from faststream._internal.utils.path import match_path
 from faststream.message import (
@@ -11,9 +11,10 @@ from faststream.nats.message import (
     NatsMessage,
     NatsObjMessage,
 )
-from faststream.nats.schemas.js_stream import compile_nats_wildcard
 
 if TYPE_CHECKING:
+    from re import Pattern
+
     from nats.aio.msg import Msg
     from nats.js.api import ObjectInfo
     from nats.js.kv import KeyValue
@@ -27,10 +28,9 @@ class NatsBaseParser:
     def __init__(
         self,
         *,
-        pattern: str,
+        path_regex: Optional["Pattern[str]"],
     ) -> None:
-        path_re, _ = compile_nats_wildcard(pattern)
-        self._path_re = path_re
+        self._path_re = path_regex
 
     async def decode_message(
         self,
@@ -42,8 +42,13 @@ class NatsBaseParser:
 class NatsParser(NatsBaseParser):
     """A class to parse NATS core messages."""
 
-    def __init__(self, *, pattern: str, is_ack_disabled: bool) -> None:
-        super().__init__(pattern=pattern)
+    def __init__(
+        self,
+        *,
+        path_regex: Optional["Pattern[str]"],
+        is_ack_disabled: bool,
+    ) -> None:
+        super().__init__(path_regex=path_regex)
 
         self.is_ack_disabled = is_ack_disabled
 

--- a/faststream/nats/publisher/config.py
+++ b/faststream/nats/publisher/config.py
@@ -5,6 +5,7 @@ from faststream._internal.configs import (
     PublisherSpecificationConfig,
     PublisherUsecaseConfig,
 )
+from faststream._internal.utils.path import Address
 from faststream.nats.configs import NatsBrokerConfig
 
 if TYPE_CHECKING:
@@ -13,14 +14,14 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class NatsPublisherSpecificationConfig(PublisherSpecificationConfig):
-    subject: str
+    subject: Address
 
 
 @dataclass(kw_only=True)
 class NatsPublisherConfig(PublisherUsecaseConfig):
     _outer_config: "NatsBrokerConfig" = field(default_factory=NatsBrokerConfig)
 
-    subject: str
+    subject: Address
     reply_to: str
     headers: dict[str, str] | None
     stream: Optional["JStream"]

--- a/faststream/nats/publisher/factory.py
+++ b/faststream/nats/publisher/factory.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING, Any, Optional
 
+from faststream._internal.utils.path import Address
+from faststream.nats.schemas.js_stream import NATS_ADDRESS_SYNTAX
+
 from .config import NatsPublisherConfig, NatsPublisherSpecificationConfig
 from .specification import NatsPublisherSpecification
 from .usecase import LogicPublisher
@@ -24,8 +27,10 @@ def create_publisher(
     description_: str | None,
     include_in_schema: bool,
 ) -> LogicPublisher:
+    address = Address(subject, NATS_ADDRESS_SYNTAX)
+
     publisher_config = NatsPublisherConfig(
-        subject=subject,
+        subject=address,
         stream=stream,
         reply_to=reply_to,
         headers=headers,
@@ -36,7 +41,7 @@ def create_publisher(
     specification = NatsPublisherSpecification(
         _outer_config=broker_config,
         specification_config=NatsPublisherSpecificationConfig(
-            subject=subject,
+            subject=address,
             schema_=schema_,
             title_=title_,
             description_=description_,

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -69,7 +69,7 @@ class NatsFastProducerImpl(NatsFastProducer):
         self.serializer: SerializerProto | None = None
         self.codec: CodecProto = DefaultCodec()
 
-        default = NatsParser(pattern="", is_ack_disabled=True)
+        default = NatsParser(path_regex=None, is_ack_disabled=True)
         self._parser = ParserComposition(parser, default.parse_message)
         self._decoder = ParserComposition(decoder, default.decode_message)
 
@@ -136,7 +136,7 @@ class NatsJSFastProducer(NatsFastProducer):
         self.serializer: SerializerProto | None = None
         self.codec: CodecProto = DefaultCodec()
 
-        default = NatsParser(pattern="", is_ack_disabled=True)
+        default = NatsParser(path_regex=None, is_ack_disabled=True)
         self._parser = ParserComposition(parser, default.parse_message)
         self._decoder = ParserComposition(decoder, default.decode_message)
 

--- a/faststream/nats/publisher/specification.py
+++ b/faststream/nats/publisher/specification.py
@@ -1,12 +1,15 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.endpoint.publisher import PublisherSpecification
-from faststream._internal.utils.path import Address
 from faststream.nats.configs import NatsBrokerConfig
-from faststream.nats.schemas.js_stream import NATS_ADDRESS_SYNTAX
 from faststream.specification.asyncapi.utils import resolve_payloads
 from faststream.specification.schema import Message, Operation, PublisherSpec
 from faststream.specification.schema.bindings import ChannelBinding, nats
 
 from .config import NatsPublisherSpecificationConfig
+
+if TYPE_CHECKING:
+    from faststream._internal.utils.path import Address
 
 
 class NatsPublisherSpecification(
@@ -15,9 +18,7 @@ class NatsPublisherSpecification(
     @property
     def subject(self) -> "Address":
         """The subject this endpoint was declared with, and its Broker address."""
-        return Address(self.config.subject, NATS_ADDRESS_SYNTAX).add_prefix(
-            self._outer_config.prefix,
-        )
+        return self.config.subject.add_prefix(self._outer_config.prefix)
 
     @property
     def name(self) -> str:

--- a/faststream/nats/publisher/usecase.py
+++ b/faststream/nats/publisher/usecase.py
@@ -4,9 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from typing_extensions import overload, override
 
 from faststream._internal.endpoint.publisher import PublisherUsecase
-from faststream._internal.utils.path import Address
 from faststream.nats.response import NatsPublishCommand
-from faststream.nats.schemas.js_stream import NATS_ADDRESS_SYNTAX
 from faststream.response.publish_type import PublishType
 
 if TYPE_CHECKING:
@@ -14,6 +12,7 @@ if TYPE_CHECKING:
     from faststream._internal.endpoint.publisher import PublisherSpecification
     from faststream._internal.producer import ProducerProto
     from faststream._internal.types import PublisherMiddleware
+    from faststream._internal.utils.path import Address
     from faststream.nats.configs import NatsBrokerConfig
     from faststream.nats.message import NatsMessage
     from faststream.nats.schemas import PubAck
@@ -44,9 +43,7 @@ class LogicPublisher(PublisherUsecase):
     @property
     def subject(self) -> "Address":
         """The subject this Publisher was declared with, and its Broker address."""
-        return Address(self._subject, NATS_ADDRESS_SYNTAX).add_prefix(
-            self._outer_config.prefix,
-        )
+        return self._subject.add_prefix(self._outer_config.prefix)
 
     @overload
     async def publish(

--- a/faststream/nats/subscriber/config.py
+++ b/faststream/nats/subscriber/config.py
@@ -6,6 +6,7 @@ from faststream._internal.configs import (
     SubscriberUsecaseConfig,
 )
 from faststream._internal.constants import EMPTY
+from faststream._internal.utils.path import Address
 from faststream.middlewares import AckPolicy
 from faststream.nats.configs import NatsBrokerConfig
 
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 
 @dataclass(kw_only=True)
 class NatsSubscriberSpecificationConfig(SubscriberSpecificationConfig):
-    subject: str
+    subject: Address
     queue: str | None
     # A JetStream consumer may address a stream through `filter_subjects` instead of `subject`,
     # so the specification layer needs them to render a meaningful address.
@@ -26,7 +27,7 @@ class NatsSubscriberSpecificationConfig(SubscriberSpecificationConfig):
 class NatsSubscriberConfig(SubscriberUsecaseConfig):
     _outer_config: "NatsBrokerConfig" = field(default_factory=NatsBrokerConfig)
 
-    subject: str
+    subject: Address
     sub_config: "ConsumerConfig"
     extra_options: dict[str, Any] | None = field(default_factory=dict)
 

--- a/faststream/nats/subscriber/factory.py
+++ b/faststream/nats/subscriber/factory.py
@@ -14,8 +14,10 @@ from nats.js.client import (
 from faststream._internal.constants import EMPTY
 from faststream._internal.endpoint.subscriber import SubscriberSpecification
 from faststream._internal.endpoint.subscriber.call_item import CallsCollection
+from faststream._internal.utils.path import Address
 from faststream.exceptions import SetupError
 from faststream.middlewares import AckPolicy
+from faststream.nats.schemas.js_stream import NATS_ADDRESS_SYNTAX
 
 from .config import NatsSubscriberConfig, NatsSubscriberSpecificationConfig
 from .specification import NatsSubscriberSpecification, NotIncludeSpecifation
@@ -150,8 +152,10 @@ def create_subscriber(
             "max_msgs": max_msgs,
         }
 
+    address = Address(subject, NATS_ADDRESS_SYNTAX)
+
     subscriber_config = NatsSubscriberConfig(
-        subject=subject,
+        subject=address,
         sub_config=config,
         extra_options=extra_options,
         no_reply=no_reply,
@@ -162,7 +166,7 @@ def create_subscriber(
     calls = CallsCollection[Any]()
 
     specification_config = NatsSubscriberSpecificationConfig(
-        subject=subject,
+        subject=address,
         queue=queue or None,
         filter_subjects=list(config.filter_subjects or ()),
         title_=title_,

--- a/faststream/nats/subscriber/specification.py
+++ b/faststream/nats/subscriber/specification.py
@@ -15,9 +15,7 @@ class NatsSubscriberSpecification(
     @property
     def subject(self) -> "Address":
         """The subject this endpoint was declared with, and its Broker address."""
-        return Address(self.config.subject, NATS_ADDRESS_SYNTAX).add_prefix(
-            self._outer_config.prefix,
-        )
+        return self.config.subject.add_prefix(self._outer_config.prefix)
 
     @property
     def filter_subjects(self) -> list[str]:

--- a/faststream/nats/subscriber/usecases/basic.py
+++ b/faststream/nats/subscriber/usecases/basic.py
@@ -8,9 +8,7 @@ from typing import (
 
 from faststream._internal.endpoint.subscriber.usecase import SubscriberUsecase
 from faststream._internal.types import MsgType
-from faststream._internal.utils.path import Address
 from faststream.nats.publisher.fake import NatsFakePublisher
-from faststream.nats.schemas.js_stream import NATS_ADDRESS_SYNTAX
 from faststream.nats.subscriber.adapters import (
     Unsubscriptable,
 )
@@ -22,6 +20,7 @@ if TYPE_CHECKING:
     from faststream._internal.endpoint.publisher import PublisherProto
     from faststream._internal.endpoint.subscriber import SubscriberSpecification
     from faststream._internal.endpoint.subscriber.call_item import CallsCollection
+    from faststream._internal.utils.path import Address
     from faststream.message import StreamMessage
     from faststream.nats.configs import NatsBrokerConfig
     from faststream.nats.subscriber.config import NatsSubscriberConfig
@@ -53,9 +52,7 @@ class LogicSubscriber(SubscriberUsecase[MsgType]):
     @property
     def subject(self) -> "Address":
         """The subject this Subscriber was declared with, and its Broker address."""
-        return Address(self._subject, NATS_ADDRESS_SYNTAX).add_prefix(
-            self._outer_config.prefix,
-        )
+        return self._subject.add_prefix(self._outer_config.prefix)
 
     @property
     def filter_subjects(self) -> list[str]:

--- a/faststream/nats/subscriber/usecases/core_subscriber.py
+++ b/faststream/nats/subscriber/usecases/core_subscriber.py
@@ -34,7 +34,7 @@ class CoreSubscriber(DefaultSubscriber["Msg"]):
         queue: str,
     ) -> None:
         parser = NatsParser(
-            pattern=config.subject,
+            path_regex=config.subject.regex,
             is_ack_disabled=True,  # core subscriber has no ack policy
         )
         config.parser = parser.parse_message

--- a/faststream/nats/subscriber/usecases/key_value_subscriber.py
+++ b/faststream/nats/subscriber/usecases/key_value_subscriber.py
@@ -40,7 +40,7 @@ class KeyValueWatchSubscriber(
         *,
         kv_watch: "KvWatch",
     ) -> None:
-        parser = KvParser(pattern=config.subject)
+        parser = KvParser(path_regex=config.subject.regex)
         config.decoder = parser.decode_message
         config.parser = parser.parse_message
         super().__init__(config, specification, calls)

--- a/faststream/nats/subscriber/usecases/object_storage_subscriber.py
+++ b/faststream/nats/subscriber/usecases/object_storage_subscriber.py
@@ -48,7 +48,7 @@ class ObjStoreWatchSubscriber(
         *,
         obj_watch: "ObjWatch",
     ) -> None:
-        parser = ObjParser(pattern="")
+        parser = ObjParser(path_regex=None)
         config.parser = parser.parse_message
         config.decoder = parser.decode_message
         super().__init__(config, specification, calls)

--- a/faststream/nats/subscriber/usecases/stream_basic.py
+++ b/faststream/nats/subscriber/usecases/stream_basic.py
@@ -33,7 +33,7 @@ class StreamSubscriber(DefaultSubscriber["Msg"]):
         stream: "JStream",
         queue: str,
     ) -> None:
-        parser = JsParser(pattern=config.subject)
+        parser = JsParser(path_regex=config.subject.regex)
         config.decoder = parser.decode_message
         config.parser = parser.parse_message
         super().__init__(config, specification, calls)

--- a/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
+++ b/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
@@ -124,7 +124,7 @@ class BatchPullStreamSubscriber(
         stream: "JStream",
         pull_sub: "PullSub",
     ) -> None:
-        parser = BatchParser(pattern=config.subject)
+        parser = BatchParser(path_regex=config.subject.regex)
         config.decoder = parser.decode_batch
         config.parser = parser.parse_batch
         super().__init__(config, specification, calls)

--- a/faststream/nats/testing.py
+++ b/faststream/nats/testing.py
@@ -141,7 +141,7 @@ class FakeProducer(NatsFastProducer):
         self.broker = broker
         self.brokers = brokers
 
-        default = NatsParser(pattern="", is_ack_disabled=True)
+        default = NatsParser(path_regex=None, is_ack_disabled=True)
         self._parser = ParserComposition(broker._parser, default.parse_message)
         self._decoder = ParserComposition(broker._decoder, default.decode_message)
         self.codec = broker.config.broker_codec or DefaultCodec()

--- a/tests/asyncapi/base/v2_6_0/naming.py
+++ b/tests/asyncapi/base/v2_6_0/naming.py
@@ -270,10 +270,18 @@ class SubscriberNaming(BaseNaming):
             "title": "custom:Message:Payload",
         }
 
+    def uri_unsafe_subscriber(self, broker: Any) -> Any:
+        """Declare on an address whose channel key needs percent-encoding.
+
+        Kafka reaches one only through `pattern=`: a topic name admits ASCII
+        alphanumerics, '.', '_' and '-', all of which are URI-safe already.
+        """
+        return broker.subscriber("/test/topic/{user_id}")
+
     def test_path_channel_refs_are_uri_encoded(self) -> None:
         broker = self.broker_class()
 
-        @broker.subscriber("/test/topic/{user_id}")
+        @self.uri_unsafe_subscriber(broker)
         async def sub(name: str, age: int) -> None: ...
 
         schema = self.get_spec(broker).to_jsonable()

--- a/tests/asyncapi/base/v3_0_0/naming.py
+++ b/tests/asyncapi/base/v3_0_0/naming.py
@@ -274,10 +274,18 @@ class SubscriberNaming(BaseNaming):
             "title": "custom:Message:Payload",
         }
 
+    def uri_unsafe_subscriber(self, broker: Any) -> Any:
+        """Declare on an address whose channel key needs percent-encoding.
+
+        Kafka reaches one only through `pattern=`: a topic name admits ASCII
+        alphanumerics, '.', '_' and '-', all of which are URI-safe already.
+        """
+        return broker.subscriber("/test/topic/{user_id}")
+
     def test_path_channel_refs_are_uri_encoded(self) -> None:
         broker = self.broker_class()
 
-        @broker.subscriber("/test/topic/{user_id}")
+        @self.uri_unsafe_subscriber(broker)
         async def sub(name: str, age: int) -> None: ...
 
         schema = self.get_spec(broker).to_jsonable()

--- a/tests/asyncapi/confluent/v2_6_0/test_naming.py
+++ b/tests/asyncapi/confluent/v2_6_0/test_naming.py
@@ -1,4 +1,5 @@
 import pytest
+from typing_extensions import override
 
 from faststream.confluent import KafkaBroker
 from tests.asyncapi.base.v2_6_0.naming import NamingTestCase
@@ -7,6 +8,12 @@ from tests.asyncapi.base.v2_6_0.naming import NamingTestCase
 @pytest.mark.confluent()
 class TestNaming(NamingTestCase):
     broker_class = KafkaBroker
+
+    # Confluent has no `pattern=`, so every address it can carry is a topic
+    # name, and every legal topic name is URI-safe already.
+    @pytest.mark.skip(reason="every legal Confluent address is URI-safe")
+    @override
+    def test_path_channel_refs_are_uri_encoded(self) -> None: ...
 
     def test_base(self) -> None:
         broker = self.broker_class()

--- a/tests/asyncapi/confluent/v3_0_0/test_naming.py
+++ b/tests/asyncapi/confluent/v3_0_0/test_naming.py
@@ -1,4 +1,5 @@
 import pytest
+from typing_extensions import override
 
 from faststream.confluent import KafkaBroker
 from tests.asyncapi.base.v3_0_0.naming import NamingTestCase
@@ -7,6 +8,12 @@ from tests.asyncapi.base.v3_0_0.naming import NamingTestCase
 @pytest.mark.confluent()
 class TestNaming(NamingTestCase):
     broker_class = KafkaBroker
+
+    # Confluent has no `pattern=`, so every address it can carry is a topic
+    # name, and every legal topic name is URI-safe already.
+    @pytest.mark.skip(reason="every legal Confluent address is URI-safe")
+    @override
+    def test_path_channel_refs_are_uri_encoded(self) -> None: ...
 
     def test_base(self) -> None:
         broker = self.broker_class()

--- a/tests/asyncapi/kafka/v2_6_0/test_address.py
+++ b/tests/asyncapi/kafka/v2_6_0/test_address.py
@@ -11,18 +11,19 @@ def test_every_address_is_named_as_declared() -> None:
     @broker.subscriber(pattern="logs.{level}")
     async def handle_logs(body: str) -> None: ...
 
-    broker.publisher("cache{{shard}}")
+    broker.publisher("cache")
 
     schema = get_2_6_0_schema(broker)
 
-    # A Kafka topic is never compiled, so `{{` is not syntax there and nothing
-    # takes it off. Only `pattern=` meets the parameter parser at all.
+    # `pattern=` is the one Kafka argument that meets the parameter parser. A
+    # topic is a literal, and it can hold no brace to escape: Kafka admits ASCII
+    # alphanumerics, '.', '_' and '-' in a topic name and nothing else.
     assert {
         name: channel["bindings"]["kafka"]["topic"]
         for name, channel in schema["channels"].items()
     } == {
         "logs.{level}:HandleLogs": "logs.{level}",
-        "cache{{shard}}:Publisher": "cache{{shard}}",
+        "cache:Publisher": "cache",
     }
 
 

--- a/tests/asyncapi/kafka/v2_6_0/test_naming.py
+++ b/tests/asyncapi/kafka/v2_6_0/test_naming.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import pytest
+from typing_extensions import override
 
 from faststream.kafka import KafkaBroker
 from tests.asyncapi.base.v2_6_0.naming import NamingTestCase
@@ -7,6 +10,10 @@ from tests.asyncapi.base.v2_6_0.naming import NamingTestCase
 @pytest.mark.kafka()
 class TestNaming(NamingTestCase):
     broker_class = KafkaBroker
+
+    @override
+    def uri_unsafe_subscriber(self, broker: Any) -> Any:
+        return broker.subscriber(pattern="/test/topic/{user_id}")
 
     def test_base(self) -> None:
         broker = self.broker_class()

--- a/tests/asyncapi/kafka/v3_0_0/test_address.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_address.py
@@ -11,18 +11,19 @@ def test_every_address_is_named_as_declared() -> None:
     @broker.subscriber(pattern="logs.{level}")
     async def handle_logs(body: str) -> None: ...
 
-    broker.publisher("cache{{shard}}")
+    broker.publisher("cache")
 
     schema = get_3_0_0_schema(broker)
 
-    # A Kafka topic is never compiled, so `{{` is not syntax there and nothing
-    # takes it off. Only `pattern=` meets the parameter parser at all.
+    # `pattern=` is the one Kafka argument that meets the parameter parser. A
+    # topic is a literal, and it can hold no brace to escape: Kafka admits ASCII
+    # alphanumerics, '.', '_' and '-' in a topic name and nothing else.
     assert {
         name: channel["bindings"]["kafka"]["topic"]
         for name, channel in schema["channels"].items()
     } == {
         "logs.{level}:HandleLogs": "logs.{level}",
-        "cache{{shard}}:Publisher": "cache{{shard}}",
+        "cache:Publisher": "cache",
     }
 
 

--- a/tests/asyncapi/kafka/v3_0_0/test_naming.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_naming.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import pytest
+from typing_extensions import override
 
 from faststream.kafka import KafkaBroker
 from tests.asyncapi.base.v3_0_0.naming import NamingTestCase
@@ -7,6 +10,10 @@ from tests.asyncapi.base.v3_0_0.naming import NamingTestCase
 @pytest.mark.kafka()
 class TestNaming(NamingTestCase):
     broker_class = KafkaBroker
+
+    @override
+    def uri_unsafe_subscriber(self, broker: Any) -> Any:
+        return broker.subscriber(pattern="/test/topic/{user_id}")
 
     def test_base(self) -> None:
         broker = self.broker_class()

--- a/tests/brokers/confluent/test_misconfigure.py
+++ b/tests/brokers/confluent/test_misconfigure.py
@@ -52,3 +52,33 @@ def test_use_only_confluent_router() -> None:
 
     with pytest.raises(SetupError):
         broker.include_routers(routers)
+
+
+@pytest.mark.confluent()
+@pytest.mark.parametrize(
+    "topic",
+    (
+        pytest.param("cache{{shard}}", id="brace"),
+        pytest.param("logs/errors", id="slash"),
+        pytest.param("orders v2", id="space"),
+        pytest.param("заказы", id="non-ascii"),
+        pytest.param("x" * 250, id="too-long"),
+        pytest.param("..", id="reserved"),
+        pytest.param("", id="empty"),
+    ),
+)
+def test_a_topic_kafka_would_refuse_is_rejected_where_it_is_written(
+    topic: str,
+) -> None:
+    broker = KafkaBroker()
+
+    # Kafka answers such a name with INVALID_TOPIC_EXCEPTION, but only once a
+    # consumer or producer reaches the cluster.
+    with pytest.raises(SetupError):
+        broker.subscriber(topic)
+
+    with pytest.raises(SetupError):
+        broker.publisher(topic)
+
+    with pytest.raises(SetupError):
+        broker.subscriber(partitions=[TopicPartition(topic, 1)])

--- a/tests/brokers/kafka/test_misconfigure.py
+++ b/tests/brokers/kafka/test_misconfigure.py
@@ -100,3 +100,41 @@ def test_use_only_kafka_router() -> None:
 
     with pytest.raises(SetupError):
         broker.include_routers(routers)
+
+
+@pytest.mark.kafka()
+@pytest.mark.parametrize(
+    "topic",
+    (
+        pytest.param("cache{{shard}}", id="brace"),
+        pytest.param("logs/errors", id="slash"),
+        pytest.param("orders v2", id="space"),
+        pytest.param("заказы", id="non-ascii"),
+        pytest.param("x" * 250, id="too-long"),
+        pytest.param("..", id="reserved"),
+        pytest.param("", id="empty"),
+    ),
+)
+def test_a_topic_kafka_would_refuse_is_rejected_where_it_is_written(
+    topic: str,
+) -> None:
+    broker = KafkaBroker()
+
+    # Kafka answers such a name with INVALID_TOPIC_EXCEPTION, but only once a
+    # consumer or producer reaches the cluster.
+    with pytest.raises(SetupError):
+        broker.subscriber(topic)
+
+    with pytest.raises(SetupError):
+        broker.publisher(topic)
+
+    with pytest.raises(SetupError):
+        broker.subscriber(partitions=[TopicPartition(topic=topic, partition=1)])
+
+
+@pytest.mark.kafka()
+def test_a_pattern_is_not_a_topic_name() -> None:
+    broker = KafkaBroker()
+
+    # A pattern never leaves the client, so the topic-name rules do not apply.
+    broker.subscriber(pattern="logs/.*/{level}")


### PR DESCRIPTION
**Stacked on #3074.** Third in the series under #2357, after #3072 and #3074.

## Why

A declaration arrives at a factory as a string. Where the config kept it as one, every reader that needed the compiled address built its own:

```python
Address(self.config.subject, NATS_ADDRESS_SYNTAX).add_prefix(prefix)
```

NATS spelled that four times and `compile_nats_wildcard(config.subject)` four more; Kafka spelled it five. Nine readers, each having to know which syntax its broker uses and which of `template` / `broker_address` / `regex` it wants. That is the shape the two bugs in #3072 and #3074 grew in: when the same conversion happens in nine places, two of them will eventually disagree.

Every other broker already holds a value object — `PubSub`, `ListSub`, `StreamSub`, `RabbitQueue`, `Topic`, and MQTT's `Address` from #3074. NATS and Kafka were the last two holding strings.

## Decisions

**The factory converts, once; the config holds the result.** `NatsSubscriberConfig.subject`, `NatsPublisherConfig.subject` and `KafkaSubscriberConfig.pattern` are now an `Address`. Readers ask it for what they need. `NATS_ADDRESS_SYNTAX` and `KAFKA_ADDRESS_SYNTAX` now appear once per factory instead of once per reader.

**Only fields that meet the parameter parser change.** Kafka `topics` and `partitions`, Confluent topics, Redis list and stream keys and the RabbitMQ queue name stay literal. `Address` would start reading `{{` in them as syntax — and for a Redis key that is worse than cosmetic: `{...}` there is a Redis Cluster hash tag, so `orders{tenant42}` would compile to `orders*` and `LPOP` would silently find nothing.

**`KAFKA_ADDRESS_SYNTAX` moves to `faststream/kafka/path.py`.** It described the whole broker but lived in `subscriber/usecase.py`, which is why the specification imported a usecase to reach it.

**The NATS parsers take a compiled regex instead of a string to compile.** Same regex as before, from the same undecorated subject.

**A topic name Kafka will refuse is now rejected where it is written.** Kafka admits ASCII alphanumerics, `.`, `_` and `-` and nothing else; FastStream accepted anything and let the cluster answer `INVALID_TOPIC_EXCEPTION` on first contact, far from the line responsible. `pattern=` is exempt — it never leaves the client.

## Behaviour change

Two things that used to be accepted now raise `SetupError` at declaration:

- a Kafka or Confluent topic name outside `[a-zA-Z0-9._-]`, longer than 249 characters, empty, or `.` / `..`

Nothing that reaches a Kafka cluster today is affected: every rejected name is one the broker itself refuses.

Two document tests asserted the old silence, declaring a publisher on `cache{{shard}}` to show a topic keeps its `{{`. True, and useless — that name cannot exist. `test_path_channel_refs_are_uri_encoded` declared on `/test/topic/{user_id}` for every broker; that address is now unreachable on both Kafka packages, so it moves behind a `uri_unsafe_subscriber` hook. Kafka reaches a URI-unsafe channel key through `pattern=`; Confluent, having no pattern, cannot reach one at all, and skips with that reason.

## Deferred

**NATS `filter_subjects` still applies a prefix two ways** — the usecase concatenates, the specification compiles. They agree on every prefix without an escape, which is why nothing fails today. It is the same divergence #3074 closed elsewhere, and it is not a refactor.

**A NATS capture regex is still built from the undecorated subject.** It matches a prefixed subject only because `compile_path` opens with `^.*?`. That works, but by accident rather than by decision, and a parameter inside a prefix is not captured. MQTT solved this in #3074 with `_make_parser(outer_config)`.

**Redis Cluster hash tags are undocumented.** `{...}` in a list or stream key belongs to Redis; in a channel name it belongs to FastStream. That holds only because FastStream uses plain pub/sub rather than `SSUBSCRIBE`, and nothing says so anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
