### PR TITLE
refactor: Kafka `TopicPartition` is FastStream's own type

### DIFF
--- a/faststream/kafka/__init__.py
+++ b/faststream/kafka/__init__.py
@@ -9,12 +9,13 @@ if TYPE_CHECKING:
 KafkaParserType: TypeAlias = ParserProto["ConsumerRecord[Any, Any]"]
 
 try:
-    from aiokafka import ConsumerRecord, TopicPartition
+    from aiokafka import ConsumerRecord
     from aiokafka.structs import RecordMetadata
 
     from .annotations import KafkaMessage
     from .broker import KafkaBroker, KafkaPublisher, KafkaRoute, KafkaRouter
     from .response import KafkaPublishCommand, KafkaPublishMessage, KafkaResponse
+    from .schemas import TopicPartition
     from .testing import TestKafkaBroker
 
 except ImportError as e:

--- a/faststream/kafka/broker/registrator.py
+++ b/faststream/kafka/broker/registrator.py
@@ -22,7 +22,6 @@ from faststream.kafka.subscriber.factory import create_subscriber
 from faststream.middlewares import AckPolicy
 
 if TYPE_CHECKING:
-    from aiokafka import TopicPartition
     from aiokafka.abc import ConsumerRebalanceListener
     from aiokafka.coordinator.assignors.abstract import AbstractPartitionAssignor
     from fast_depends.dependencies import Dependant
@@ -36,6 +35,7 @@ if TYPE_CHECKING:
         BatchPublisher,
         DefaultPublisher,
     )
+    from faststream.kafka.schemas import TopicPartition
     from faststream.kafka.subscriber.usecase import (
         BatchSubscriber,
         ConcurrentBetweenPartitionsSubscriber,

--- a/faststream/kafka/broker/router.py
+++ b/faststream/kafka/broker/router.py
@@ -20,7 +20,7 @@ from faststream.kafka.configs import KafkaBrokerConfig
 from faststream.middlewares import AckPolicy
 
 if TYPE_CHECKING:
-    from aiokafka import ConsumerRecord, TopicPartition
+    from aiokafka import ConsumerRecord
     from aiokafka.abc import ConsumerRebalanceListener
     from aiokafka.coordinator.assignors.abstract import AbstractPartitionAssignor
     from fast_depends.dependencies import Dependant
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
         BrokerMiddleware,
         CustomCallable,
     )
+    from faststream.kafka.schemas import TopicPartition
 
 
 class KafkaPublisher(ArgsContainer):

--- a/faststream/kafka/fastapi/fastapi.py
+++ b/faststream/kafka/fastapi/fastapi.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
     from asyncio import AbstractEventLoop
     from enum import Enum
 
-    from aiokafka import TopicPartition
     from aiokafka.abc import AbstractTokenProvider, ConsumerRebalanceListener
     from aiokafka.coordinator.assignors.abstract import AbstractPartitionAssignor
     from fastapi import params
@@ -51,6 +50,7 @@ if TYPE_CHECKING:
         BatchPublisher,
         DefaultPublisher,
     )
