### PR TITLE
test(redis): sound cluster pub/sub tests — arrival order and channel isolation

### DIFF
--- a/tests/brokers/redis/cluster/test_cluster_pubsub_more.py
+++ b/tests/brokers/redis/cluster/test_cluster_pubsub_more.py
@@ -41,7 +41,11 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
                 timeout=self.timeout,
             )
 
-        assert received == ["a", "b"]
+        # `test.pattern.foo` and `test.pattern.bar` hash to different slots, so the
+        # two publishes reach different nodes and propagate over the cluster bus
+        # independently. Which one arrives first is a race, and not one this test is
+        # about — sorted rather than a set, so a message delivered twice still fails.
+        assert sorted(received) == ["a", "b"]
 
     @pytest.mark.asyncio()
     async def test_multiple_subscribers_same_channel(

--- a/tests/brokers/redis/cluster/test_cluster_pubsub_more.py
+++ b/tests/brokers/redis/cluster/test_cluster_pubsub_more.py
@@ -19,6 +19,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
     @pytest.mark.asyncio()
     async def test_pattern_subscribe(
         self,
+        queue: str,
         settings_cluster: SettingsCluster,
         event: asyncio.Event,
     ) -> None:
@@ -26,7 +27,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
 
         received = []
 
-        @broker.subscriber(channel="test.pattern.*")
+        @broker.subscriber(channel=f"test.pattern.{queue}.*")
         async def handler(msg: str) -> None:
             received.append(msg)
             if len(received) == 2:
@@ -34,22 +35,23 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
 
         async with broker:
             await broker.start()
-            await broker.publish("a", channel="test.pattern.foo")
-            await broker.publish("b", channel="test.pattern.bar")
+            await broker.publish("a", channel=f"test.pattern.{queue}.foo")
+            await broker.publish("b", channel=f"test.pattern.{queue}.bar")
             await asyncio.wait(
                 (asyncio.create_task(event.wait()),),
                 timeout=self.timeout,
             )
 
-        # `test.pattern.foo` and `test.pattern.bar` hash to different slots, so the
-        # two publishes reach different nodes and propagate over the cluster bus
-        # independently. Which one arrives first is a race, and not one this test is
-        # about — sorted rather than a set, so a message delivered twice still fails.
+        # The two channels hash to their own slots, so the publishes reach different
+        # nodes and propagate over the cluster bus independently. Which one arrives
+        # first is a race, and not one this test is about — sorted rather than a set,
+        # so a message delivered twice still fails.
         assert sorted(received) == ["a", "b"]
 
     @pytest.mark.asyncio()
     async def test_multiple_subscribers_same_channel(
         self,
+        queue: str,
         settings_cluster: SettingsCluster,
         event: asyncio.Event,
         event2: asyncio.Event,
@@ -59,19 +61,19 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
         received1 = []
         received2 = []
 
-        @broker.subscriber(channel="multi-channel")
+        @broker.subscriber(channel=f"multi-channel-{queue}")
         async def handler1(msg: str) -> None:
             received1.append(msg)
             event.set()
 
-        @broker.subscriber(channel="multi-channel")
+        @broker.subscriber(channel=f"multi-channel-{queue}")
         async def handler2(msg: str) -> None:
             received2.append(msg)
             event2.set()
 
         async with broker:
             await broker.start()
-            await broker.publish("shared", channel="multi-channel")
+            await broker.publish("shared", channel=f"multi-channel-{queue}")
             await asyncio.wait(
                 (
                     asyncio.create_task(event.wait()),
@@ -86,12 +88,13 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
     @pytest.mark.asyncio()
     async def test_get_one_from_channel(
         self,
+        queue: str,
         settings_cluster: SettingsCluster,
         mock: MagicMock,
     ) -> None:
         broker = self.get_broker(startup_nodes=settings_cluster.startup_nodes)
 
-        sub = broker.subscriber(channel="get-one-channel")
+        sub = broker.subscriber(channel=f"get-one-channel-{queue}")
 
         async with broker:
             await broker.start()
@@ -103,7 +106,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
 
             async def publish() -> None:
                 await asyncio.sleep(0.1)
-                await broker.publish("test_msg", channel="get-one-channel")
+                await broker.publish("test_msg", channel=f"get-one-channel-{queue}")
 
             await asyncio.wait(
                 (
@@ -118,12 +121,13 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
     @pytest.mark.asyncio()
     async def test_get_one_timeout_channel(
         self,
+        queue: str,
         settings_cluster: SettingsCluster,
         mock: MagicMock,
     ) -> None:
         broker = self.get_broker(startup_nodes=settings_cluster.startup_nodes)
 
-        sub = broker.subscriber(channel="empty-channel")
+        sub = broker.subscriber(channel=f"empty-channel-{queue}")
 
         async with broker:
             await broker.start()
@@ -135,6 +139,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
     @pytest.mark.asyncio()
     async def test_headers_propagation(
         self,
+        queue: str,
         settings_cluster: SettingsCluster,
         mock: MagicMock,
         event: asyncio.Event,
@@ -146,7 +151,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
             startup_nodes=settings_cluster.startup_nodes,
         )
 
-        @broker.subscriber(channel="headers-channel")
+        @broker.subscriber(channel=f"headers-channel-{queue}")
         async def handler(
             body: str,
             msg=Context("message"),
@@ -162,7 +167,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
             await broker.start()
             await broker.publish(
                 "data",
-                channel="headers-channel",
+                channel=f"headers-channel-{queue}",
                 correlation_id="my-cor-id",
                 reply_to="reply-chan",
             )
@@ -179,6 +184,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
     @pytest.mark.asyncio()
     async def test_stop_consume_channel(
         self,
+        queue: str,
         settings_cluster: SettingsCluster,
         mock: MagicMock,
         event: asyncio.Event,
@@ -187,7 +193,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
 
         broker = self.get_broker(startup_nodes=settings_cluster.startup_nodes)
 
-        @broker.subscriber(channel="stop-channel")
+        @broker.subscriber(channel=f"stop-channel-{queue}")
         async def handler(msg: str) -> None:
             mock(msg)
             event.set()
@@ -195,13 +201,13 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
 
         async with broker:
             await broker.start()
-            await broker.publish("hello", channel="stop-channel")
+            await broker.publish("hello", channel=f"stop-channel-{queue}")
             await asyncio.wait(
                 (asyncio.create_task(event.wait()),),
                 timeout=self.timeout,
             )
             await asyncio.sleep(0.5)
-            await broker.publish("hello2", channel="stop-channel")
+            await broker.publish("hello2", channel=f"stop-channel-{queue}")
             await asyncio.sleep(0.5)
 
         assert event.is_set()
@@ -210,12 +216,13 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
     @pytest.mark.asyncio()
     async def test_unsubscribe_cleans_up(
         self,
+        queue: str,
         settings_cluster: SettingsCluster,
         event: asyncio.Event,
     ) -> None:
         broker = self.get_broker(startup_nodes=settings_cluster.startup_nodes)
 
-        sub = broker.subscriber(channel="restart-channel")
+        sub = broker.subscriber(channel=f"restart-channel-{queue}")
 
         @sub
         async def handler(msg: str) -> None:
@@ -226,7 +233,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
 
             # First round
             await sub.start()
-            await broker.publish("msg1", channel="restart-channel")
+            await broker.publish("msg1", channel=f"restart-channel-{queue}")
             await asyncio.wait(
                 (asyncio.create_task(event.wait()),),
                 timeout=self.timeout,
@@ -238,7 +245,7 @@ class TestClusterPubSubMore(RedisClusterTestcaseConfig):
             # Second round
             event.clear()
             await sub.start()
-            await broker.publish("msg2", channel="restart-channel")
+            await broker.publish("msg2", channel=f"restart-channel-{queue}")
             await asyncio.wait(
                 (asyncio.create_task(event.wait()),),
                 timeout=self.timeout,


### PR DESCRIPTION
Two changes to `tests/brokers/redis/cluster/test_cluster_pubsub_more.py`, the second following from reviewing the first.

## `test_pattern_subscribe` asserted an order the cluster does not give

It publishes to two channels and asserts the pattern subscriber received them in publication order:

```python
await broker.publish("a", channel="test.pattern.foo")
await broker.publish("b", channel="test.pattern.bar")
...
assert received == ["a", "b"]
```

The two channels hash to different slots, so the publishes reach different nodes and propagate over the cluster bus independently:

```
test.pattern.foo   slot=13062  ->  127.0.0.1:7003
test.pattern.bar   slot=3925   ->  127.0.0.1:7001
```

Which one arrives first is whichever race finishes first. On an idle machine the first publish wins almost always — 12/12 locally — and on a loaded CI runner it does not:

```
assert ['b', 'a'] == ['a', 'b']
```

Seen on #3070, whose diff cannot reach message delivery: its only Redis change is removing three duplicated `name` properties from `subscriber/specification.py`, which builds the AsyncAPI document. Re-running the same job on the same commit turned it green.

**Not `@pytest.mark.flaky`.** That is the convention here — `pytest-rerunfailures` is a dependency and 30 tests carry `(reruns=3, reruns_delay=1)`, all identical — and it would go green. But the assertion asks for something the system does not provide, so three reruns toss the same coin three times, and take three times as long to say so.

```python
assert sorted(received) == ["a", "b"]
```

`sorted` rather than a set, so the test still fails if a message is lost or delivered twice:

| received | before | after |
|---|---|---|
| `['a', 'b']` | pass | pass |
| `['b', 'a']` | **fail** | pass |
| `['a']` | fail | fail |
| `['a', 'a']` | fail | fail |

## Channels now come from the `queue` fixture

This file was the one connected file in the cluster suite naming its channels literally — `multi-channel`, `get-one-channel`, `empty-channel`, `stop-channel`, `restart-channel`. Every neighbouring file already derives them from `queue`, a fresh uuid4 per test.

Nothing collides today: each literal is used by exactly one test, and pub/sub keeps no state between runs. But `just test-all` runs `-m "all" -n auto`, and `pytest_collection_modifyitems` marks *every* test `all`, so these do run in parallel. `empty-channel` is the sharp one — a test whose whole premise is that nothing is on the channel.

## Checked

Beyond this file, I went through both `tests/brokers/redis/cluster/` and `tests/brokers/redis/sentinel/` looking for the same defect and found none:

- The other five order-dependent assertions are sound. `test_cluster_connect.py:83` and `:112` push to a **single list key**, which is FIFO on one node, so their order is guaranteed; the rest assert a single element.
- Every sentinel test is a unit test — no live broker, nothing to race.
- `test_stream_consume` looks contradictory (publishes up to 10 times, asserts exactly one delivery) but is correct: `last_id` defaults to `"$"` and resolves at the first XREAD, so earlier publishes are dropped rather than queued.

Empirically, the connected cluster suite ran clean 3× under 8-way CPU load and 2× under `-n auto`.
