### PR TITLE
fix(rabbit): validate cached declarations

### DIFF
--- a/faststream/rabbit/helpers/declarer.py
+++ b/faststream/rabbit/helpers/declarer.py
@@ -1,6 +1,8 @@
-from typing import TYPE_CHECKING, Optional, Protocol, cast
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Optional, Protocol, cast
 
 from faststream._internal.constants import EMPTY
+from faststream.exceptions import SetupError
 
 if TYPE_CHECKING:
     import aio_pika
@@ -8,6 +10,41 @@ if TYPE_CHECKING:
     from faststream.rabbit.schemas import Channel, RabbitExchange, RabbitQueue
 
     from .channel_manager import ChannelManager
+
+
+def _queue_declaration(queue: "RabbitQueue") -> dict[str, Any]:
+    return {
+        "durable": queue.durable,
+        "exclusive": queue.exclusive,
+        "auto_delete": queue.auto_delete,
+        "arguments": deepcopy(queue.arguments or {}),
+    }
+
+
+def _exchange_declaration(exchange: "RabbitExchange") -> dict[str, Any]:
+    return {
+        "type": exchange.type,
+        "durable": exchange.durable,
+        "auto_delete": exchange.auto_delete,
+        "arguments": deepcopy(exchange.arguments or {}),
+    }
+
+
+def _validate_declaration(
+    object_type: str,
+    name: str,
+    previous: dict[str, Any],
+    current: dict[str, Any],
+) -> None:
+    conflicting = tuple(
+        setting for setting, value in current.items() if previous[setting] != value
+    )
+    if conflicting:
+        msg = (
+            f"{object_type} {name!r} is already declared with conflicting settings: "
+            f"{', '.join(conflicting)}."
+        )
+        raise SetupError(msg)
 
 
 class RabbitDeclarer(Protocol):
@@ -64,8 +101,14 @@ class RabbitDeclarerImpl(RabbitDeclarer):
 
     def __init__(self, channel_manager: "ChannelManager") -> None:
         self.__channel_manager = channel_manager
-        self._queues: dict[RabbitQueue, aio_pika.RobustQueue] = {}
-        self._exchanges: dict[RabbitExchange, aio_pika.RobustExchange] = {}
+        self._queues: dict[
+            str,
+            tuple[dict[str, Any] | None, aio_pika.RobustQueue],
+        ] = {}
+        self._exchanges: dict[
+            str,
+            tuple[dict[str, Any] | None, aio_pika.RobustExchange],
+        ] = {}
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(queues={list(self._queues.keys())}, exchanges={list(self._exchanges.keys())})"
@@ -81,13 +124,16 @@ class RabbitDeclarerImpl(RabbitDeclarer):
         *,
         channel: Optional["Channel"] = None,
     ) -> "aio_pika.RobustQueue":
-        if (q := self._queues.get(queue)) is None:
-            if declare is EMPTY:
-                declare = queue.declare
+        if declare is EMPTY:
+            declare = queue.declare
 
+        current = _queue_declaration(queue)
+        cached = self._queues.get(queue.name)
+
+        if cached is None or (declare and cached[0] is None):
             channel_obj = await self.__channel_manager.get_channel(channel)
 
