### PR TITLE
fix(nats): bound pull fetches by worker capacity

### DIFF
--- a/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
+++ b/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
@@ -91,19 +91,76 @@ class PullStreamSubscriber(
 
 class ConcurrentPullStreamSubscriber(ConcurrentMixin["Msg"], PullStreamSubscriber):
     @override
-    async def _create_subscription(self) -> None:
-        """Create NATS subscription and start consume task."""
-        if self.subscription:
+    async def _consume_pull(
+        self,
+        cb: Callable[["Msg"], Awaitable["SendableMessage"]],
+    ) -> None:
+        """Consume no more messages than the available worker capacity."""
+        if not self.running:
             return
 
-        self.start_consume_task()
+        assert self.subscription
+        fetch_error: Exception | None = None
 
-        self.subscription = await self.jetstream.pull_subscribe(
-            subject=self.subject.broker_address,
-            config=self.config,
-            **self.extra_options,
-        )
-        self.add_task(self._consume_pull, func_kwargs={"cb": self._put_msg})
+        async with anyio.create_task_group() as tg:
+            while self.running:  # pragma: no branch
+                reserved_slots = await self._reserve_worker_slots()
+
+                try:
+                    if not self.running:
+                        continue
+
+                    try:
+                        messages = await self.subscription.fetch(
+                            batch=reserved_slots,
+                            timeout=self.pull_sub.timeout,
+                        )
+                    except (
+                        TimeoutError,
+                        ConnectionClosedError,
+                        ServiceUnavailableError,
+                    ):
+                        continue
+                    except Exception as exc:
+                        fetch_error = exc
+                        break
+
+                    for msg in messages:
+                        tg.start_soon(self._consume_with_release, cb, msg)
+                        reserved_slots -= 1
+
+                finally:
+                    for _ in range(reserved_slots):
+                        self.limiter.release()
+
+        if fetch_error is not None and self.running:
+            raise fetch_error
+
+    async def _reserve_worker_slots(self) -> int:
+        """Reserve the currently available capacity for the next fetch."""
+        max_slots = min(self.pull_sub.batch_size, self.max_workers)
+        if max_slots < 1:
+            return max_slots
+
+        await self.limiter.acquire()
+        reserved_slots = 1
+
+        while reserved_slots < max_slots and self.limiter.value:
+            self.limiter.acquire_nowait()
+            reserved_slots += 1
+
+        return reserved_slots
+
+    async def _consume_with_release(
+        self,
+        cb: Callable[["Msg"], Awaitable["SendableMessage"]],
+        msg: "Msg",
+    ) -> None:
+        """Release reserved capacity only after message processing finishes."""
+        try:
+            await cb(msg)
+        finally:
+            self.limiter.release()
 
 
 class BatchPullStreamSubscriber(

--- a/tests/brokers/nats/test_consume.py
+++ b/tests/brokers/nats/test_consume.py
@@ -58,6 +58,58 @@ class TestConsume(NatsTestcaseConfig, BrokerRealConsumeTestcase):
         assert event2.is_set()
         assert mock.call_count == 2, mock.call_count
 
+    async def test_concurrent_pull_respects_worker_capacity(
+        self,
+        queue: str,
+        stream: JStream,
+        event: asyncio.Event,
+        event2: asyncio.Event,
+    ) -> None:
+        broker = self.get_broker()
+        release_handlers = asyncio.Event()
+
+        subscriber = broker.subscriber(
+            queue,
+            durable=queue,
+            stream=stream,
+            pull_sub=PullSub(batch_size=2, batch=True),
+            max_workers=2,
+        )
+
+        @subscriber
+        async def handler(msg: str) -> None:
+            if event.is_set():
+                event2.set()
+            else:
+                event.set()
+            await release_handlers.wait()
+
+        async with self.patch_broker(broker) as br:
+            await br.start()
+
+            try:
+                await asyncio.gather(*(br.publish(i, queue) for i in range(4)))
+                await asyncio.wait_for(
+                    asyncio.gather(event.wait(), event2.wait()),
+                    timeout=3,
+                )
+
+                assert subscriber.subscription
+                max_ack_pending = 0
+
+                for _ in range(20):
+                    consumer_info = await subscriber.subscription.consumer_info()
+                    max_ack_pending = max(
+                        max_ack_pending,
+                        consumer_info.num_ack_pending or 0,
+                    )
+                    await asyncio.sleep(0.05)
+
+                assert max_ack_pending == 2
+
+            finally:
+                release_handlers.set()
+
     async def test_consume_js(
         self, queue: str, stream: JStream, event: asyncio.Event
     ) -> None:

--- a/tests/brokers/nats/test_pull_subscriber.py
+++ b/tests/brokers/nats/test_pull_subscriber.py
@@ -1,0 +1,282 @@
+import asyncio
+from contextlib import suppress
+from typing import Any
+
+import pytest
+from nats.errors import TimeoutError
+
+from faststream.nats import JStream, NatsBroker, PullSub
+from faststream.nats.subscriber.usecases import ConcurrentPullStreamSubscriber
+
+
+class FakeSubscription:
+    def __init__(self) -> None:
+        self.fetch_requests: list[int] = []
+        self.second_fetch_started = asyncio.Event()
+
+    async def fetch(self, *, batch: int, timeout: float | None) -> list[object]:
+        self.fetch_requests.append(batch)
+
+        if len(self.fetch_requests) == 1:
+            return [object() for _ in range(batch)]
+
+        self.second_fetch_started.set()
+        await asyncio.Event().wait()
+        return []
+
+
+def create_subscriber(*, batch_size: int = 2) -> ConcurrentPullStreamSubscriber:
+    broker = NatsBroker()
+    subscriber = broker.subscriber(
+        "test",
+        stream=JStream("test"),
+        pull_sub=PullSub(batch_size=batch_size, batch=True),
+        max_workers=2,
+    )
+    assert isinstance(subscriber, ConcurrentPullStreamSubscriber)
+    return subscriber
+
+
+async def stop_task(task: asyncio.Task[Any]) -> None:
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio()
+@pytest.mark.nats()
+async def test_pull_waits_for_worker_capacity() -> None:
+    subscriber = create_subscriber(batch_size=5)
+    subscription = FakeSubscription()
+    subscriber.subscription = subscription  # type: ignore[assignment]
+    subscriber.running = True
+
+    handlers_started = 0
+    both_handlers_started = asyncio.Event()
+    release_handler = asyncio.Semaphore(0)
+
+    async def consume(message: object) -> None:
+        nonlocal handlers_started
+        handlers_started += 1
+        if handlers_started == 2:
+            both_handlers_started.set()
+        await release_handler.acquire()
+
+    pull_task = asyncio.create_task(subscriber._consume_pull(cb=consume))
+
+    try:
+        await asyncio.wait_for(both_handlers_started.wait(), timeout=1)
+        for _ in range(20):
+            await asyncio.sleep(0)
+
+        assert subscription.fetch_requests == [2]
+        assert not subscription.second_fetch_started.is_set()
+
+        release_handler.release()
+        await asyncio.wait_for(subscription.second_fetch_started.wait(), timeout=1)
+        assert subscription.fetch_requests == [2, 1]
+
+    finally:
+        subscriber.running = False
+        release_handler.release()
+        release_handler.release()
+        await stop_task(pull_task)
+
+    assert subscriber.limiter.value == subscriber.max_workers
+
+
+@pytest.mark.asyncio()
+@pytest.mark.nats()
+async def test_pull_releases_unused_fetch_capacity() -> None:
+    subscriber = create_subscriber()
+    second_fetch_started = asyncio.Event()
+    fetch_requests: list[int] = []
+
+    class PartialSubscription:
+        async def fetch(
+            self,
+            *,
+            batch: int,
+            timeout: float | None,
+        ) -> list[object]:
+            fetch_requests.append(batch)
+            if len(fetch_requests) == 1:
+                return [object()]
+
+            second_fetch_started.set()
+            await asyncio.Event().wait()
+            return []
+
+    subscriber.subscription = PartialSubscription()  # type: ignore[assignment]
+    subscriber.running = True
+    release_handler = asyncio.Event()
+
+    async def consume(message: object) -> None:
+        await release_handler.wait()
+
+    pull_task = asyncio.create_task(subscriber._consume_pull(cb=consume))
+
+    try:
+        await asyncio.wait_for(second_fetch_started.wait(), timeout=1)
+        assert fetch_requests == [2, 1]
+
+    finally:
+        subscriber.running = False
+        release_handler.set()
+        await stop_task(pull_task)
+
+    assert subscriber.limiter.value == subscriber.max_workers
+
+
+@pytest.mark.asyncio()
+@pytest.mark.nats()
+async def test_pull_releases_capacity_after_timeout() -> None:
+    subscriber = create_subscriber()
+    second_fetch_started = asyncio.Event()
+    fetch_requests: list[int] = []
+
+    class TimingOutSubscription:
+        async def fetch(
+            self,
+            *,
+            batch: int,
+            timeout: float | None,
+        ) -> list[object]:
+            fetch_requests.append(batch)
+            if len(fetch_requests) == 1:
+                raise TimeoutError
+
+            second_fetch_started.set()
+            await asyncio.Event().wait()
+            return []
+
+    subscriber.subscription = TimingOutSubscription()  # type: ignore[assignment]
+    subscriber.running = True
+    pull_task = asyncio.create_task(subscriber._consume_pull(cb=subscriber.consume))
+
+    await asyncio.wait_for(second_fetch_started.wait(), timeout=1)
+    assert fetch_requests == [2, 2]
+
+    subscriber.running = False
+    await stop_task(pull_task)
+
+    assert subscriber.limiter.value == subscriber.max_workers
+
+
+@pytest.mark.asyncio()
+@pytest.mark.nats()
+async def test_pull_does_not_fetch_after_stop_while_waiting_for_capacity() -> None:
+    subscriber = create_subscriber()
+    subscription = FakeSubscription()
+    subscriber.subscription = subscription  # type: ignore[assignment]
+    subscriber.running = True
+    handlers_started = 0
+    both_handlers_started = asyncio.Event()
+    release_handlers = asyncio.Event()
+
+    async def consume(message: object) -> None:
+        nonlocal handlers_started
+        handlers_started += 1
+        if handlers_started == 2:
+            both_handlers_started.set()
+        await release_handlers.wait()
+
+    pull_task = asyncio.create_task(subscriber._consume_pull(cb=consume))
+    await asyncio.wait_for(both_handlers_started.wait(), timeout=1)
+
+    subscriber.running = False
+    release_handlers.set()
+    await asyncio.wait_for(pull_task, timeout=1)
+
+    assert subscription.fetch_requests == [2]
+    assert subscriber.limiter.value == subscriber.max_workers
+
+
+@pytest.mark.asyncio()
+@pytest.mark.nats()
+@pytest.mark.parametrize("stop_before_release", (False, True))
+async def test_unexpected_fetch_error_does_not_cancel_active_handler(
+    stop_before_release: bool,
+) -> None:
+    subscriber = create_subscriber()
+    second_fetch_started = asyncio.Event()
+    fetch_requests: list[int] = []
+
+    class FailingSubscription:
+        async def fetch(
+            self,
+            *,
+            batch: int,
+            timeout: float | None,
+        ) -> list[object]:
+            fetch_requests.append(batch)
+            if len(fetch_requests) == 1:
+                return [object(), object()]
+
+            second_fetch_started.set()
+            msg = "unexpected fetch error"
+            raise RuntimeError(msg)
+
+    subscriber.subscription = FailingSubscription()  # type: ignore[assignment]
+    subscriber.running = True
+    handlers_started = 0
+    both_handlers_started = asyncio.Event()
+    release_handler = asyncio.Semaphore(0)
+
+    async def consume(message: object) -> None:
+        nonlocal handlers_started
+        handlers_started += 1
+        if handlers_started == 2:
+            both_handlers_started.set()
+        await release_handler.acquire()
+
+    pull_task = asyncio.create_task(subscriber._consume_pull(cb=consume))
+    await asyncio.wait_for(both_handlers_started.wait(), timeout=1)
+
+    release_handler.release()
+    await asyncio.wait_for(second_fetch_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert not pull_task.done()
+
+    if stop_before_release:
+        subscriber.running = False
+
+    release_handler.release()
+    if stop_before_release:
+        await pull_task
+    else:
+        with pytest.raises(RuntimeError, match="unexpected fetch error"):
+            await pull_task
+
+    assert fetch_requests == [2, 1]
+    assert subscriber.limiter.value == subscriber.max_workers
+
+
+@pytest.mark.asyncio()
+@pytest.mark.nats()
+async def test_pull_releases_capacity_when_fetch_is_cancelled() -> None:
+    subscriber = create_subscriber()
+    fetch_started = asyncio.Event()
+
+    class BlockingSubscription:
+        async def fetch(
+            self,
+            *,
+            batch: int,
+            timeout: float | None,
+        ) -> list[object]:
+            fetch_started.set()
+            await asyncio.Event().wait()
+            return []
+
+    subscriber.subscription = BlockingSubscription()  # type: ignore[assignment]
+    subscriber.running = True
+    pull_task = asyncio.create_task(subscriber._consume_pull(cb=subscriber.consume))
+
+    await asyncio.wait_for(fetch_started.wait(), timeout=1)
+    assert subscriber.limiter.value == 0
+
+    subscriber.running = False
+    await stop_task(pull_task)
+
+    assert subscriber.limiter.value == subscriber.max_workers


### PR DESCRIPTION
# Description

Concurrent JetStream pull subscribers fetched another batch as soon as raw messages entered the local queue. The semaphore was released at enqueue time, so NATS could mark more messages as delivered than handlers could process before `ack_wait`.

This change reserves available worker slots before each fetch, caps the request to the smaller of `batch_size` and available capacity, and holds every reservation until message processing finishes. Partial fetches, expected NATS fetch errors, and cancellation return unused capacity. Already-running handlers finish before an unexpected fetch error reaches the task supervisor.

The regression coverage includes deterministic scheduling tests and a real JetStream assertion that server-side `num_ack_pending` never exceeds `max_workers`.

Fixes #2563

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project
- [x] I have conducted a self-review of my own code
- [x] Documentation changes are not required for this internal scheduling fix
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the fix
- [x] New and existing unit tests pass locally
- [x] Static analysis checks pass locally

## Validation

- Full non-connected test suite
- Full NATS connected test suite
- Ruff formatting and lint checks
- Mypy, Pyright, Bandit, and Semgrep