+    from faststream.kafka.schemas import TopicPartition
     from faststream.kafka.subscriber.usecase import (
         BatchSubscriber,
         ConcurrentBetweenPartitionsSubscriber,

--- a/faststream/kafka/schemas/__init__.py
+++ b/faststream/kafka/schemas/__init__.py
@@ -1,0 +1,3 @@
+from faststream.kafka.schemas.partition import TopicPartition
+
+__all__ = ("TopicPartition",)

--- a/faststream/kafka/schemas/partition.py
+++ b/faststream/kafka/schemas/partition.py
@@ -1,0 +1,24 @@
+from typing import NamedTuple
+
+
+class TopicPartition(NamedTuple):
+    """A topic and partition pair, naming the assignment a Subscriber is declared with.
+
+    FastStream's own rather than a re-export of `aiokafka.TopicPartition`, so the
+    type is ours to grow at the same import path. Still a `NamedTuple` with the
+    client library's two fields in the same order, because unpacking, indexing,
+    ordering, hashing and equality against the client library's tuple are what the
+    re-export gave users and none of them survive an ordinary class, or a third
+    field. What the consumer is assigned is the client library's tuple, rebuilt
+    where the assignment happens; this one is never handed to aiokafka.
+
+    Separate from `faststream.confluent.TopicPartition`, which carries `offset`,
+    `leader_epoch` and `metadata` — fields the aiokafka client has no equivalent
+    for, and so a promise this signature must not make.
+    """
+
+    topic: str
+    """A topic name."""
+
+    partition: int
+    """A partition id."""

--- a/faststream/kafka/subscriber/config.py
+++ b/faststream/kafka/subscriber/config.py
@@ -11,8 +11,9 @@ from faststream.kafka.configs import KafkaBrokerConfig
 from faststream.middlewares import AckPolicy
 
 if TYPE_CHECKING:
-    from aiokafka import TopicPartition
     from aiokafka.abc import ConsumerRebalanceListener
+
+    from faststream.kafka.schemas import TopicPartition
 
 
 @dataclass(kw_only=True)

--- a/faststream/kafka/subscriber/factory.py
+++ b/faststream/kafka/subscriber/factory.py
@@ -17,10 +17,10 @@ from .usecase import (
 )
 
 if TYPE_CHECKING:
-    from aiokafka import TopicPartition
     from aiokafka.abc import ConsumerRebalanceListener
 
     from faststream.kafka.configs import KafkaBrokerConfig
+    from faststream.kafka.schemas import TopicPartition
 
 
 def create_subscriber(

--- a/faststream/kafka/subscriber/usecase.py
+++ b/faststream/kafka/subscriber/usecase.py
@@ -5,7 +5,10 @@ from itertools import chain
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import anyio
-from aiokafka import ConsumerRecord, TopicPartition
+from aiokafka import (
+    ConsumerRecord,
+    TopicPartition as AIOKafkaTopicPartition,
+)
 from aiokafka.errors import ConsumerStoppedError, KafkaError, UnsupportedCodecError
 from typing_extensions import override
 
@@ -80,9 +83,13 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
         return [f"{self._outer_config.prefix}{t}" for t in self._topics]
 
     @property
-    def partitions(self) -> list[TopicPartition]:
+    def partitions(self) -> list[AIOKafkaTopicPartition]:
+        """The assignment as the consumer receives it: the client library's tuples, prefixed.
+
+        Declared with `faststream.kafka.TopicPartition`; handed to aiokafka as its own.
+        """
         return [
-            TopicPartition(
+            AIOKafkaTopicPartition(
                 topic=f"{self._outer_config.prefix}{p.topic}",
                 partition=p.partition,
             )

--- a/tests/brokers/kafka/test_partition.py
+++ b/tests/brokers/kafka/test_partition.py
@@ -1,0 +1,11 @@
+import pytest
+from aiokafka import TopicPartition as AIOKafkaTopicPartition
+
+from faststream.kafka import TopicPartition
+
+
+@pytest.mark.kafka()
+def test_topic_partition_is_faststreams_own_and_still_the_client_library_tuple() -> None:
+    assert TopicPartition.__module__.startswith("faststream.")
+    # what the consumer is assigned is aiokafka's tuple; user code compares the two
+    assert TopicPartition("topic", 1) == AIOKafkaTopicPartition("topic", 1)


### PR DESCRIPTION
`faststream.kafka.TopicPartition` was a re-export of the aiokafka tuple. It is now a `NamedTuple` of FastStream's own at the same import path, with the client library's two fields first and in its order. User code does not change: unpacking, indexing, equality and hashing against the client library's tuple, and ordering all keep working. One test pins what is ours: the name resolves to a `faststream.` module and the value still equals the client library's tuple; the existing Kafka suite already declares Subscribers with it.

The client library's tuple is built only where the consumer is assigned; the Subscriber already rebuilt it there with the Router prefix applied, and nothing FastStream hands to aiokafka changes. The rebalance listener and the message keep reading aiokafka's type, because that is what the consumer gives them. Every registrator, router and FastAPI signature that takes partitions now names the FastStream type; the in-memory test broker's use of it type-checks that.

### On #3067

This gives the topic-creation work an object of our own to carry `declare`. The field itself comes with that PR, not here.

### Scope

First of the prefactors split out of #3030 so that the Config-value work lands on `main` in reviewable pieces. No public or internal API breaks; no user-visible behaviour changes; no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
