### PR TITLE
chore: own Redis, label AsyncAPI, drop a stale README aside

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,3 +32,8 @@
 /faststream/mqtt/ @borisalekseev
 /tests/brokers/mqtt/ @borisalekseev
 /docs/docs/en/mqtt/ @borisalekseev
+
+# Redis
+/faststream/redis/ @powersemmi
+/tests/brokers/redis/ @powersemmi
+/docs/docs/en/redis/ @powersemmi

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -57,6 +57,13 @@ Observability:
       - faststream/prometheus/**
       - docs/docs/en/getting-started/observability/**
 
+AsyncAPI:
+  - changed-files:
+    - any-glob-to-any-file:
+      - faststream/specification/**
+      - faststream/**/specification.py
+      - docs/docs/en/getting-started/asyncapi/**
+
 dependencies:
   - changed-files:
     - any-glob-to-any-file:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Making streaming microservices has never been easier. The API is small enough to
 
 - **Extensible**: Use extensions for lifespans, custom serialization and middleware
 
-- [**Integrations**](#any-framework): **FastStream** is fully compatible with any HTTP framework you want — including a dedicated [**FastAPI** plugin](#fastapi-plugin-deprecated), now shipped as its own package
+- [**Integrations**](#any-framework): **FastStream** is fully compatible with any HTTP framework you want — including a dedicated [**FastAPI** plugin](#fastapi-plugin-deprecated)
 
 That is **FastStream**: everything a messaging service needs around your handlers, and nothing between you and your broker.
 

--- a/docs/docs/en/index.md
+++ b/docs/docs/en/index.md
@@ -101,7 +101,7 @@ Making streaming microservices has never been easier. The API is small enough to
 
 - **Extensible**: Use extensions for lifespans, custom serialization and middleware
 
-- [**Integrations**](#any-framework): **FastStream** is fully compatible with any HTTP framework you want — including a dedicated [**FastAPI** plugin](#fastapi-plugin-deprecated), now shipped as its own package
+- [**Integrations**](#any-framework): **FastStream** is fully compatible with any HTTP framework you want — including a dedicated [**FastAPI** plugin](#fastapi-plugin-deprecated)
 
 That is **FastStream**: everything a messaging service needs around your handlers, and nothing between you and your broker.
 


### PR DESCRIPTION
Three small repo-maintenance changes.

- **CODEOWNERS**: `@powersemmi` owns the Redis broker, its tests and its docs, following the same three-path shape the MQTT block uses.
- **labeler**: an `AsyncAPI` label for changes under `faststream/specification/**` and `docs/docs/en/getting-started/asyncapi/**`. The label has to exist in repo settings for the action to apply it.
- **README / docs index**: the FastAPI plugin bullet ended with "now shipped as its own package". The feature list should say where the plugin is today, not how it got there — the link and the `(deprecated)` marker already carry that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)