-            self._queues[queue] = q = cast(
+            q = cast(
                 "aio_pika.RobustQueue",
                 await channel_obj.declare_queue(
                     name=queue.name,
@@ -95,11 +141,23 @@ class RabbitDeclarerImpl(RabbitDeclarer):
                     exclusive=queue.exclusive,
                     passive=not declare,
                     auto_delete=queue.auto_delete,
-                    arguments=queue.arguments,
+                    arguments=deepcopy(queue.arguments),
                     timeout=queue.timeout,
                     robust=queue.robust,
                 ),
             )
+            self._queues[queue.name] = (current if declare else None, q)
+
+        else:
+            previous, q = cached
+            if declare:
+                assert previous is not None
+                _validate_declaration(
+                    "RabbitQueue",
+                    queue.name,
+                    previous,
+                    current,
+                )
 
         return q
 
@@ -115,11 +173,14 @@ class RabbitDeclarerImpl(RabbitDeclarer):
         if not exchange.name:
             return channel_obj.default_exchange
 
-        if (exch := self._exchanges.get(exchange)) is None:
-            if declare is EMPTY:
-                declare = exchange.declare
+        if declare is EMPTY:
+            declare = exchange.declare
 
-            self._exchanges[exchange] = exch = cast(
+        current = _exchange_declaration(exchange)
+        cached = self._exchanges.get(exchange.name)
+
+        if cached is None or (declare and cached[0] is None):
+            exch = cast(
                 "aio_pika.RobustExchange",
                 await channel_obj.declare_exchange(
                     name=exchange.name,
@@ -127,11 +188,15 @@ class RabbitDeclarerImpl(RabbitDeclarer):
                     durable=exchange.durable,
                     auto_delete=exchange.auto_delete,
                     passive=not declare,
-                    arguments=exchange.arguments,
+                    arguments=deepcopy(exchange.arguments),
                     timeout=exchange.timeout,
                     robust=exchange.robust,
                     internal=False,  # deprecated RMQ option
                 ),
+            )
+            self._exchanges[exchange.name] = (
+                current if declare else None,
+                exch,
             )
 
             if exchange.bind_to is not None:
@@ -142,6 +207,17 @@ class RabbitDeclarerImpl(RabbitDeclarer):
                     arguments=exchange.bind_arguments,
                     timeout=exchange.timeout,
                     robust=exchange.robust,
+                )
+
+        else:
+            previous, exch = cached
+            if declare:
+                assert previous is not None
+                _validate_declaration(
+                    "RabbitExchange",
+                    exchange.name,
+                    previous,
+                    current,
                 )
 
         return exch

--- a/faststream/rabbit/helpers/declarer.py
+++ b/faststream/rabbit/helpers/declarer.py
@@ -3,45 +3,30 @@ from typing import TYPE_CHECKING, Any, Optional, Protocol, cast
 
 from faststream._internal.constants import EMPTY
 from faststream.exceptions import SetupError
+from faststream.rabbit.schemas import RabbitExchange, RabbitQueue
 
 if TYPE_CHECKING:
     import aio_pika
 
-    from faststream.rabbit.schemas import Channel, RabbitExchange, RabbitQueue
+    from faststream.rabbit.schemas import Channel
 
     from .channel_manager import ChannelManager
 
 
-def _queue_declaration(queue: "RabbitQueue") -> dict[str, Any]:
-    return {
-        "durable": queue.durable,
-        "exclusive": queue.exclusive,
-        "auto_delete": queue.auto_delete,
-        "arguments": deepcopy(queue.arguments or {}),
-    }
-
-
-def _exchange_declaration(exchange: "RabbitExchange") -> dict[str, Any]:
-    return {
-        "type": exchange.type,
-        "durable": exchange.durable,
-        "auto_delete": exchange.auto_delete,
-        "arguments": deepcopy(exchange.arguments or {}),
-    }
-
-
 def _validate_declaration(
-    object_type: str,
-    name: str,
-    previous: dict[str, Any],
-    current: dict[str, Any],
+    schema_type: str,
+    object_name: str,
+    cached_settings: dict[str, Any],
+    requested_settings: dict[str, Any],
 ) -> None:
     conflicting = tuple(
-        setting for setting, value in current.items() if previous[setting] != value
+        setting
+        for setting, value in requested_settings.items()
+        if cached_settings[setting] != value
     )
     if conflicting:
         msg = (
-            f"{object_type} {name!r} is already declared with conflicting settings: "
+            f"{schema_type} {object_name!r} is already declared with conflicting settings: "
             f"{', '.join(conflicting)}."
         )
         raise SetupError(msg)
@@ -127,13 +112,19 @@ class RabbitDeclarerImpl(RabbitDeclarer):
         if declare is EMPTY:
             declare = queue.declare
 
-        current = _queue_declaration(queue)
-        cached = self._queues.get(queue.name)
+        # Keep a nested snapshot so later schema mutations are detected.
+        requested_settings = {
+            "durable": queue.durable,
+            "exclusive": queue.exclusive,
+            "auto_delete": queue.auto_delete,
+            "arguments": deepcopy(queue.arguments or {}),
+        }
+        cached_queue = self._queues.get(queue.name)
 
-        if cached is None or (declare and cached[0] is None):
+        if cached_queue is None or (declare and cached_queue[0] is None):
             channel_obj = await self.__channel_manager.get_channel(channel)
 
-            q = cast(
+            declared_queue = cast(
                 "aio_pika.RobustQueue",
                 await channel_obj.declare_queue(
                     name=queue.name,
@@ -141,25 +132,28 @@ class RabbitDeclarerImpl(RabbitDeclarer):
                     exclusive=queue.exclusive,
                     passive=not declare,
                     auto_delete=queue.auto_delete,
-                    arguments=deepcopy(queue.arguments),
+                    arguments=queue.arguments,
                     timeout=queue.timeout,
                     robust=queue.robust,
                 ),
             )
-            self._queues[queue.name] = (current if declare else None, q)
+            self._queues[queue.name] = (
+                requested_settings if declare else None,
+                declared_queue,
+            )
 
         else:
-            previous, q = cached
+            cached_settings, declared_queue = cached_queue
             if declare:
-                assert previous is not None
+                assert cached_settings is not None
                 _validate_declaration(
-                    "RabbitQueue",
+                    RabbitQueue.__name__,
                     queue.name,
-                    previous,
-                    current,
+                    cached_settings,
+                    requested_settings,
                 )
 
-        return q
+        return declared_queue
 
     async def declare_exchange(
         self,
@@ -176,11 +170,17 @@ class RabbitDeclarerImpl(RabbitDeclarer):
         if declare is EMPTY:
             declare = exchange.declare
 
-        current = _exchange_declaration(exchange)
-        cached = self._exchanges.get(exchange.name)
+        # Keep a nested snapshot so later schema mutations are detected.
+        requested_settings = {
+            "type": exchange.type,
+            "durable": exchange.durable,
+            "auto_delete": exchange.auto_delete,
+            "arguments": deepcopy(exchange.arguments or {}),
+        }
+        cached_exchange = self._exchanges.get(exchange.name)
 
-        if cached is None or (declare and cached[0] is None):
-            exch = cast(
+        if cached_exchange is None or (declare and cached_exchange[0] is None):
+            declared_exchange = cast(
                 "aio_pika.RobustExchange",
                 await channel_obj.declare_exchange(
                     name=exchange.name,
@@ -188,20 +188,20 @@ class RabbitDeclarerImpl(RabbitDeclarer):
                     durable=exchange.durable,
                     auto_delete=exchange.auto_delete,
                     passive=not declare,
-                    arguments=deepcopy(exchange.arguments),
+                    arguments=exchange.arguments,
                     timeout=exchange.timeout,
                     robust=exchange.robust,
                     internal=False,  # deprecated RMQ option
                 ),
             )
             self._exchanges[exchange.name] = (
-                current if declare else None,
-                exch,
+                requested_settings if declare else None,
+                declared_exchange,
             )
 
             if exchange.bind_to is not None:
                 parent = await self.declare_exchange(exchange.bind_to)
-                await exch.bind(
+                await declared_exchange.bind(
                     exchange=parent,
                     routing_key=exchange.routing(),
                     arguments=exchange.bind_arguments,
@@ -210,14 +210,14 @@ class RabbitDeclarerImpl(RabbitDeclarer):
                 )
 
         else:
-            previous, exch = cached
+            cached_settings, declared_exchange = cached_exchange
             if declare:
-                assert previous is not None
+                assert cached_settings is not None
                 _validate_declaration(
-                    "RabbitExchange",
+                    RabbitExchange.__name__,
                     exchange.name,
-                    previous,
-                    current,
+                    cached_settings,
+                    requested_settings,
                 )
 
-        return exch
+        return declared_exchange

--- a/faststream/rabbit/schemas/exchange.py
+++ b/faststream/rabbit/schemas/exchange.py
@@ -47,7 +47,7 @@ class RabbitExchange(NameRequired):
         )
 
     def __hash__(self) -> int:
-        """Supports hash to store real objects in declarer."""
+        """Return a hash based on declaration settings."""
 
         def _hash_dict(d: Any) -> Any:
             if isinstance(d, dict):

--- a/faststream/rabbit/schemas/queue.py
+++ b/faststream/rabbit/schemas/queue.py
@@ -74,7 +74,7 @@ class RabbitQueue(NameRequired):
         )
 
     def __hash__(self) -> int:
-        """Supports hash to store real objects in declarer."""
+        """Return a hash based on declaration settings."""
 
         def _hash_dict(d: Any) -> Any:
             if isinstance(d, dict):

--- a/tests/brokers/rabbit/specific/test_declare.py
+++ b/tests/brokers/rabbit/specific/test_declare.py
@@ -1,9 +1,15 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from unittest.mock import AsyncMock
 
 import pytest
 
-from faststream.rabbit import RabbitBroker, RabbitExchange, RabbitQueue
+from faststream.exceptions import SetupError
+from faststream.rabbit import (
+    ExchangeType,
+    RabbitBroker,
+    RabbitExchange,
+    RabbitQueue,
+)
 from faststream.rabbit.helpers.declarer import RabbitDeclarerImpl
 
 if TYPE_CHECKING:
@@ -49,6 +55,238 @@ async def test_declare_exchange(async_mock: AsyncMock, queue: str) -> None:
 
 @pytest.mark.rabbit()
 @pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    ("settings", "conflicting_field"),
+    (
+        pytest.param({"durable": False}, "durable", id="durable"),
+        pytest.param({"exclusive": True}, "exclusive", id="exclusive"),
+        pytest.param({"auto_delete": True}, "auto_delete", id="auto-delete"),
+        pytest.param(
+            {"arguments": {"custom": ["value"]}},
+            "arguments",
+            id="arguments",
+        ),
+    ),
+)
+async def test_reject_conflicting_queue_declaration(
+    async_mock: AsyncMock,
+    queue: str,
+    settings: dict[str, Any],
+    conflicting_field: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    await declarer.declare_queue(RabbitQueue(queue))
+
+    with pytest.raises(
+        SetupError,
+        match=rf"RabbitQueue .*{conflicting_field}",
+    ):
+        await declarer.declare_queue(RabbitQueue(queue, **settings))
+
+    async_mock.declare_queue.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    ("settings", "conflicting_field"),
+    (
+        pytest.param(
+            {"type": ExchangeType.FANOUT},
+            "type",
+            id="type",
+        ),
+        pytest.param({"durable": False}, "durable", id="durable"),
+        pytest.param({"auto_delete": True}, "auto_delete", id="auto-delete"),
+        pytest.param(
+            {"arguments": {"custom": ["value"]}},
+            "arguments",
+            id="arguments",
+        ),
+    ),
+)
+async def test_reject_conflicting_exchange_declaration(
+    async_mock: AsyncMock,
+    queue: str,
+    settings: dict[str, Any],
+    conflicting_field: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    await declarer.declare_exchange(RabbitExchange(queue))
+
+    with pytest.raises(
+        SetupError,
+        match=rf"RabbitExchange .*{conflicting_field}",
+    ):
+        await declarer.declare_exchange(RabbitExchange(queue, **settings))
+
+    async_mock.declare_exchange.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_passive_queue_access_ignores_declaration_settings(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    q1 = await declarer.declare_queue(RabbitQueue(queue))
+    q2 = await declarer.declare_queue(
+        RabbitQueue(queue, durable=False),
+        declare=False,
+    )
+
+    assert q1 is q2
+    async_mock.declare_queue.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_passive_exchange_access_ignores_declaration_settings(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    ex1 = await declarer.declare_exchange(
+        RabbitExchange(queue, type=ExchangeType.TOPIC),
+    )
+    ex2 = await declarer.declare_exchange(
+        RabbitExchange(queue),
+        declare=False,
+    )
+
+    assert ex1 is ex2
+    async_mock.declare_exchange.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_active_queue_replaces_passive_cache_entry(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    passive_object = object()
+    active_object = object()
+    async_mock.declare_queue.side_effect = (passive_object, active_object)
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+
+    q1 = await declarer.declare_queue(RabbitQueue(queue), declare=False)
+    active_queue = RabbitQueue(queue, durable=False)
+    q2 = await declarer.declare_queue(active_queue)
+    q3 = await declarer.declare_queue(active_queue)
+
+    assert q1 is passive_object
+    assert q2 is active_object
+    assert q3 is active_object
+    assert async_mock.declare_queue.await_count == 2
+    assert async_mock.declare_queue.await_args_list[0].kwargs["passive"] is True
+    assert async_mock.declare_queue.await_args_list[1].kwargs["passive"] is False
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_active_exchange_replaces_passive_cache_entry(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    passive_object = object()
+    active_object = object()
+    async_mock.declare_exchange.side_effect = (passive_object, active_object)
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+
+    ex1 = await declarer.declare_exchange(RabbitExchange(queue), declare=False)
+    active_exchange = RabbitExchange(queue, type=ExchangeType.TOPIC)
+    ex2 = await declarer.declare_exchange(active_exchange)
+    ex3 = await declarer.declare_exchange(active_exchange)
+
+    assert ex1 is passive_object
+    assert ex2 is active_object
+    assert ex3 is active_object
+    assert async_mock.declare_exchange.await_count == 2
+    assert async_mock.declare_exchange.await_args_list[0].kwargs["passive"] is True
+    assert async_mock.declare_exchange.await_args_list[1].kwargs["passive"] is False
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_queue_binding_settings_do_not_conflict(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    q1 = await declarer.declare_queue(
+        RabbitQueue(
+            queue,
+            routing_key="first",
+            bind_arguments={"key": "first"},
+        ),
+    )
+    q2 = await declarer.declare_queue(
+        RabbitQueue(
+            queue,
+            routing_key="second",
+            bind_arguments={"key": "second"},
+        ),
+    )
+
+    assert q1 is q2
+    async_mock.declare_queue.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_exchange_binding_settings_do_not_conflict(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    ex1 = await declarer.declare_exchange(
+        RabbitExchange(
+            queue,
+            bind_to=RabbitExchange(f"{queue}-parent-1"),
+            routing_key="first",
+            bind_arguments={"key": "first"},
+        ),
+    )
+    ex2 = await declarer.declare_exchange(
+        RabbitExchange(
+            queue,
+            bind_to=RabbitExchange(f"{queue}-parent-2"),
+            routing_key="second",
+            bind_arguments={"key": "second"},
+        ),
+    )
+
+    assert ex1 is ex2
+    assert async_mock.declare_exchange.await_count == 2
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_reuse_declarations_with_nested_arguments(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    arguments = {"custom": ["value", {"nested": True}]}
+
+    q1 = await declarer.declare_queue(RabbitQueue(queue, arguments=arguments))
+    q2 = await declarer.declare_queue(RabbitQueue(queue, arguments=arguments))
+    ex1 = await declarer.declare_exchange(
+        RabbitExchange(f"{queue}-exchange", arguments=arguments),
+    )
+    ex2 = await declarer.declare_exchange(
+        RabbitExchange(f"{queue}-exchange", arguments=arguments),
+    )
+
+    assert q1 is q2
+    assert ex1 is ex2
+    async_mock.declare_queue.assert_awaited_once()
+    async_mock.declare_exchange.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
 async def test_declare_nested_exchange_cash_nested(
     async_mock: AsyncMock,
     queue: str,
@@ -66,6 +304,87 @@ async def test_declare_nested_exchange_cash_nested(
 
 @pytest.mark.rabbit()
 @pytest.mark.asyncio()
+async def test_reject_conflicting_cached_parent_exchange(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    parent = RabbitExchange(f"{queue}-parent")
+    await declarer.declare_exchange(RabbitExchange(queue, bind_to=parent))
+
+    with pytest.raises(SetupError, match=r"RabbitExchange .*durable"):
+        await declarer.declare_exchange(
+            RabbitExchange(parent.name, durable=False),
+        )
+
+    assert async_mock.declare_exchange.await_count == 2
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_detect_queue_schema_mutation(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    arguments: dict[str, Any] = {"custom": ["first"]}
+    schema = RabbitQueue(queue, arguments=arguments)
+    await declarer.declare_queue(schema)
+    declared_arguments = async_mock.declare_queue.await_args.kwargs["arguments"]
+
+    arguments["custom"].append("second")
+
+    assert declared_arguments == {
+        "x-queue-type": "classic",
+        "custom": ["first"],
+    }
+    with pytest.raises(SetupError, match=r"RabbitQueue .*arguments"):
+        await declarer.declare_queue(schema)
+
+    async_mock.declare_queue.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_detect_exchange_schema_mutation(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    arguments: dict[str, Any] = {"custom": ["first"]}
+    schema = RabbitExchange(queue, arguments=arguments)
+    await declarer.declare_exchange(schema)
+    declared_arguments = async_mock.declare_exchange.await_args.kwargs["arguments"]
+
+    arguments["custom"].append("second")
+
+    assert declared_arguments == {"custom": ["first"]}
+    with pytest.raises(SetupError, match=r"RabbitExchange .*arguments"):
+        await declarer.declare_exchange(schema)
+
+    async_mock.declare_exchange.assert_awaited_once()
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
+async def test_disconnect_clears_declaration_settings(
+    async_mock: AsyncMock,
+    queue: str,
+) -> None:
+    declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
+    await declarer.declare_queue(RabbitQueue(queue))
+
+    with pytest.raises(SetupError):
+        await declarer.declare_queue(RabbitQueue(queue, durable=False))
+
+    declarer.disconnect()
+    await declarer.declare_queue(RabbitQueue(queue, durable=False))
+
+    assert async_mock.declare_queue.await_count == 2
+
+
+@pytest.mark.rabbit()
+@pytest.mark.asyncio()
 async def test_publisher_declare(async_mock: AsyncMock, queue: str) -> None:
     declarer = RabbitDeclarerImpl(FakeChannelManager(async_mock))
 
@@ -78,5 +397,7 @@ async def test_publisher_declare(async_mock: AsyncMock, queue: str) -> None:
 
     await broker.start()
 
-    assert RabbitQueue.validate(queue) not in declarer._queues
-    assert RabbitExchange.validate(queue) in declarer._exchanges
+    async_mock.declare_queue.assert_awaited_once()
+    assert async_mock.declare_queue.await_args.kwargs["name"] == "amq.rabbitmq.reply-to"
+    async_mock.declare_exchange.assert_awaited_once()
+    assert async_mock.declare_exchange.await_args.kwargs["name"] == queue

--- a/tests/brokers/rabbit/specific/test_declare.py
+++ b/tests/brokers/rabbit/specific/test_declare.py
@@ -330,14 +330,9 @@ async def test_detect_queue_schema_mutation(
     arguments: dict[str, Any] = {"custom": ["first"]}
     schema = RabbitQueue(queue, arguments=arguments)
     await declarer.declare_queue(schema)
-    declared_arguments = async_mock.declare_queue.await_args.kwargs["arguments"]
 
     arguments["custom"].append("second")
 
-    assert declared_arguments == {
-        "x-queue-type": "classic",
-        "custom": ["first"],
-    }
     with pytest.raises(SetupError, match=r"RabbitQueue .*arguments"):
         await declarer.declare_queue(schema)
 
@@ -354,11 +349,9 @@ async def test_detect_exchange_schema_mutation(
     arguments: dict[str, Any] = {"custom": ["first"]}
     schema = RabbitExchange(queue, arguments=arguments)
     await declarer.declare_exchange(schema)
-    declared_arguments = async_mock.declare_exchange.await_args.kwargs["arguments"]
 
     arguments["custom"].append("second")
 
-    assert declared_arguments == {"custom": ["first"]}
     with pytest.raises(SetupError, match=r"RabbitExchange .*arguments"):
         await declarer.declare_exchange(schema)
 

--- a/tests/docs/rabbit/test_bind.py
+++ b/tests/docs/rabbit/test_bind.py
@@ -21,8 +21,8 @@ async def test_bind(monkeypatch, async_mock: AsyncMock):
             assert len(broker.config.declarer._queues) == 2  # with `reply-to`
             assert len(broker.config.declarer._exchanges) == 1
 
-            assert some_queue in broker.config.declarer._queues
-            assert some_exchange in broker.config.declarer._exchanges
+            assert some_queue.name in broker.config.declarer._queues
+            assert some_exchange.name in broker.config.declarer._exchanges
 
             row_exchange = await broker.config.declarer.declare_exchange(some_exchange)
             async_mock.assert_awaited_once_with(


### PR DESCRIPTION
# Description

Rabbit declarations are now cached by broker object name together with an independent snapshot of the settings that define an active declaration. Reusing the same queue or exchange returns the cached aio-pika object, while a conflicting active declaration raises a `SetupError` that identifies the differing fields before another broker call is attempted.

Passive lookups (`declare=False`) reuse an existing object by name without treating placeholder settings as a new declaration. If a passive lookup populated the cache first, the first active declaration still reaches RabbitMQ and replaces that entry with an authoritative snapshot.

The declaration arguments passed to aio-pika are deep-copied separately from the validation snapshot. This prevents later mutation of nested user arguments from silently changing the settings replayed by aio-pika during a robust reconnect. Binding-only settings remain outside declaration identity.

This removes the declarer's dependency on `RabbitQueue` and `RabbitExchange` hashing, including the previous `TypeError` for nested list arguments. Their public hash behavior remains unchanged because #2796 established it as compatibility-sensitive; the hash docstrings now describe declaration identity instead of the internal cache.

The original `0.6.0` branch requested on the issue is no longer available, so this targets the current `main` branch.

Addresses #2034

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix
- [ ] Both new and existing unit tests pass by running `just test-coverage`
- [x] Static analysis passes
- [ ] I have included code examples

## Validation

- Full non-connected test suite
- RabbitMQ non-connected test suite
- Focused declaration tests (23 cases)
- Ruff formatting and linting
- Mypy and Pyright
- Bandit and Semgrep