### PR TITLE
docs: list HBB (AI·SW Maestro 17th) on the users page

### DIFF
--- a/docs/docs/en/who-uses.md
+++ b/docs/docs/en/who-uses.md
@@ -32,6 +32,7 @@ of their own.
 | **CTIC** | CTIC Technology Centre, Spain | [connector-building-blocks](https://github.com/fundacionctic/connector-building-blocks){.external-link target="_blank"} — Eclipse Dataspace Components tooling |
 | **QCrBox** | Quantum Crystallography Toolbox | [QCrBox](https://github.com/QCrBox/QCrBox){.external-link target="_blank"} — small-molecule crystallography |
 | **NERSC** | National Energy Research Scientific Computing Center, US DOE | [interactEM](https://github.com/NERSC/interactEM){.external-link target="_blank"} |
+| **HBB (AI·SW Maestro 17th)** | Dev team in AI·SW Maestro, a software talent programme in Korea | [Kkori-AI](https://github.com/SW-Maestro-17th-HBB/Kkori-AI){.external-link target="_blank"} — AI worker of Kkori, an interview-prep service: analyses uploaded resumes and generates interview reports |
 
 ## Companies
 


### PR DESCRIPTION
# Description

Adds one entry to the users page: **HBB (AI·SW Maestro 17th)**, with the team's explicit consent.

They were asked in #3069 and answered there. The team name, the description of the programme and the description of the project are all their own wording, used verbatim rather than paraphrased.

`Kkori-AI`'s worker declares `faststream[redis]` and consumes a Redis Stream consumer group; that use case is what produced #3003, #3049 and #3069 — including the runtime verification on a real Redis in #3069.

Filed as its own PR from `main` so the consent and its source stay easy to find later.

Fixes # (no issue)

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings

Tests are not applicable — a single table row in the docs.
