### PR TITLE
feat(redis): use native async cluster pubsub

### DIFF
--- a/docs/docs/en/redis/cluster.md
+++ b/docs/docs/en/redis/cluster.md
@@ -12,7 +12,7 @@ search:
 
 ## Overview
 
-**FastStream** provides a `RedisClusterBroker` for working with [**Redis Cluster**](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/){.external-link target="_blank"}. It is a drop-in replacement for `RedisBroker` with the same constructor API, designed for multi-node cluster deployments.
+**FastStream** provides a `RedisClusterBroker` for working with [**Redis Cluster**](https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/){.external-link target="_blank"}. It is a drop-in replacement for `RedisBroker` with the same constructor API, designed for multi-node cluster deployments. It requires `redis-py >= 8.0.0` and uses a single native async cluster client for List, Stream, and Pub/Sub operations.
 
 ## When to Use
 
@@ -50,7 +50,7 @@ broker = RedisClusterBroker(
 |---|---|---|
 | List | ✅ | ✅ |
 | Stream + XAUTOCLAIM | ✅ | ✅ |
-| Pub/Sub | ✅ | ✅ (via sync cluster) |
+| Pub/Sub | ✅ | ✅ (native async) |
 | Pipeline | ✅ | ❌ |
 
 ## Stream Location
@@ -78,7 +78,6 @@ broker = RedisClusterBroker(url="redis://localhost:7000")
 
 - **Pipeline** is not supported in Redis Cluster.
 - **XAUTOCLAIM** with `min_idle_time` requires a consumer group with `group` and `consumer` parameters on `StreamSub`.
-- **Pub/Sub** uses a synchronous `RedisCluster` client (via `ThreadPoolExecutor`) because the async client does not expose `publish`/`pubsub` until `redis-py >= 8.0.0`.
 
 ## References
 

--- a/docs/docs/en/redis/index.md
+++ b/docs/docs/en/redis/index.md
@@ -41,7 +41,7 @@ Ultimately, the choice between **Pub/Sub**, **List**, or **Streams** hinges on t
 The **FastStream** `RedisBroker` is a key component of the **FastStream** framework that enables seamless integration with **Redis**. With the `RedisBroker`, developers can easily connect to **Redis** instances, publish messages to **Redis** channels, and subscribe to **Redis** channels within their **FastStream** applications.
 
 !!! tip "Redis Cluster Support"
-    For multi-node **Redis Cluster** deployments FastStream provides `RedisClusterBroker`. It is a drop-in replacement with the same API and supports List, Stream, Sharded Pub/Sub, and XAUTOCLAIM. See the [Cluster documentation](./cluster.md){.internal-link} for details.
+    For multi-node **Redis Cluster** deployments FastStream provides `RedisClusterBroker`. It is a drop-in replacement with the same API and supports List, Stream, regular Pub/Sub, and XAUTOCLAIM. This does not include sharded Pub/Sub (`SPUBLISH` and `SSUBSCRIBE`). See the [Cluster documentation](./cluster.md){.internal-link} for details.
 
 ### Establishing a Connection
 

--- a/docs/docs/en/redis/pubsub/index.md
+++ b/docs/docs/en/redis/pubsub/index.md
@@ -13,7 +13,7 @@ search:
 [**Redis Pub/Sub Channels**](https://redis.io/docs/latest/develop/pubsub/){.external-link target="_blank"} are a feature of **Redis** that enables messaging between clients through a publish/subscribe (pub/sub) pattern. A **Redis** channel is essentially a medium through which messages are transmitted. Different clients can subscribe to these channels to listen for messages, while other clients can publish messages to these channels.
 
 !!! tip "Cluster Support"
-    `RedisClusterBroker` supports Pub/Sub via a synchronous `RedisCluster` client. See the [Cluster docs](../cluster.md){.internal-link}.
+    `RedisClusterBroker` supports regular Pub/Sub through its native async cluster client. See the [Cluster docs](../cluster.md){.internal-link}.
 
 When a message is published to a **Redis** channel, all subscribers to that channel receive the message instantly. This makes **Redis** channels suitable for a variety of real-time applications such as chat rooms, notifications, live updates, and many more use cases where messages must be broadcast promptly to multiple clients.
 

--- a/docs/docs/en/redis/pubsub/publishing.md
+++ b/docs/docs/en/redis/pubsub/publishing.md
@@ -13,7 +13,7 @@ search:
 The **FastStream** `RedisBroker` supports all standard [publishing use cases](../../getting-started/publishing/index.md){.internal-link} similar to the `KafkaBroker`, allowing you to publish messages to Redis channels with ease.
 
 !!! tip "Redis Cluster"
-    With `RedisClusterBroker`, Pub/Sub works via a synchronous `RedisCluster` client. See the [Cluster docs](../cluster.md){.internal-link}.
+    With `RedisClusterBroker`, Pub/Sub publishing uses the broker's native async cluster client. See the [Cluster docs](../cluster.md){.internal-link}.
 
 Below you will find guidance on how to utilize the `RedisBroker` for publishing messages, including creating publisher objects and using decorators for streamlined publishing workflows.
 

--- a/docs/docs/en/redis/pubsub/subscription.md
+++ b/docs/docs/en/redis/pubsub/subscription.md
@@ -15,7 +15,7 @@ search:
 **Redis Pub/Sub** is the default subscriber type in **FastStream**, so you can simply create a regular `#!python @broker.subscriber("channel_name")` with a channel name and it creates a subscriber using **Redis Pub/Sub**.
 
 !!! tip "Redis Cluster"
-    With `RedisClusterBroker`, channel subscribers use a synchronous `RedisCluster` client under the hood. See the [Cluster docs](../cluster.md){.internal-link}.
+    With `RedisClusterBroker`, channel subscribers use the broker's native async cluster client. See the [Cluster docs](../cluster.md){.internal-link}.
 
 In this example, we will build a FastStream application that listens to messages from the Redis channel named `#!python "test"`.
 

--- a/faststream/redis/_compat.py
+++ b/faststream/redis/_compat.py
@@ -6,4 +6,4 @@ major, minor, patch, *_ = _REDIS_VERSION.split(".")
 
 _REDIS_MAJOR, _REDIS_MINOR = int(major), int(minor)
 
-REDIS_V720 = _REDIS_MAJOR >= 7 and _REDIS_MINOR >= 2
+REDIS_V720 = (_REDIS_MAJOR, _REDIS_MINOR) >= (7, 2)

--- a/faststream/redis/_compat.py
+++ b/faststream/redis/_compat.py
@@ -7,3 +7,4 @@ major, minor, patch, *_ = _REDIS_VERSION.split(".")
 _REDIS_MAJOR, _REDIS_MINOR = int(major), int(minor)
 
 REDIS_V720 = (_REDIS_MAJOR, _REDIS_MINOR) >= (7, 2)
+REDIS_V800 = (_REDIS_MAJOR, _REDIS_MINOR) >= (8, 0)

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
 
     from faststream._internal.basic_types import SendableMessage
     from faststream.redis.message import RedisChannelMessage
-    from faststream.redis.publisher.producer import RedisClusterFastProducer
     from faststream.redis.schemas.types import RedisBrokerParams
     from faststream.security import BaseSecurity
 
@@ -163,8 +162,8 @@ class RedisBroker(
         self,
         connection_state: "ConnectionState[Any]",
         kwargs: dict[str, Any],
-    ) -> "RedisFastProducer | RedisClusterFastProducer":
-        """Build the producer. Overridden by the Cluster broker."""
+    ) -> "RedisFastProducer":
+        """Build the Redis producer."""
         return RedisFastProducer(
             connection=connection_state,
             parser=kwargs.get("parser"),

--- a/faststream/redis/broker/cluster_broker.py
+++ b/faststream/redis/broker/cluster_broker.py
@@ -70,6 +70,9 @@ class RedisClusterBroker(RedisBroker):
         if maxlen is not None:
             publish_kwargs["maxlen"] = maxlen
 
+        if not self._cluster_state:
+            await self._connect()
+
         return cast(
             "int | bytes",
             await super().publish(

--- a/faststream/redis/broker/cluster_broker.py
+++ b/faststream/redis/broker/cluster_broker.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from redis.asyncio.cluster import ClusterNode
 from redis.asyncio.connection import SSLConnection
@@ -8,17 +8,10 @@ from typing_extensions import Unpack
 
 from faststream._internal.constants import EMPTY
 from faststream.redis.broker import RedisBroker
-from faststream.redis.configs.state import (
-    ConnectionState,
-    RedisClusterConnectionState,
-)
-from faststream.redis.publisher.producer import (
-    RedisClusterFastProducer,
-)
+from faststream.redis.configs.state import RedisClusterConnectionState
 from faststream.redis.schemas.types import (
     CLUSTER_INCOMPATIBLE_PARAMS,
 )
-from faststream.redis.subscriber.usecases.basic import LogicSubscriber
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -26,9 +19,7 @@ if TYPE_CHECKING:
     from redis.asyncio.client import Pipeline
 
     from faststream._internal.basic_types import SendableMessage
-    from faststream.redis.schemas import ListSub, PubSub, StreamSub
     from faststream.redis.schemas.types import RedisClusterParams
-    from faststream.redis.subscriber.usecases import ChannelSubscriber
     from faststream.security import BaseSecurity
 
 
@@ -46,70 +37,12 @@ class RedisClusterBroker(RedisBroker):
         self,
         connection_options: dict[str, Any],
         kwargs: dict[str, Any],
-    ) -> "ConnectionState[Any]":
+    ) -> RedisClusterConnectionState:
         return RedisClusterConnectionState(connection_options)
-
-    def _make_producer(
-        self,
-        connection_state: "ConnectionState[Any]",
-        kwargs: dict[str, Any],
-    ) -> "RedisClusterFastProducer":
-        state = cast("RedisClusterConnectionState", connection_state)
-        return RedisClusterFastProducer(
-            connection=state,
-            cluster_state=state,
-            parser=kwargs.get("parser"),
-            decoder=kwargs.get("decoder"),
-            message_format=self.message_format,
-            serializer=kwargs.get("serializer"),
-        )
 
     @property
     def _cluster_state(self) -> RedisClusterConnectionState:
         return cast("RedisClusterConnectionState", self.config.broker_config.connection)
-
-    def subscriber(  # type: ignore[override]
-        self,
-        channel: Union["PubSub", str, None] = None,
-        *,
-        list: Union["ListSub", str, None] = None,
-        stream: Union["StreamSub", str, None] = None,
-        **kwargs: Any,
-    ) -> "LogicSubscriber":
-        if channel is not None:
-            return self._make_channel_subscriber(channel, **kwargs)
-        return super().subscriber(
-            channel=None,
-            list=list,
-            stream=stream,
-            **kwargs,
-        )
-
-    def _make_channel_subscriber(
-        self,
-        channel: Union["PubSub", str],
-        **kwargs: Any,
-    ) -> "ChannelSubscriber":
-        state = self._cluster_state
-
-        sub = cast(
-            "ChannelSubscriber",
-            super().subscriber(channel=channel, list=None, stream=None, **kwargs),
-        )
-
-        async def _patched_start() -> None:
-            if sub.subscription:
-                return
-            psub = state.pubsub()
-            sub.subscription = psub  # type: ignore[assignment]
-            if sub.channel.pattern:
-                await psub.psubscribe(sub.channel.name)
-            else:
-                await psub.subscribe(sub.channel.name)
-            await LogicSubscriber.start(sub, psub)
-
-        sub.start = _patched_start  # type: ignore[method-assign]
-        return sub
 
     async def publish(  # type: ignore[override]
         self,

--- a/faststream/redis/broker/cluster_broker.py
+++ b/faststream/redis/broker/cluster_broker.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from redis.asyncio.client import Pipeline
 
     from faststream._internal.basic_types import SendableMessage
+    from faststream.redis.configs.state import ConnectionState
     from faststream.redis.schemas.types import RedisClusterParams
     from faststream.security import BaseSecurity
 
@@ -37,7 +38,7 @@ class RedisClusterBroker(RedisBroker):
         self,
         connection_options: dict[str, Any],
         kwargs: dict[str, Any],
-    ) -> RedisClusterConnectionState:
+    ) -> "ConnectionState[Any]":
         return RedisClusterConnectionState(connection_options)
 
     @property
@@ -70,6 +71,8 @@ class RedisClusterBroker(RedisBroker):
         if maxlen is not None:
             publish_kwargs["maxlen"] = maxlen
 
+        # Direct publish may run before start(), while cluster state exposes a client
+        # only after topology initialization.
         if not self._cluster_state:
             await self._connect()
 

--- a/faststream/redis/configs/broker.py
+++ b/faststream/redis/configs/broker.py
@@ -10,17 +10,14 @@ if TYPE_CHECKING:
     from redis.asyncio.cluster import RedisCluster
 
     from faststream.redis.parser import MessageFormat
-    from faststream.redis.publisher.producer import (
-        RedisClusterFastProducer,
-        RedisFastProducer,
-    )
+    from faststream.redis.publisher.producer import RedisFastProducer
 
     from .state import ConnectionState
 
 
 @dataclass(kw_only=True)
 class RedisBrokerConfig(BrokerConfig):
-    producer: "RedisFastProducer | RedisClusterFastProducer"
+    producer: "RedisFastProducer"
     connection: "ConnectionState[Redis[bytes]] | ConnectionState[RedisCluster[bytes]]"
 
     message_format: type["MessageFormat"]

--- a/faststream/redis/configs/state.py
+++ b/faststream/redis/configs/state.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from contextlib import suppress
 from typing import Any, Generic, TypeVar
 
 from redis.asyncio.client import Redis
@@ -10,7 +9,7 @@ from redis.asyncio.sentinel import Sentinel
 
 from faststream.__about__ import __version__
 from faststream.exceptions import IncorrectState
-from faststream.redis._compat import REDIS_V720
+from faststream.redis._compat import REDIS_V720, REDIS_V800
 
 if REDIS_V720:
     from redis.driver_info import DriverInfo
@@ -34,7 +33,7 @@ def _get_driver_info() -> dict[str, Any]:
 
 
 def _ensure_cluster_pubsub_supported() -> None:
-    if not (hasattr(RedisCluster, "publish") and hasattr(RedisCluster, "pubsub")):
+    if not REDIS_V800:
         msg = (
             "RedisClusterBroker requires redis-py >= 8.0.0 for native async "
             "publish and pubsub support."
@@ -135,21 +134,17 @@ class RedisClusterConnectionState(ConnectionState["RedisCluster[bytes]"]):
 
     async def connect(self) -> "RedisCluster[bytes]":
         if self._connected:
-            return self._client  # type: ignore[return-value]
+            return self.client
 
         _ensure_cluster_pubsub_supported()
 
         connection_kwargs = {k: v for k, v in self._options.items() if v is not None}
+        # Keep parser-facing replies RESP2-shaped across redis-py 8 (see issue #3009).
         connection_kwargs.setdefault("legacy_responses", True)
         connection_kwargs |= _get_driver_info()
 
         client: RedisCluster[bytes] = RedisCluster(**connection_kwargs)
-        try:
-            await client.initialize()
-        except BaseException:
-            with suppress(Exception):
-                await client.aclose()  # type: ignore[attr-defined]
-            raise
+        await client.initialize()
 
         self._client = client
         self._connected = True

--- a/faststream/redis/configs/state.py
+++ b/faststream/redis/configs/state.py
@@ -1,20 +1,14 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor
-from functools import partial
+from contextlib import suppress
 from typing import Any, Generic, TypeVar
 
 from redis.asyncio.client import Redis
 from redis.asyncio.cluster import RedisCluster
 from redis.asyncio.connection import ConnectionPool
 from redis.asyncio.sentinel import Sentinel
-from redis.cluster import (
-    ClusterNode,
-    RedisCluster as SyncRC,
-)
 
 from faststream.__about__ import __version__
-from faststream._internal.utils.functions import run_in_executor
 from faststream.exceptions import IncorrectState
 from faststream.redis._compat import REDIS_V720
 
@@ -39,6 +33,15 @@ def _get_driver_info() -> dict[str, Any]:
     }
 
 
+def _ensure_cluster_pubsub_supported() -> None:
+    if not (hasattr(RedisCluster, "publish") and hasattr(RedisCluster, "pubsub")):
+        msg = (
+            "RedisClusterBroker requires redis-py >= 8.0.0 for native async "
+            "publish and pubsub support."
+        )
+        raise IncorrectState(msg)
+
+
 class ConnectionState(ABC, Generic[ClientT]):
     """Base connection state."""
 
@@ -47,8 +50,6 @@ class ConnectionState(ABC, Generic[ClientT]):
 
         self._connected = False
         self._client: ClientT | None = None
-        self._sync_cluster: Any = None
-        self._thread_pool: Any = None
 
     @property
     def client(self) -> ClientT:
@@ -130,129 +131,26 @@ class RedisSentinelConnectionState(RedisConnectionState):
 
 
 class RedisClusterConnectionState(ConnectionState["RedisCluster[bytes]"]):
-    """Manages a Redis Cluster connection lifecycle.
-
-    Uses an **async** ``RedisCluster`` for List/Stream/KV commands and a
-    **sync** ``redis.cluster.RedisCluster`` (wrapped via
-    ``run_in_executor``) for Pub/Sub — the async client doesn't expose
-    ``publish`` / ``pubsub`` until ``redis-py >= 8.0.0``.
-    """
-
-    def __init__(self, options: dict[str, Any] | None = None) -> None:
-        self._options = options or {}
-
-        self._connected = False
-        self._client: RedisCluster[bytes] | None = None
-        self._sync_cluster: Any = None
-        self._thread_pool: ThreadPoolExecutor | None = None
-
-    @property
-    def client(self) -> "RedisCluster[bytes]":
-        if not self._client:
-            msg = "Connection is not available yet. Please, connect the broker first."
-            raise IncorrectState(msg)
-        return self._client
-
-    def __bool__(self) -> bool:
-        return self._connected
+    """Manages a Redis Cluster connection using its native async client."""
 
     async def connect(self) -> "RedisCluster[bytes]":
         if self._connected:
             return self._client  # type: ignore[return-value]
 
+        _ensure_cluster_pubsub_supported()
+
         connection_kwargs = {k: v for k, v in self._options.items() if v is not None}
+        connection_kwargs.setdefault("legacy_responses", True)
         connection_kwargs |= _get_driver_info()
 
         client: RedisCluster[bytes] = RedisCluster(**connection_kwargs)
+        try:
+            await client.initialize()
+        except BaseException:
+            with suppress(Exception):
+                await client.aclose()  # type: ignore[attr-defined]
+            raise
+
         self._client = client
         self._connected = True
         return client
-
-    async def disconnect(self) -> None:
-        if self._thread_pool is not None:
-            self._thread_pool.shutdown(wait=False)
-            self._thread_pool = None
-            self._sync_cluster = None
-        if self._client:
-            await self._client.aclose()  # type: ignore[attr-defined]
-        self._client = None
-        self._connected = False
-
-    async def sync_publish(self, channel: str, body: bytes) -> int:
-        sync = self._get_sync_cluster()
-        return await run_in_executor(self._thread_pool, sync.publish, channel, body)
-
-    def pubsub(self) -> "_SyncPubSubProxy":
-        if self._thread_pool is not None:
-            pool = self._thread_pool
-        elif self._client is not None:
-            # Test mode: store the pool so disconnect() cleans it up
-            pool = self._thread_pool = ThreadPoolExecutor(max_workers=1)
-        else:
-            msg = "Pub/Sub proxy is not available"
-            raise IncorrectState(msg)
-
-        sync = self._get_sync_cluster()
-        return _SyncPubSubProxy(sync, pool)
-
-    def _get_sync_cluster(self) -> Any:
-        if self._sync_cluster is not None:
-            return self._sync_cluster
-
-        # Test mode: _client set by _fake_connect, _connected stays False
-        if not self._connected and self._client is not None:
-            return self._client
-
-        raw = self._options
-        nodes = [ClusterNode(n.host, n.port) for n in raw.get("startup_nodes", [])]
-        if not nodes:
-            host = raw.get("host", "127.0.0.1")
-            port = int(raw.get("port", 6379))
-            nodes.append(ClusterNode(host, port))
-
-        self._sync_cluster = SyncRC(
-            startup_nodes=nodes,
-            password=raw.get("password"),
-            username=raw.get("username"),
-            ssl=raw.get("ssl", False),
-            socket_timeout=raw.get("socket_timeout"),
-            socket_connect_timeout=raw.get("socket_connect_timeout"),
-        )
-        self._thread_pool = ThreadPoolExecutor(max_workers=4)
-        return self._sync_cluster
-
-
-class _SyncPubSubProxy:
-    """Wraps a **sync** ``redis.cluster.RedisCluster.pubsub()`` for async use.
-
-    ``redis-py``'s async ``RedisCluster`` lacks ``publish`` / ``pubsub``
-    until version 8.0.0.  We use the sync client via a
-    ``ThreadPoolExecutor`` (following the same pattern as the Confluent
-    adapter) so Pub/Sub works with ``redis-py >= 7.4.0``.
-    """
-
-    def __init__(self, sync_cluster: Any, pool: ThreadPoolExecutor) -> None:
-        self._pool = pool
-        self._psub = sync_cluster.pubsub()
-
-    async def subscribe(self, channel: str) -> None:
-        await run_in_executor(self._pool, self._psub.subscribe, channel)
-
-    async def psubscribe(self, pattern: str) -> None:
-        await run_in_executor(self._pool, self._psub.psubscribe, pattern)
-
-    async def unsubscribe(self) -> None:
-        await run_in_executor(self._pool, self._psub.unsubscribe)
-
-    async def get_message(
-        self,
-        ignore_subscribe_messages: bool = False,
-        timeout: float | None = 0.0,
-    ) -> Any:
-        return await run_in_executor(
-            self._pool,
-            partial(self._psub.get_message, ignore_subscribe_messages, timeout),
-        )
-
-    async def aclose(self) -> None:
-        await run_in_executor(self._pool, self._psub.close)

--- a/faststream/redis/exceptions.py
+++ b/faststream/redis/exceptions.py
@@ -8,12 +8,3 @@ class StreamGroupNotFoundError(FastStreamException):
     deletion of the stream/group.  The subscriber cannot proceed and
     must be restarted to recreate the group.
     """
-
-
-class UnreachablePathError(FastStreamException):
-    """Raised when an allegedly unreachable code path is hit."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            "This code path should never be reached — it indicates a logic bug."
-        )

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -8,16 +8,12 @@ from faststream._internal.endpoint.utils import ParserComposition
 from faststream._internal.parser import DefaultCodec
 from faststream._internal.producer import ProducerProto
 from faststream._internal.utils.nuid import NUID
