### PR TITLE
fix(redis): keep group read cursor in get_one and iterator

### DIFF
--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -209,7 +209,7 @@ class _StreamHandlerMixin(LogicSubscriber):
                 stream_message = await self._client.xreadgroup(
                     groupname=self.stream_sub.group,
                     consumername=self.stream_sub.consumer,
-                    streams={self.stream_sub.name: self.last_id},
+                    streams={self.stream_sub.name: self.read_id},
                     block=math.ceil(timeout * 1000),
                     count=1,
                 )
@@ -283,7 +283,7 @@ class _StreamHandlerMixin(LogicSubscriber):
                     stream_message = await self._client.xreadgroup(
                         groupname=self.stream_sub.group,
                         consumername=self.stream_sub.consumer,
-                        streams={self.stream_sub.name: self.last_id},
+                        streams={self.stream_sub.name: self.read_id},
                         block=math.ceil(timeout * 1000),
                         count=1,
                     )

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -989,7 +989,7 @@ class TestConsumeStream(RedisTestcaseConfig):
         self,
         queue: str,
     ) -> None:
-        broker = self.get_broker(apply_types=True)
+        broker = self.get_broker()
         subscriber = broker.subscriber(
             stream=StreamSub(queue, group="test_group", consumer="test_consumer")
         )
@@ -1012,7 +1012,7 @@ class TestConsumeStream(RedisTestcaseConfig):
         self,
         queue: str,
     ) -> None:
-        broker = self.get_broker(apply_types=True)
+        broker = self.get_broker()
         subscriber = broker.subscriber(
             stream=StreamSub(queue, group="test_group", consumer="test_consumer")
         )

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -985,6 +985,52 @@ class TestConsumeStream(RedisTestcaseConfig):
             calls = [call(msg) for msg in expected_messages]
             mock.assert_has_calls(calls=calls)
 
+    async def test_get_one_group_cursor_advances(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker(apply_types=True)
+        subscriber = broker.subscriber(
+            stream=StreamSub(queue, group="test_group", consumer="test_consumer")
+        )
+
+        async with self.patch_broker(broker) as br:
+            await br.start()
+
+            await br.publish("first", stream=queue)
+            await br.publish("second", stream=queue)
+
+            msg1 = await subscriber.get_one(timeout=3)
+            msg2 = await subscriber.get_one(timeout=3)
+
+            assert msg1 is not None
+            assert msg2 is not None
+            assert await msg1.decode() == "first"
+            assert await msg2.decode() == "second"
+
+    async def test_iterator_group_cursor_advances(
+        self,
+        queue: str,
+    ) -> None:
+        broker = self.get_broker(apply_types=True)
+        subscriber = broker.subscriber(
+            stream=StreamSub(queue, group="test_group", consumer="test_consumer")
+        )
+
+        async with self.patch_broker(broker) as br:
+            await br.start()
+
+            await br.publish("first", stream=queue)
+            await br.publish("second", stream=queue)
+
+            results = []
+            async for msg in subscriber:
+                results.append(await msg.decode())
+                if len(results) >= 2:
+                    break
+
+            assert results == ["first", "second"]
+
     @pytest.mark.slow()
     async def test_consume_stream_group_deleted(
         self,


### PR DESCRIPTION
# Description

 get_one() and __aiter__() were both passing self.last_id to XREADGROUP instead of self.read_id. Since last_id gets updated to the last delivered message ID after each call, the cursor was stuck and Redis would never deliver the next message in consumer group mode.

Fixes #3050 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [X] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [X] I have conducted a self-review of my own code
- [X] My changes do not generate any new warnings
- [X] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [X] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