-from faststream.redis.configs.state import RedisClusterConnectionState
-from faststream.redis.exceptions import UnreachablePathError
 from faststream.redis.message import DATA_KEY
 from faststream.redis.parser import RedisPubSubParser, SimpleParserConfig
 from faststream.redis.response import DestinationType, RedisPublishCommand
 
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
-    from redis.asyncio.client import Redis
-    from redis.asyncio.cluster import RedisCluster
 
     from faststream._internal.parser import CodecProto
     from faststream._internal.types import CustomCallable
@@ -81,20 +77,16 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         if codec is not None:
             self.codec = codec
 
-    def _build_child(
-        self, **kwargs: Any
-    ) -> "RedisFastProducer | RedisClusterFastProducer":
+    def _build_child(self, **kwargs: Any) -> "RedisFastProducer":
         return self.__class__(**kwargs)  # type: ignore[return-value]
 
 
 class RedisFastProducer(BaseRedisFastProducer):
-    """Producer for a single-node Redis."""
-
-    _connection: "ConnectionState[Redis[bytes]]"
+    """Producer for standalone and clustered Redis clients."""
 
     def __init__(
         self,
-        connection: "ConnectionState[Redis[bytes]]",
+        connection: "ConnectionState[Any]",
         parser: Optional["CustomCallable"],
         decoder: Optional["CustomCallable"],
         message_format: type["MessageFormat"],
@@ -129,10 +121,10 @@ class RedisFastProducer(BaseRedisFastProducer):
         connection = cmd.pipeline or self._connection.client
 
         if cmd.destination_type is DestinationType.Channel:
-            return await connection.publish(cmd.destination, msg)
+            return cast("int", await connection.publish(cmd.destination, msg))
 
         if cmd.destination_type is DestinationType.List:
-            return await connection.rpush(cmd.destination, msg)
+            return cast("int", await connection.rpush(cmd.destination, msg))
 
         if cmd.destination_type is DestinationType.Stream:
             return cast(
@@ -175,106 +167,6 @@ class RedisFastProducer(BaseRedisFastProducer):
                 )
 
                 # get real response
-                response_msg = await psub.get_message(
-                    ignore_subscribe_messages=True,
-                    timeout=cmd.timeout or 0.0,
-                )
-
-            if scope.cancel_called:
-                raise TimeoutError
-
-            return response_msg
-
-        finally:
-            with suppress(Exception):
-                await psub.unsubscribe()
-                await psub.aclose()  # type: ignore[attr-defined]
-
-
-class RedisClusterFastProducer(BaseRedisFastProducer):
-    """Producer that routes channel operations through the sync cluster."""
-
-    def __init__(
-        self,
-        connection: "ConnectionState[RedisCluster[bytes]]",
-        cluster_state: RedisClusterConnectionState,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(connection=connection, **kwargs)
-        self._cluster_state = cluster_state
-
-    @property
-    def cluster_state(self) -> RedisClusterConnectionState:
-        return self._cluster_state
-
-    @override
-    def _build_child(self, **kwargs: Any) -> "RedisClusterFastProducer":
-        return RedisClusterFastProducer(cluster_state=self._cluster_state, **kwargs)
-
-    @override
-    async def publish(self, cmd: "RedisPublishCommand") -> int | bytes:
-        msg = await cmd.message_format.encode(
-            message=cmd.body,
-            reply_to=cmd.reply_to,
-            headers=cmd.headers,
-            correlation_id=cmd.correlation_id or "",
-            serializer=self.serializer,
-            codec=self.codec,
-        )
-
-        if cmd.destination_type is DestinationType.Channel:
-            return await self._cluster_state.sync_publish(cmd.destination, msg)
-
-        if cmd.destination_type is DestinationType.List:
-            return cast("int", await self._connection.client.rpush(cmd.destination, msg))
-        if cmd.destination_type is DestinationType.Stream:
-            return cast(
-                "bytes",
-                await self._connection.client.xadd(
-                    name=cmd.destination,
-                    fields={DATA_KEY: msg},
-                    maxlen=cmd.maxlen,
-                ),
-            )
-        raise UnreachablePathError
-
-    @override
-    async def request(self, cmd: "RedisPublishCommand") -> "Any":
-        nuid = NUID()
-        reply_to = str(nuid.next(), "utf-8")
-        psub = self._cluster_state.pubsub()
-
-        try:
-            await psub.subscribe(reply_to)
-
-            msg = await cmd.message_format.encode(
-                message=cmd.body,
-                reply_to=reply_to,
-                headers=cmd.headers,
-                correlation_id=cmd.correlation_id or "",
-                serializer=self.serializer,
-                codec=self.codec,
-            )
-
-            if cmd.destination_type is DestinationType.Channel:
-                await self._cluster_state.sync_publish(cmd.destination, msg)
-            elif cmd.destination_type is DestinationType.List:
-                await self._connection.client.rpush(cmd.destination, msg)
-            elif cmd.destination_type is DestinationType.Stream:
-                await self._connection.client.xadd(
-                    name=cmd.destination,
-                    fields={DATA_KEY: msg},
-                    maxlen=cmd.maxlen,
-                )
-            else:
-                raise UnreachablePathError
-
-            with anyio.fail_after(cmd.timeout) as scope:
-                await psub.get_message(
-                    ignore_subscribe_messages=True,
-                    timeout=cmd.timeout or 0.0,
-                )
-
                 response_msg = await psub.get_message(
                     ignore_subscribe_messages=True,
                     timeout=cmd.timeout or 0.0,

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -14,6 +14,8 @@ from faststream.redis.response import DestinationType, RedisPublishCommand
 
 if TYPE_CHECKING:
     from fast_depends.library.serializer import SerializerProto
+    from redis.asyncio.client import Redis
+    from redis.asyncio.cluster import RedisCluster
 
     from faststream._internal.parser import CodecProto
     from faststream._internal.types import CustomCallable
@@ -84,9 +86,11 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
 class RedisFastProducer(BaseRedisFastProducer):
     """Producer for standalone and clustered Redis clients."""
 
+    _connection: "ConnectionState[Redis[bytes] | RedisCluster[bytes]]"
+
     def __init__(
         self,
-        connection: "ConnectionState[Any]",
+        connection: "ConnectionState[Redis[bytes] | RedisCluster[bytes]]",
         parser: Optional["CustomCallable"],
         decoder: Optional["CustomCallable"],
         message_format: type["MessageFormat"],
@@ -118,13 +122,14 @@ class RedisFastProducer(BaseRedisFastProducer):
         msg: bytes,
         cmd: "RedisPublishCommand",
     ) -> int | bytes:
-        connection = cmd.pipeline or self._connection.client
+        # RedisCluster exposes the Redis command API dynamically, outside its stubs.
+        connection = cast("Redis[bytes]", cmd.pipeline or self._connection.client)
 
         if cmd.destination_type is DestinationType.Channel:
-            return cast("int", await connection.publish(cmd.destination, msg))
+            return await connection.publish(cmd.destination, msg)
 
         if cmd.destination_type is DestinationType.List:
-            return cast("int", await connection.rpush(cmd.destination, msg))
+            return await connection.rpush(cmd.destination, msg)
 
         if cmd.destination_type is DestinationType.Stream:
             return cast(
@@ -143,7 +148,7 @@ class RedisFastProducer(BaseRedisFastProducer):
     async def request(self, cmd: "RedisPublishCommand") -> "Any":
         nuid = NUID()
         reply_to = str(nuid.next(), "utf-8")
-        psub = self._connection.client.pubsub()
+        psub = cast("Redis[bytes]", self._connection.client).pubsub()
 
         try:
             await psub.subscribe(reply_to)
@@ -180,4 +185,4 @@ class RedisFastProducer(BaseRedisFastProducer):
         finally:
             with suppress(Exception):
                 await psub.unsubscribe()
-                await psub.aclose()
+                await psub.aclose()  # type: ignore[attr-defined]

--- a/faststream/redis/schemas/types.py
+++ b/faststream/redis/schemas/types.py
@@ -6,6 +6,7 @@ from fast_depends.dependencies import Dependant
 from fast_depends.library.serializer import SerializerProto
 from redis.asyncio.connection import BaseParser, Connection, Encoder
 from redis.asyncio.retry import Retry
+from redis.credentials import CredentialProvider
 from typing_extensions import Required, TypedDict
 
 from faststream._internal.basic_types import LoggerProto
@@ -33,6 +34,10 @@ class RedisConnectionParams(TypedDict, total=False):
         type[Connection], "Connection class. Defaults to ``EMPTY``."
     ]
     client_name: Annotated[str | None, "Redis client name. Defaults to ``None``."]
+    credential_provider: Annotated[
+        CredentialProvider | None,
+        "Credential provider for dynamic authentication. Defaults to ``None``.",
+    ]
     health_check_interval: Annotated[float, "Health check interval. Defaults to ``0``."]
     max_connections: Annotated[
         int | None, "Max connections in pool. Defaults to ``None``."

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -1,7 +1,6 @@
 import re
 import uuid
 from collections.abc import AsyncGenerator, Generator, Iterable, Iterator, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import ExitStack, asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from functools import partial
@@ -218,8 +217,6 @@ class TestRedisBroker(TestBroker[RedisBroker, EnterType]):
 
         connection_state = broker.config.broker_config.connection
         connection_state._client = connection
-        connection_state._sync_cluster = MagicMock()
-        connection_state._thread_pool = ThreadPoolExecutor(max_workers=1)
         connection_state._connected = True
         return connection
 

--- a/tests/brokers/redis/cluster/test_cluster.py
+++ b/tests/brokers/redis/cluster/test_cluster.py
@@ -1,9 +1,11 @@
 import ssl
 import warnings
+from unittest.mock import AsyncMock
 
 import pytest
 
 from faststream.redis import RedisClusterBroker, RedisRouter
+from faststream.redis.configs import state as state_module
 from faststream.security import BaseSecurity, SASLPlaintext
 
 pytestmark = pytest.mark.redis_cluster
@@ -245,8 +247,11 @@ class TestClusterBrokerInheritance:
         broker = RedisClusterBroker()
         assert isinstance(broker.config, ConfigComposition)
 
-    def test_start_stop_lifecycle(self) -> None:
+    def test_start_stop_lifecycle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import anyio
+
+        initialize = AsyncMock()
+        monkeypatch.setattr(state_module.RedisCluster, "initialize", initialize)
 
         async def test() -> None:
             broker = RedisClusterBroker()
@@ -257,6 +262,7 @@ class TestClusterBrokerInheritance:
             assert broker._connection is None
 
         anyio.run(test)
+        initialize.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/brokers/redis/cluster/test_cluster.py
+++ b/tests/brokers/redis/cluster/test_cluster.py
@@ -1,12 +1,12 @@
 import ssl
 import warnings
-from unittest.mock import AsyncMock
 
 import pytest
 
 from faststream.redis import RedisClusterBroker, RedisRouter
 from faststream.redis.configs import state as state_module
 from faststream.security import BaseSecurity, SASLPlaintext
+from tests.tools import spy_decorator
 
 pytestmark = pytest.mark.redis_cluster
 
@@ -247,14 +247,15 @@ class TestClusterBrokerInheritance:
         broker = RedisClusterBroker()
         assert isinstance(broker.config, ConfigComposition)
 
+    @pytest.mark.connected()
     def test_start_stop_lifecycle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import anyio
 
-        initialize = AsyncMock()
+        initialize = spy_decorator(state_module.RedisCluster.initialize)
         monkeypatch.setattr(state_module.RedisCluster, "initialize", initialize)
 
         async def test() -> None:
-            broker = RedisClusterBroker()
+            broker = RedisClusterBroker("redis://127.0.0.1:7001")
             assert broker._connection is None
             await broker.start()
             assert broker._connection is not None
@@ -262,7 +263,7 @@ class TestClusterBrokerInheritance:
             assert broker._connection is None
 
         anyio.run(test)
-        initialize.assert_awaited_once()
+        initialize.mock.assert_awaited_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/brokers/redis/cluster/test_cluster_connect.py
+++ b/tests/brokers/redis/cluster/test_cluster_connect.py
@@ -300,12 +300,7 @@ class TestClusterPubSub:
         settings_cluster: SettingsCluster,
         event: asyncio.Event,
     ) -> None:
-        """Pub/Sub via sync cluster wrapper."""
-        from redis.cluster import RedisCluster as _SyncRC
-
-        if not hasattr(_SyncRC, "publish"):
-            pytest.skip("sync cluster pubsub not available")
-
+        """Pub/Sub via the native async cluster client."""
         broker = RedisClusterBroker(
             url=settings_cluster.url,
             startup_nodes=settings_cluster.startup_nodes,
@@ -326,5 +321,3 @@ class TestClusterPubSub:
             )
 
         assert received == ["hello"]
-        # a future redis-py version fixes this the test can be written
-        # analogously to test_publish_subscribe with `sharded=True`.

--- a/tests/brokers/redis/cluster/test_cluster_more_unit.py
+++ b/tests/brokers/redis/cluster/test_cluster_more_unit.py
@@ -215,11 +215,28 @@ class TestClusterBrokerWarnings:
     """Tests for RuntimeWarning on pipeline usage."""
 
     @pytest.mark.asyncio()
-    async def test_publish_with_pipeline_warns(self) -> None:
+    async def test_publish_with_pipeline_warns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         broker = RedisClusterBroker(url="redis://127.0.0.1:7001")
-        async with TestRedisBroker(broker) as br:
-            with pytest.warns(RuntimeWarning, match="Pipeline is not supported"):
-                await br.publish("hello", channel="ch", pipeline=None)
+        client = MagicMock()
+        client.publish = AsyncMock(return_value=1)
+
+        async def connect() -> MagicMock:
+            broker._cluster_state._client = client
+            broker._cluster_state._connected = True
+            return client
+
+        connect_mock = AsyncMock(side_effect=connect)
+        monkeypatch.setattr(broker, "_connect", connect_mock)
+
+        with pytest.warns(RuntimeWarning, match="Pipeline is not supported"):
+            result = await broker.publish("hello", channel="ch", pipeline=None)
+
+        assert result == 1
+        connect_mock.assert_awaited_once_with()
+        client.publish.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_publish_batch_with_pipeline_warns(self) -> None:

--- a/tests/brokers/redis/cluster/test_cluster_more_unit.py
+++ b/tests/brokers/redis/cluster/test_cluster_more_unit.py
@@ -1,21 +1,37 @@
-from concurrent.futures import ThreadPoolExecutor
+from importlib.metadata import version
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import anyio
 import pytest
+from redis.credentials import CredentialProvider
 
+from faststream.exceptions import IncorrectState
 from faststream.redis import RedisClusterBroker, RedisRouter, TestRedisBroker
-from faststream.redis.configs import ConnectionState, RedisConnectionState
-from faststream.redis.configs.state import RedisClusterConnectionState
-from faststream.redis.exceptions import UnreachablePathError
-from faststream.redis.parser import BinaryMessageFormatV1
-from faststream.redis.publisher.producer import (
-    RedisClusterFastProducer,
-    RedisFastProducer,
+from faststream.redis._compat import REDIS_V720
+from faststream.redis.configs import (
+    ConnectionState,
+    RedisConnectionState,
+    state as state_module,
 )
+from faststream.redis.configs.state import RedisClusterConnectionState
+from faststream.redis.parser import BinaryMessageFormatV1
+from faststream.redis.publisher.producer import RedisFastProducer
 from faststream.redis.response import RedisPublishCommand
 from faststream.response.publish_type import PublishType
+
+
+def test_redis_v720_uses_lexicographic_version_comparison() -> None:
+    major, minor, *_ = version("redis").split(".")
+    assert REDIS_V720 is ((int(major), int(minor)) >= (7, 2))
+
+
+def test_driver_info_avoids_deprecated_kwargs() -> None:
+    kwargs = state_module._get_driver_info()
+    if REDIS_V720:
+        assert set(kwargs) == {"driver_info"}
+    else:
+        assert set(kwargs) == {"lib_name", "lib_version"}
 
 
 class TestRedisClusterConnectionStateUnit:
@@ -35,12 +51,164 @@ class TestRedisClusterConnectionStateUnit:
         state = RedisClusterConnectionState(opts)
         assert state._options == opts
 
-    def test_get_sync_cluster_creates_once(self) -> None:
-        state = RedisClusterConnectionState({"host": "127.0.0.1", "port": 7000})
-        # We can't actually connect, but we can verify the method shape
-        # by checking that _sync_cluster starts as None
-        assert state._sync_cluster is None
-        assert state._thread_pool is None
+    def test_bool_reflects_connected(self) -> None:
+        state = RedisClusterConnectionState()
+        assert not state
+        state._connected = True
+        assert state
+
+
+class TestRedisClusterConnectionStateConnect:
+    @pytest.mark.asyncio()
+    @pytest.mark.parametrize("available_method", ("publish", "pubsub"))
+    async def test_native_pubsub_guard_runs_before_client_construction(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        available_method: str,
+    ) -> None:
+        constructed = False
+
+        class IncompatibleCluster:
+            def __init__(self, **kwargs: object) -> None:
+                nonlocal constructed
+                constructed = True
+
+        setattr(IncompatibleCluster, available_method, lambda self: None)
+        monkeypatch.setattr(state_module, "RedisCluster", IncompatibleCluster)
+        get_driver_info = MagicMock()
+        monkeypatch.setattr(state_module, "_get_driver_info", get_driver_info)
+
+        state = RedisClusterConnectionState()
+        with pytest.raises(IncorrectState, match=r"redis-py >= 8\.0\.0"):
+            await state.connect()
+
+        assert not constructed
+        get_driver_info.assert_not_called()
+        assert state._client is None
+        assert not state
+
+    @pytest.mark.asyncio()
+    async def test_connect_passes_native_client_options(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+        initialized = False
+
+        class NativeCluster:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+            async def publish(self) -> None: ...
+
+            def pubsub(self) -> None: ...
+
+            async def initialize(self) -> None:
+                nonlocal initialized
+                initialized = True
+
+        driver_info = object()
+        credential_provider = object()
+        monkeypatch.setattr(state_module, "RedisCluster", NativeCluster)
+        monkeypatch.setattr(
+            state_module,
+            "_get_driver_info",
+            lambda: {"driver_info": driver_info},
+        )
+
+        state = RedisClusterConnectionState({
+            "host": "127.0.0.1",
+            "port": 7000,
+            "credential_provider": credential_provider,
+            "socket_timeout": None,
+        })
+        client = await state.connect()
+
+        assert client is state.client
+        assert captured == {
+            "host": "127.0.0.1",
+            "port": 7000,
+            "credential_provider": credential_provider,
+            "legacy_responses": True,
+            "driver_info": driver_info,
+        }
+        assert "lib_name" not in captured
+        assert "lib_version" not in captured
+        assert initialized
+        assert state
+
+    @pytest.mark.asyncio()
+    async def test_connect_respects_explicit_legacy_responses(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        class NativeCluster:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+            async def publish(self) -> None: ...
+
+            def pubsub(self) -> None: ...
+
+            async def initialize(self) -> None: ...
+
+        monkeypatch.setattr(state_module, "RedisCluster", NativeCluster)
+        monkeypatch.setattr(state_module, "_get_driver_info", dict)
+
+        state = RedisClusterConnectionState({"legacy_responses": False})
+        await state.connect()
+
+        assert captured["legacy_responses"] is False
+
+    @pytest.mark.asyncio()
+    async def test_connect_closes_client_when_initialize_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        closed = False
+
+        class FailingCluster:
+            def __init__(self, **kwargs: object) -> None: ...
+
+            async def publish(self) -> None: ...
+
+            def pubsub(self) -> None: ...
+
+            async def initialize(self) -> None:
+                msg = "cluster discovery failed"
+                raise RuntimeError(msg)
+
+            async def aclose(self) -> None:
+                nonlocal closed
+                closed = True
+
+        monkeypatch.setattr(state_module, "RedisCluster", FailingCluster)
+        monkeypatch.setattr(state_module, "_get_driver_info", dict)
+
+        state = RedisClusterConnectionState()
+        with pytest.raises(RuntimeError, match="cluster discovery failed"):
+            await state.connect()
+
+        assert closed
+        assert state._client is None
+        assert not state
+
+    @pytest.mark.asyncio()
+    async def test_connect_returns_existing_client_without_reconstruction(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        client = MagicMock()
+        state = RedisClusterConnectionState()
+        state._client = client
+        state._connected = True
+        constructor = MagicMock()
+        monkeypatch.setattr(state_module, "RedisCluster", constructor)
+
+        assert await state.connect() is client
+        constructor.assert_not_called()
 
 
 class TestClusterBrokerWarnings:
@@ -85,6 +253,17 @@ class TestClusterBrokerInheritanceExtra:
         )
         nodes = broker.config.broker_config.connection._options.get("startup_nodes", [])
         assert len(nodes) > 1
+
+    def test_credential_provider_reaches_cluster_connection(self) -> None:
+        credential_provider = MagicMock(spec=CredentialProvider)
+        broker = RedisClusterBroker(
+            credential_provider=credential_provider,
+        )
+
+        assert (
+            broker.config.broker_config.connection._options["credential_provider"]
+            is credential_provider
+        )
 
     def test_router_inclusion_works(self) -> None:
         broker = RedisClusterBroker(routers=[RedisRouter()])
@@ -136,31 +315,21 @@ class TestClusterBrokerInheritanceExtra:
         assert len(broker.subscribers) == 1
 
 
-class TestSyncPubSubProxyUnit:
-    """Unit tests for _SyncPubSubProxy."""
-
-    def test_proxy_stores_pubsub_and_pool(self) -> None:
-        """Verify proxy initialises correctly."""
-        pool = ThreadPoolExecutor(max_workers=1)
-        try:
-            # We need a sync cluster to create pubsub, so just verify
-            # the class structure — actual init tested in integration.
-            pass
-        finally:
-            pool.shutdown(wait=False)
-
-
 class TestRedisClusterConnectionStateDisconnect:
     """Tests for disconnect lifecycle."""
 
     @pytest.mark.asyncio()
-    async def test_disconnect_cleans_thread_pool(self) -> None:
+    async def test_disconnect_closes_async_client(self) -> None:
         state = RedisClusterConnectionState({"host": "127.0.0.1", "port": 7000})
-        assert state._thread_pool is None
+        client = AsyncMock()
+        state._client = client
+        state._connected = True
+
         await state.disconnect()
-        assert state._thread_pool is None
-        assert state._sync_cluster is None
+
+        client.aclose.assert_awaited_once()
         assert state._client is None
+        assert not state
 
     @pytest.mark.asyncio()
     async def test_disconnect_before_connect_no_error(self) -> None:
@@ -168,46 +337,42 @@ class TestRedisClusterConnectionStateDisconnect:
         await state.disconnect()  # Should not raise
         assert not bool(state)
 
-    def test_bool_reflects_connected(self) -> None:
-        state = RedisClusterConnectionState()
-        assert not state
-        state._connected = True
-        assert state
 
+class TestClusterNativeProducerUnit:
+    """The cluster broker uses the shared native async producer path."""
 
-class TestClusterFastProducerUnit:
-    """Direct unit tests for RedisClusterFastProducer routing logic."""
+    def test_broker_uses_standard_producer(self) -> None:
+        broker = RedisClusterBroker()
+        assert type(broker.config.broker_config.producer) is RedisFastProducer
 
     @pytest.fixture()
-    def mock_client(self) -> AsyncMock:
-        client = AsyncMock()
+    def mock_client(self) -> MagicMock:
+        client = MagicMock()
+        client.publish = AsyncMock(return_value=1)
         client.rpush = AsyncMock(return_value=1)
         client.xadd = AsyncMock(return_value=b"stream-id")
+        psub = MagicMock()
+        psub.subscribe = AsyncMock()
+        psub.get_message = AsyncMock(side_effect=[None, "resp"])
+        psub.unsubscribe = AsyncMock()
+        psub.aclose = AsyncMock()
+        client.pubsub.return_value = psub
         return client
 
     @pytest.fixture()
-    def mock_connection(self, mock_client: AsyncMock) -> ConnectionState[Any]:
+    def mock_connection(self, mock_client: MagicMock) -> ConnectionState[Any]:
         conn = RedisConnectionState()
         conn._client = mock_client
         conn._connected = True
         return conn
 
     @pytest.fixture()
-    def mock_cluster_state(self) -> AsyncMock:
-        state = AsyncMock(spec=RedisClusterConnectionState)
-        state.sync_publish = AsyncMock(return_value=1)
-        return state
-
-    @pytest.fixture()
     def producer(
         self,
         mock_connection: ConnectionState,
-        mock_cluster_state: AsyncMock,
     ) -> RedisFastProducer:
-
-        return RedisClusterFastProducer(
+        return RedisFastProducer(
             connection=mock_connection,
-            cluster_state=mock_cluster_state,
             parser=None,
             decoder=None,
             message_format=BinaryMessageFormatV1,
@@ -218,7 +383,7 @@ class TestClusterFastProducerUnit:
     async def test_publish_channel(
         self,
         producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
         cmd = RedisPublishCommand(
             b"hello",
@@ -227,13 +392,13 @@ class TestClusterFastProducerUnit:
         )
         result = await producer.publish(cmd)
         assert result == 1
-        mock_cluster_state.sync_publish.assert_awaited_once()
+        mock_client.publish.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_publish_list(
         self,
         producer: RedisFastProducer,
-        mock_client: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
         cmd = RedisPublishCommand(
             b"hello",
@@ -250,7 +415,7 @@ class TestClusterFastProducerUnit:
     async def test_publish_stream(
         self,
         producer: RedisFastProducer,
-        mock_client: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
         cmd = RedisPublishCommand(
             b"hello",
@@ -267,28 +432,22 @@ class TestClusterFastProducerUnit:
         self,
         producer: RedisFastProducer,
     ) -> None:
-        """No matching destination_type → UnreachablePathError."""
         cmd = RedisPublishCommand(
             b"hello",
             channel="ch",
             _publish_type=PublishType.PUBLISH,
         )
         cmd.destination_type = None  # type: ignore[assignment]
-        with pytest.raises(UnreachablePathError):
+        with pytest.raises(AssertionError, match="unreachable"):
             await producer.publish(cmd)
 
     @pytest.mark.asyncio()
     async def test_request_channel(
         self,
         producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
+        psub = mock_client.pubsub.return_value
 
         cmd = RedisPublishCommand(
             b"hello",
@@ -298,21 +457,17 @@ class TestClusterFastProducerUnit:
         )
         result = await producer.request(cmd)
         assert result == "resp"
-        mock_cluster_state.sync_publish.assert_awaited_once()
+        mock_client.publish.assert_awaited_once()
+        psub.unsubscribe.assert_awaited_once()
+        psub.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_request_list(
         self,
         producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-        mock_client: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
+        psub = mock_client.pubsub.return_value
 
         cmd = RedisPublishCommand(
             b"hello",
@@ -323,20 +478,16 @@ class TestClusterFastProducerUnit:
         result = await producer.request(cmd)
         assert result == "resp"
         mock_client.rpush.assert_awaited_once()
+        psub.unsubscribe.assert_awaited_once()
+        psub.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_request_stream(
         self,
         producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
-        mock_client: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
+        psub = mock_client.pubsub.return_value
 
         cmd = RedisPublishCommand(
             b"hello",
@@ -348,24 +499,22 @@ class TestClusterFastProducerUnit:
         result = await producer.request(cmd)
         assert result == "resp"
         mock_client.xadd.assert_awaited_once()
+        psub.unsubscribe.assert_awaited_once()
+        psub.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_request_timeout(
         self,
         producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
         """Timeout inside fail_after raises TimeoutError."""
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
+        psub = mock_client.pubsub.return_value
 
         async def _slow(*args: object, **kwargs: object) -> None:
             await anyio.sleep(10)
 
         psub.get_message = _slow
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
 
         cmd = RedisPublishCommand(
             b"hello",
@@ -375,20 +524,16 @@ class TestClusterFastProducerUnit:
         )
         with pytest.raises(TimeoutError):
             await producer.request(cmd)
+        psub.unsubscribe.assert_awaited_once()
+        psub.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_request_unreachable(
         self,
         producer: RedisFastProducer,
-        mock_cluster_state: AsyncMock,
+        mock_client: MagicMock,
     ) -> None:
-        """No matching destination_type → UnreachablePathError."""
-        psub = AsyncMock()
-        psub.subscribe = AsyncMock()
-        psub.get_message = AsyncMock(side_effect=[None, "resp"])
-        psub.unsubscribe = AsyncMock()
-        psub.aclose = AsyncMock()
-        mock_cluster_state.pubsub.return_value = psub
+        psub = mock_client.pubsub.return_value
 
         cmd = RedisPublishCommand(
             b"hello",
@@ -397,8 +542,10 @@ class TestClusterFastProducerUnit:
             _publish_type=PublishType.REQUEST,
         )
         cmd.destination_type = None  # type: ignore[assignment]
-        with pytest.raises(UnreachablePathError):
+        with pytest.raises(AssertionError, match="unreachable"):
             await producer.request(cmd)
+        psub.unsubscribe.assert_awaited_once()
+        psub.aclose.assert_awaited_once()
 
 
 class TestClusterBrokerPing:

--- a/tests/brokers/redis/cluster/test_cluster_more_unit.py
+++ b/tests/brokers/redis/cluster/test_cluster_more_unit.py
@@ -8,7 +8,7 @@ from redis.credentials import CredentialProvider
 
 from faststream.exceptions import IncorrectState
 from faststream.redis import RedisClusterBroker, RedisRouter, TestRedisBroker
-from faststream.redis._compat import REDIS_V720
+from faststream.redis._compat import REDIS_V720, REDIS_V800
 from faststream.redis.configs import (
     ConnectionState,
     RedisConnectionState,
@@ -21,9 +21,11 @@ from faststream.redis.response import RedisPublishCommand
 from faststream.response.publish_type import PublishType
 
 
-def test_redis_v720_uses_lexicographic_version_comparison() -> None:
+def test_redis_version_flags_use_lexicographic_comparison() -> None:
     major, minor, *_ = version("redis").split(".")
-    assert REDIS_V720 is ((int(major), int(minor)) >= (7, 2))
+    redis_version = (int(major), int(minor))
+    assert REDIS_V720 is (redis_version >= (7, 2))
+    assert REDIS_V800 is (redis_version >= (8, 0))
 
 
 def test_driver_info_avoids_deprecated_kwargs() -> None:
@@ -60,11 +62,9 @@ class TestRedisClusterConnectionStateUnit:
 
 class TestRedisClusterConnectionStateConnect:
     @pytest.mark.asyncio()
-    @pytest.mark.parametrize("available_method", ("publish", "pubsub"))
-    async def test_native_pubsub_guard_runs_before_client_construction(
+    async def test_redis8_guard_runs_before_client_construction(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        available_method: str,
     ) -> None:
         constructed = False
 
@@ -73,7 +73,7 @@ class TestRedisClusterConnectionStateConnect:
                 nonlocal constructed
                 constructed = True
 
-        setattr(IncompatibleCluster, available_method, lambda self: None)
+        monkeypatch.setattr(state_module, "REDIS_V800", False)
         monkeypatch.setattr(state_module, "RedisCluster", IncompatibleCluster)
         get_driver_info = MagicMock()
         monkeypatch.setattr(state_module, "_get_driver_info", get_driver_info)
@@ -163,7 +163,7 @@ class TestRedisClusterConnectionStateConnect:
         assert captured["legacy_responses"] is False
 
     @pytest.mark.asyncio()
-    async def test_connect_closes_client_when_initialize_fails(
+    async def test_initialize_failure_leaves_state_disconnected(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -191,7 +191,8 @@ class TestRedisClusterConnectionStateConnect:
         with pytest.raises(RuntimeError, match="cluster discovery failed"):
             await state.connect()
 
-        assert closed
+        # RedisCluster.initialize closes partially opened node pools before re-raising.
+        assert not closed
         assert state._client is None
         assert not state
 

--- a/tests/brokers/redis/cluster/test_cluster_test_client.py
+++ b/tests/brokers/redis/cluster/test_cluster_test_client.py
@@ -1,6 +1,9 @@
+from unittest.mock import AsyncMock
+
 import pytest
 
 from faststream.redis import ListSub, StreamSub
+from faststream.redis.configs import state as state_module
 from faststream.redis.testing import FakeProducer
 from tests.brokers.base.testclient import BrokerTestclientTestcase
 from tests.brokers.redis.basic import RedisClusterMemoryTestcaseConfig
@@ -18,8 +21,19 @@ class TestClusterTestClient(RedisClusterMemoryTestcaseConfig, BrokerTestclientTe
     ) -> None:
         await super().test_broker_with_real_patches_publishers_and_subscribers(queue)
 
-    async def test_broker_gets_patched_attrs_within_cm(self) -> None:
+    async def test_broker_gets_patched_attrs_within_cm(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        initialize = AsyncMock()
+        monkeypatch.setattr(state_module.RedisCluster, "initialize", initialize)
+
         await super().test_broker_gets_patched_attrs_within_cm(FakeProducer)
+        initialize.assert_awaited_once()
+
+    @pytest.mark.connected()
+    async def test_broker_with_real_doesnt_get_patched(self) -> None:
+        await super().test_broker_with_real_doesnt_get_patched()
 
     async def test_pub_sub_pattern(self) -> None:
         broker = self.get_broker()

--- a/tests/brokers/redis/cluster/test_cluster_test_client.py
+++ b/tests/brokers/redis/cluster/test_cluster_test_client.py
@@ -1,5 +1,3 @@
-from unittest.mock import AsyncMock
-
 import pytest
 
 from faststream.redis import ListSub, StreamSub
@@ -7,6 +5,7 @@ from faststream.redis.configs import state as state_module
 from faststream.redis.testing import FakeProducer
 from tests.brokers.base.testclient import BrokerTestclientTestcase
 from tests.brokers.redis.basic import RedisClusterMemoryTestcaseConfig
+from tests.tools import spy_decorator
 
 
 @pytest.mark.redis_cluster()
@@ -21,15 +20,16 @@ class TestClusterTestClient(RedisClusterMemoryTestcaseConfig, BrokerTestclientTe
     ) -> None:
         await super().test_broker_with_real_patches_publishers_and_subscribers(queue)
 
+    @pytest.mark.connected()
     async def test_broker_gets_patched_attrs_within_cm(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        initialize = AsyncMock()
+        initialize = spy_decorator(state_module.RedisCluster.initialize)
         monkeypatch.setattr(state_module.RedisCluster, "initialize", initialize)
 
         await super().test_broker_gets_patched_attrs_within_cm(FakeProducer)
-        initialize.assert_awaited_once()
+        initialize.mock.assert_awaited_once()
 
     @pytest.mark.connected()
     async def test_broker_with_real_doesnt_get_patched(self) -> None:

--- a/tests/mypy/redis.py
+++ b/tests/mypy/redis.py
@@ -1,4 +1,5 @@
 from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, cast
 
 import prometheus_client
 from typing_extensions import assert_type
@@ -10,6 +11,7 @@ from faststream.redis import (
     Redis,
     RedisBroker,
     RedisChannelMessage,
+    RedisClusterBroker,
     RedisListMessage,
     RedisMessage as Message,
     RedisPublisher,
@@ -38,6 +40,13 @@ from faststream.redis.subscriber.usecases import (
     StreamBatchSubscriber,
     StreamConcurrentSubscriber,
     StreamSubscriber,
+)
+
+if TYPE_CHECKING:
+    from redis.credentials import CredentialProvider
+
+RedisClusterBroker(
+    credential_provider=cast("CredentialProvider", object()),
 )
 
 


### PR DESCRIPTION
## Summary

- replace the synchronous Redis Cluster Pub/Sub client and thread-pool proxy with redis-py 8's native async cluster API
- reuse the standard Redis producer and channel subscriber for standalone and clustered Redis
- initialize the cluster client before exposing it so channel-only applications start with a populated slot cache, and close partially initialized clients on failure
- keep the package-wide `redis>=5,<9` range while rejecting cluster connections before client construction when native async Pub/Sub is unavailable
- preserve RESP2-shaped responses, forward and type `credential_provider`, and fix DriverInfo selection across redis-py major versions

## Compatibility

`RedisClusterBroker` now requires redis-py 8.0.0 or newer at connection time. Standalone and Sentinel users retain the existing redis-py 5 floor. Regular Pub/Sub is supported; sharded Pub/Sub remains out of scope.

## Validation

- Redis non-connected suite: 386 passed, 6 skipped, 1 xfailed
- Ruff format/check, codespell, Mypy (516 files), and Pyright
- Bandit and Semgrep (0 findings)
- full MkDocs build
- isolated compatibility probes on redis-py 5.3.1, 7.4.0, 8.0.0, and 8.0.1

The connected Redis Cluster suite was not run locally because no cluster runtime was available; the existing CI suite covers regular Pub/Sub, pattern Pub/Sub, request/reply, cleanup, and restart behavior.

Builds on the direction and prior investigation in #2893. Thanks to @fbartonoctopus for identifying the credential-provider gap.

Fixes #3009