### PR TITLE
feat(redis): support cluster publishing pipelines

### DIFF
--- a/docs/docs/en/redis/cluster.md
+++ b/docs/docs/en/redis/cluster.md
@@ -20,7 +20,7 @@ search:
 |---|---|
 | Single Redis instance | Multi-node cluster |
 | Development / testing | Production with HA |
-| Need `pipeline` support | Can tolerate no pipeline |
+| Single-node transactions | Same-slot transactions |
 
 ## Connecting
 
@@ -51,7 +51,7 @@ broker = RedisClusterBroker(
 | List | ✅ | ✅ |
 | Stream + XAUTOCLAIM | ✅ | ✅ |
 | Pub/Sub | ✅ | ✅ (via sync cluster) |
-| Pipeline | ✅ | ❌ |
+| Pipeline | ✅ | ✅ (lists and streams) |
 
 ## Stream Location
 
@@ -76,7 +76,8 @@ broker = RedisClusterBroker(url="redis://localhost:7000")
 
 ## Limitations
 
-- **Pipeline** is not supported in Redis Cluster.
+- **Pipelines** support lists and streams, but redis-py blocks channel `PUBLISH` commands in cluster pipelines. See [Redis Pipeline](pipeline.md){.internal-link} for a tested example.
+- **Transactions** require `redis-py >= 6.2.0`, `transaction=True`, and keys in the same hash slot. A shared hash tag such as `{orders}` keeps related keys together. Pipelining without a transaction is not atomic.
 - **XAUTOCLAIM** with `min_idle_time` requires a consumer group with `group` and `consumer` parameters on `StreamSub`.
 - **Pub/Sub** uses a synchronous `RedisCluster` client (via `ThreadPoolExecutor`) because the async client does not expose `publish`/`pubsub` until `redis-py >= 8.0.0`.
 

--- a/docs/docs/en/redis/pipeline.md
+++ b/docs/docs/en/redis/pipeline.md
@@ -10,7 +10,7 @@ search:
 
 # Redis Pipeline
 
-**FastStream** supports [**Redis** pipelining](https://redis.io/docs/latest/develop/use/pipelining/){.external-link target="_blank"} to optimize performance when publishing multiple messages in a batch. This allows you to queue several **Redis** operations and execute them in one network round-trip, reducing latency significantly.
+**FastStream** supports [**Redis** pipelining](https://redis.io/docs/latest/develop/use/pipelining/){.external-link target="_blank"} to optimize performance when publishing multiple messages in a batch. This allows you to queue several **Redis** operations and execute them together, reducing network round-trips.
 
 ## Usage Example
 
@@ -36,11 +36,26 @@ When using `#!python broker.publish_batch()` in combination with the `pipeline` 
 
 ## Notes
 
-- Pipelining is supported for all **Redis** queue types, including channels, lists, and streams.
-- You can combine multiple queue types in a single pipeline.
+- With `RedisBroker`, pipelining is supported for all **Redis** queue types, including channels, lists, and streams.
+- You can combine supported queue types in a single pipeline.
 
-!!! warning "Redis Cluster"
-    Pipeline is **not supported** in Redis Cluster. If you are using `RedisClusterBroker`, the `pipeline` parameter is not available. Consider using `publish_batch()` with individual requests instead.
+## Redis Cluster
+
+`RedisClusterBroker` accepts a `redis.asyncio.cluster.ClusterPipeline` through the same `pipeline` parameter. Create it from the client returned by `#!python await broker.connect()`. You can queue list and stream publications with `broker.publish()` or a publisher's `publish()`, and list batches with `broker.publish_batch()` or a batch publisher.
+
+Pipelining alone does not make commands atomic. To combine a state update and a publication atomically, use `transaction=True` and keep every key in the same hash slot. The example uses the shared `{orders}` hash tag for the counter and stream:
+
+```python linenums="1"
+{!> docs_src/redis/pipeline/cluster_pipeline.py !}
+```
+
+The publication stays queued alongside `INCR` until `#!python await pipe.execute()`. Its result list contains the command results in order: the updated counter followed by the stream entry ID. `transaction=True` requires `redis-py >= 6.2.0`; ordinary cluster pipelines do not provide transaction semantics.
+
+!!! warning "Cluster pipeline restrictions"
+    redis-py blocks `PUBLISH` in cluster pipelines. Passing `pipeline=pipe` with a channel raises `RedisClusterException`; FastStream does not publish outside the pipeline as a fallback. Publish to channels without a pipeline instead.
+
+!!! note "WATCH and MULTI"
+    With a watched transaction, commands issued after `WATCH` but before `MULTI` execute immediately, following redis-py's behavior. Call `pipe.multi()` before queueing publications that must belong to the transaction.
 
 ## Benefits
 

--- a/docs/docs_src/redis/pipeline/cluster_pipeline.py
+++ b/docs/docs_src/redis/pipeline/cluster_pipeline.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from faststream.redis import RedisClusterBroker
+
+broker = RedisClusterBroker("redis://127.0.0.1:7001")
+
+
+async def increment_and_publish(
+    broker: RedisClusterBroker,
+    key: str = "orders",
+) -> list[int | bytes]:
+    client = await broker.connect()
+    async with client.pipeline(transaction=True) as pipe:
+        pipe.incr(f"{{{key}}}:count")
+        await broker.publish(
+            "created",
+            stream=f"{{{key}}}:events",
+            pipeline=pipe,
+        )
+        return await pipe.execute()
+
+
+async def main() -> None:
+    async with broker:
+        await increment_and_publish(broker)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from redis.asyncio.client import Pipeline, Redis
+    from redis.asyncio.cluster import ClusterPipeline
 
     from faststream._internal.basic_types import SendableMessage
     from faststream.redis.message import RedisChannelMessage
@@ -222,6 +223,21 @@ class RedisBroker(
         pipeline: Optional["Pipeline[bytes]"] = None,
     ) -> bytes: ...
 
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        *,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        list: str | None = None,
+        stream: str | None = None,
+        maxlen: int | None = None,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "int | bytes | ClusterPipeline[bytes]": ...
+
     @override
     async def publish(
         self,
@@ -234,8 +250,8 @@ class RedisBroker(
         list: str | None = None,
         stream: str | None = None,
         maxlen: int | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = None,
-    ) -> int | bytes:
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+    ) -> "int | bytes | ClusterPipeline[bytes]":
         """Publish message directly.
 
         This method allows you to publish a message in a non-AsyncAPI-documented way.
@@ -259,10 +275,11 @@ class RedisBroker(
             maxlen:
                 Redis Stream maxlen publish option. Remove eldest message if maxlen exceeded.
             pipeline:
-                Redis pipeline to use for publishing messages.
+                Redis pipeline to use for publishing messages. Cluster pipelines
+                support lists and streams; queued commands run on pipeline.execute().
 
         Returns:
-            int: The result of the publish operation, typically the number of messages published.
+            The publish result, or the cluster pipeline when the command is queued.
         """
         cmd = RedisPublishCommand(
             message,
@@ -278,7 +295,7 @@ class RedisBroker(
             message_format=self.message_format,
         )
 
-        result: int | bytes = await super()._basic_publish(
+        result: int | bytes | ClusterPipeline[bytes] = await super()._basic_publish(
             cmd,
             producer=self.config.producer,
         )
@@ -315,8 +332,8 @@ class RedisBroker(
         )
         return msg
 
-    @override
-    async def publish_batch(  # type: ignore[override]
+    @overload  # type: ignore[override]
+    async def publish_batch(
         self,
         *messages: "SendableMessage",
         list: str,
@@ -324,7 +341,29 @@ class RedisBroker(
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
         pipeline: Optional["Pipeline[bytes]"] = None,
-    ) -> int:
+    ) -> int: ...
+
+    @overload
+    async def publish_batch(
+        self,
+        *messages: "SendableMessage",
+        list: str,
+        correlation_id: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "int | ClusterPipeline[bytes]": ...
+
+    @override
+    async def publish_batch(
+        self,
+        *messages: "SendableMessage",
+        list: str,
+        correlation_id: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+    ) -> "int | ClusterPipeline[bytes]":
         """Publish multiple messages to Redis List by one request.
 
         Args:
@@ -336,7 +375,7 @@ class RedisBroker(
             pipeline: Redis pipeline to use for publishing messages.
 
         Returns:
-            int: The result of the batch publish operation.
+            The batch publish result, or the cluster pipeline when it is queued.
         """
         cmd = RedisPublishCommand(
             *messages,
@@ -349,7 +388,7 @@ class RedisBroker(
             message_format=self.message_format,
         )
 
-        result: int = await self._basic_publish_batch(
+        result: int | ClusterPipeline[bytes] = await self._basic_publish_batch(
             cmd,
             producer=self.config.producer,
         )

--- a/faststream/redis/broker/broker.py
+++ b/faststream/redis/broker/broker.py
@@ -205,7 +205,7 @@ class RedisBroker(
         list: str | None = None,
         stream: None = None,
         maxlen: int | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> int: ...
 
     @overload
@@ -220,7 +220,7 @@ class RedisBroker(
         list: str | None = None,
         stream: str = ...,
         maxlen: int | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> bytes: ...
 
     @overload
@@ -235,8 +235,8 @@ class RedisBroker(
         list: str | None = None,
         stream: str | None = None,
         maxlen: int | None = None,
-        pipeline: "ClusterPipeline[bytes]",
-    ) -> "int | bytes | ClusterPipeline[bytes]": ...
+        pipeline: "Pipeline[bytes]",
+    ) -> "Pipeline[bytes]": ...
 
     @override
     async def publish(
@@ -251,7 +251,7 @@ class RedisBroker(
         stream: str | None = None,
         maxlen: int | None = None,
         pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
-    ) -> "int | bytes | ClusterPipeline[bytes]":
+    ) -> "int | bytes | Pipeline[bytes] | ClusterPipeline[bytes]":
         """Publish message directly.
 
         This method allows you to publish a message in a non-AsyncAPI-documented way.
@@ -275,11 +275,11 @@ class RedisBroker(
             maxlen:
                 Redis Stream maxlen publish option. Remove eldest message if maxlen exceeded.
             pipeline:
-                Redis pipeline to use for publishing messages. Cluster pipelines
-                support lists and streams; queued commands run on pipeline.execute().
+                Redis pipeline to use for publishing messages. Queued commands run on
+                pipeline.execute().
 
         Returns:
-            The publish result, or the cluster pipeline when the command is queued.
+            The publish result, or the pipeline when the command is queued.
         """
         cmd = RedisPublishCommand(
             message,
@@ -295,7 +295,9 @@ class RedisBroker(
             message_format=self.message_format,
         )
 
-        result: int | bytes | ClusterPipeline[bytes] = await super()._basic_publish(
+        result: (
+            int | bytes | Pipeline[bytes] | ClusterPipeline[bytes]
+        ) = await super()._basic_publish(
             cmd,
             producer=self.config.producer,
         )
@@ -340,7 +342,7 @@ class RedisBroker(
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> int: ...
 
     @overload
@@ -351,8 +353,8 @@ class RedisBroker(
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
-        pipeline: "ClusterPipeline[bytes]",
-    ) -> "int | ClusterPipeline[bytes]": ...
+        pipeline: "Pipeline[bytes]",
+    ) -> "Pipeline[bytes]": ...
 
     @override
     async def publish_batch(
@@ -363,7 +365,7 @@ class RedisBroker(
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
         pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
-    ) -> "int | ClusterPipeline[bytes]":
+    ) -> "int | Pipeline[bytes] | ClusterPipeline[bytes]":
         """Publish multiple messages to Redis List by one request.
 
         Args:
@@ -375,7 +377,7 @@ class RedisBroker(
             pipeline: Redis pipeline to use for publishing messages.
 
         Returns:
-            The batch publish result, or the cluster pipeline when it is queued.
+            The batch publish result, or the pipeline when it is queued.
         """
         cmd = RedisPublishCommand(
             *messages,
@@ -388,7 +390,9 @@ class RedisBroker(
             message_format=self.message_format,
         )
 
-        result: int | ClusterPipeline[bytes] = await self._basic_publish_batch(
+        result: (
+            int | Pipeline[bytes] | ClusterPipeline[bytes]
+        ) = await self._basic_publish_batch(
             cmd,
             producer=self.config.producer,
         )

--- a/faststream/redis/broker/cluster_broker.py
+++ b/faststream/redis/broker/cluster_broker.py
@@ -1,6 +1,6 @@
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast, overload
 
 from redis.asyncio.cluster import ClusterNode
 from redis.asyncio.connection import SSLConnection
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from redis.asyncio.client import Pipeline
+    from redis.asyncio.cluster import ClusterPipeline
 
     from faststream._internal.basic_types import SendableMessage
     from faststream.redis.schemas import ListSub, PubSub, StreamSub
@@ -111,45 +112,6 @@ class RedisClusterBroker(RedisBroker):
         sub.start = _patched_start  # type: ignore[method-assign]
         return sub
 
-    async def publish(  # type: ignore[override]
-        self,
-        message: "SendableMessage" = None,
-        channel: str | None = None,
-        *,
-        reply_to: str = "",
-        headers: dict[str, Any] | None = None,
-        correlation_id: str | None = None,
-        list: str | None = None,
-        stream: str | None = None,
-        maxlen: int | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = EMPTY,
-    ) -> int | bytes:
-        if pipeline is not EMPTY:
-            warnings.warn(
-                "Pipeline is not supported in Redis Cluster and will be ignored.",
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
-
-        publish_kwargs: dict[str, Any] = {}
-        if stream is not None:
-            publish_kwargs["stream"] = stream
-        if maxlen is not None:
-            publish_kwargs["maxlen"] = maxlen
-
-        return cast(
-            "int | bytes",
-            await super().publish(
-                message,
-                channel,
-                reply_to=reply_to,
-                headers=headers,
-                correlation_id=correlation_id,
-                list=list,
-                **publish_kwargs,
-            ),
-        )
-
     async def _connect(self) -> Any:
         await self.config.connect()
         return self.config.broker_config.connection.client
@@ -168,23 +130,38 @@ class RedisClusterBroker(RedisBroker):
         await self.connect()
         await super().start()
 
-    async def publish_batch(  # type: ignore[override]
+    @overload  # type: ignore[override]
+    async def publish_batch(
         self,
         *messages: "SendableMessage",
         list: str,
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = EMPTY,
-    ) -> int:
-        if pipeline is not EMPTY:
-            warnings.warn(
-                "Pipeline is not supported in Redis Cluster and will be ignored.",
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
+        pipeline: Optional["Pipeline[bytes]"] = None,
+    ) -> int: ...
 
-        if not self._cluster_state:
+    @overload
+    async def publish_batch(
+        self,
+        *messages: "SendableMessage",
+        list: str,
+        correlation_id: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "int | ClusterPipeline[bytes]": ...
+
+    async def publish_batch(
+        self,
+        *messages: "SendableMessage",
+        list: str,
+        correlation_id: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+    ) -> "int | ClusterPipeline[bytes]":
+        if pipeline is None and not self._cluster_state:
             await self._connect()
 
         return await super().publish_batch(
@@ -193,6 +170,7 @@ class RedisClusterBroker(RedisBroker):
             correlation_id=correlation_id,
             reply_to=reply_to,
             headers=headers,
+            pipeline=pipeline,
         )
 
     @staticmethod

--- a/faststream/redis/broker/cluster_broker.py
+++ b/faststream/redis/broker/cluster_broker.py
@@ -23,7 +23,6 @@ from faststream.redis.subscriber.usecases.basic import LogicSubscriber
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from redis.asyncio.client import Pipeline
     from redis.asyncio.cluster import ClusterPipeline
 
     from faststream._internal.basic_types import SendableMessage
@@ -112,6 +111,79 @@ class RedisClusterBroker(RedisBroker):
         sub.start = _patched_start  # type: ignore[method-assign]
         return sub
 
+    @overload  # type: ignore[override]
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        *,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        list: str | None = None,
+        stream: None = None,
+        maxlen: int | None = None,
+        pipeline: None = None,
+    ) -> int: ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        *,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        list: str | None = None,
+        stream: str = ...,
+        maxlen: int | None = None,
+        pipeline: None = None,
+    ) -> bytes: ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        *,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        list: str | None = None,
+        stream: str | None = None,
+        maxlen: int | None = None,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "ClusterPipeline[bytes]": ...
+
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        *,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        list: str | None = None,
+        stream: str | None = None,
+        maxlen: int | None = None,
+        pipeline: Optional["ClusterPipeline[bytes]"] = None,
+    ) -> "int | bytes | ClusterPipeline[bytes]":
+        return cast(
+            "int | bytes | ClusterPipeline[bytes]",
+            await super().publish(
+                message,
+                channel,
+                reply_to=reply_to,
+                headers=headers,
+                correlation_id=correlation_id,
+                list=list,
+                stream=stream,
+                maxlen=maxlen,
+                pipeline=cast("Any", pipeline),
+            ),
+        )
+
     async def _connect(self) -> Any:
         await self.config.connect()
         return self.config.broker_config.connection.client
@@ -138,7 +210,7 @@ class RedisClusterBroker(RedisBroker):
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> int: ...
 
     @overload
@@ -150,7 +222,7 @@ class RedisClusterBroker(RedisBroker):
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
         pipeline: "ClusterPipeline[bytes]",
-    ) -> "int | ClusterPipeline[bytes]": ...
+    ) -> "ClusterPipeline[bytes]": ...
 
     async def publish_batch(
         self,
@@ -159,18 +231,21 @@ class RedisClusterBroker(RedisBroker):
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
-        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+        pipeline: Optional["ClusterPipeline[bytes]"] = None,
     ) -> "int | ClusterPipeline[bytes]":
         if pipeline is None and not self._cluster_state:
             await self._connect()
 
-        return await super().publish_batch(
-            *messages,
-            list=list,
-            correlation_id=correlation_id,
-            reply_to=reply_to,
-            headers=headers,
-            pipeline=pipeline,
+        return cast(
+            "int | ClusterPipeline[bytes]",
+            await super().publish_batch(
+                *messages,
+                list=list,
+                correlation_id=correlation_id,
+                reply_to=reply_to,
+                headers=headers,
+                pipeline=cast("Any", pipeline),
+            ),
         )
 
     @staticmethod

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -2,6 +2,7 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import anyio
+from redis.asyncio.client import Pipeline
 from redis.asyncio.cluster import ClusterPipeline
 from typing_extensions import override
 
@@ -59,7 +60,7 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
     @override
     async def publish_batch(
         self, cmd: "RedisPublishCommand"
-    ) -> "int | ClusterPipeline[bytes]":
+    ) -> "int | Pipeline[bytes] | ClusterPipeline[bytes]":
         batch = [
             await cmd.message_format.encode(
                 message=msg,
@@ -76,7 +77,7 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
             cmd.pipeline if cmd.pipeline is not None else self._connection.client
         )
         result = connection.rpush(cmd.destination, *batch)
-        if isinstance(result, ClusterPipeline):
+        if isinstance(result, (Pipeline, ClusterPipeline)):
             return result
         return cast("int", await result)
 
@@ -84,7 +85,7 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         self,
         msg: bytes,
         cmd: "RedisPublishCommand",
-    ) -> "int | bytes | ClusterPipeline[bytes]":
+    ) -> "int | bytes | Pipeline[bytes] | ClusterPipeline[bytes]":
         connection: Any = (
             cmd.pipeline if cmd.pipeline is not None else self._connection.client
         )
@@ -102,9 +103,9 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         else:
             raise UnreachablePathError
 
-        # Awaiting a queued ClusterPipeline clears its commands (see issue #3044).
-        # WATCH-mode commands can instead return a coroutine that must be awaited.
-        if isinstance(result, ClusterPipeline):
+        # Queued commands return their pipeline; WATCH-mode commands can instead
+        # return a coroutine that must be awaited (see issue #3044).
+        if isinstance(result, (Pipeline, ClusterPipeline)):
             return result
         return cast("int | bytes", await result)
 
@@ -147,7 +148,7 @@ class RedisFastProducer(BaseRedisFastProducer):
     @override
     async def publish(
         self, cmd: "RedisPublishCommand"
-    ) -> "int | bytes | ClusterPipeline[bytes]":
+    ) -> "int | bytes | Pipeline[bytes] | ClusterPipeline[bytes]":
         msg = await cmd.message_format.encode(
             message=cmd.body,
             reply_to=cmd.reply_to,
@@ -226,7 +227,7 @@ class RedisClusterFastProducer(BaseRedisFastProducer):
     @override
     async def publish(
         self, cmd: "RedisPublishCommand"
-    ) -> "int | bytes | ClusterPipeline[bytes]":
+    ) -> "int | bytes | Pipeline[bytes] | ClusterPipeline[bytes]":
         msg = await cmd.message_format.encode(
             message=cmd.body,
             reply_to=cmd.reply_to,

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -2,6 +2,7 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import anyio
+from redis.asyncio.cluster import ClusterPipeline
 from typing_extensions import override
 
 from faststream._internal.endpoint.utils import ParserComposition
@@ -56,7 +57,9 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
         self.codec = codec or DefaultCodec()
 
     @override
-    async def publish_batch(self, cmd: "RedisPublishCommand") -> int:
+    async def publish_batch(
+        self, cmd: "RedisPublishCommand"
+    ) -> "int | ClusterPipeline[bytes]":
         batch = [
             await cmd.message_format.encode(
                 message=msg,
@@ -69,8 +72,41 @@ class BaseRedisFastProducer(ProducerProto[RedisPublishCommand]):
             for msg in cmd.batch_bodies
         ]
 
-        connection = cmd.pipeline or self._connection.client
-        return cast("int", await connection.rpush(cmd.destination, *batch))
+        connection: Any = (
+            cmd.pipeline if cmd.pipeline is not None else self._connection.client
+        )
+        result = connection.rpush(cmd.destination, *batch)
+        if isinstance(result, ClusterPipeline):
+            return result
+        return cast("int", await result)
+
+    async def _publish(
+        self,
+        msg: bytes,
+        cmd: "RedisPublishCommand",
+    ) -> "int | bytes | ClusterPipeline[bytes]":
+        connection: Any = (
+            cmd.pipeline if cmd.pipeline is not None else self._connection.client
+        )
+
+        if cmd.destination_type is DestinationType.Channel:
+            result = connection.publish(cmd.destination, msg)
+        elif cmd.destination_type is DestinationType.List:
+            result = connection.rpush(cmd.destination, msg)
+        elif cmd.destination_type is DestinationType.Stream:
+            result = connection.xadd(
+                name=cmd.destination,
+                fields={DATA_KEY: msg},
+                maxlen=cmd.maxlen,
+            )
+        else:
+            raise UnreachablePathError
+
+        # Awaiting a queued ClusterPipeline clears its commands (see issue #3044).
+        # WATCH-mode commands can instead return a coroutine that must be awaited.
+        if isinstance(result, ClusterPipeline):
+            return result
+        return cast("int | bytes", await result)
 
     def connect(
         self,
@@ -109,7 +145,9 @@ class RedisFastProducer(BaseRedisFastProducer):
         )
 
     @override
-    async def publish(self, cmd: "RedisPublishCommand") -> int | bytes:
+    async def publish(
+        self, cmd: "RedisPublishCommand"
+    ) -> "int | bytes | ClusterPipeline[bytes]":
         msg = await cmd.message_format.encode(
             message=cmd.body,
             reply_to=cmd.reply_to,
@@ -119,33 +157,7 @@ class RedisFastProducer(BaseRedisFastProducer):
             codec=self.codec,
         )
 
-        return await self.__publish(msg, cmd)
-
-    async def __publish(
-        self,
-        msg: bytes,
-        cmd: "RedisPublishCommand",
-    ) -> int | bytes:
-        connection = cmd.pipeline or self._connection.client
-
-        if cmd.destination_type is DestinationType.Channel:
-            return await connection.publish(cmd.destination, msg)
-
-        if cmd.destination_type is DestinationType.List:
-            return await connection.rpush(cmd.destination, msg)
-
-        if cmd.destination_type is DestinationType.Stream:
-            return cast(
-                "bytes",
-                await connection.xadd(
-                    name=cmd.destination,
-                    fields={DATA_KEY: msg},
-                    maxlen=cmd.maxlen,
-                ),
-            )
-
-        error_msg = "unreachable"
-        raise AssertionError(error_msg)
+        return await self._publish(msg, cmd)
 
     @override
     async def request(self, cmd: "RedisPublishCommand") -> "Any":
@@ -165,7 +177,7 @@ class RedisFastProducer(BaseRedisFastProducer):
                 codec=self.codec,
             )
 
-            await self.__publish(msg, cmd)
+            await self._publish(msg, cmd)
 
             with anyio.fail_after(cmd.timeout) as scope:
                 # skip subscribe message
@@ -212,7 +224,9 @@ class RedisClusterFastProducer(BaseRedisFastProducer):
         return RedisClusterFastProducer(cluster_state=self._cluster_state, **kwargs)
 
     @override
-    async def publish(self, cmd: "RedisPublishCommand") -> int | bytes:
+    async def publish(
+        self, cmd: "RedisPublishCommand"
+    ) -> "int | bytes | ClusterPipeline[bytes]":
         msg = await cmd.message_format.encode(
             message=cmd.body,
             reply_to=cmd.reply_to,
@@ -222,21 +236,9 @@ class RedisClusterFastProducer(BaseRedisFastProducer):
             codec=self.codec,
         )
 
-        if cmd.destination_type is DestinationType.Channel:
+        if cmd.pipeline is None and cmd.destination_type is DestinationType.Channel:
             return await self._cluster_state.sync_publish(cmd.destination, msg)
-
-        if cmd.destination_type is DestinationType.List:
-            return cast("int", await self._connection.client.rpush(cmd.destination, msg))
-        if cmd.destination_type is DestinationType.Stream:
-            return cast(
-                "bytes",
-                await self._connection.client.xadd(
-                    name=cmd.destination,
-                    fields={DATA_KEY: msg},
-                    maxlen=cmd.maxlen,
-                ),
-            )
-        raise UnreachablePathError
+        return await self._publish(msg, cmd)
 
     @override
     async def request(self, cmd: "RedisPublishCommand") -> "Any":

--- a/faststream/redis/publisher/usecase.py
+++ b/faststream/redis/publisher/usecase.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from typing_extensions import override
+from typing_extensions import overload, override
 
 from faststream._internal.endpoint.publisher import (
     PublisherSpecification,
@@ -13,6 +13,7 @@ from faststream.response.publish_type import PublishType
 
 if TYPE_CHECKING:
     from redis.asyncio.client import Pipeline
+    from redis.asyncio.cluster import ClusterPipeline
 
     from faststream._internal.basic_types import SendableMessage
     from faststream._internal.types import PublisherMiddleware
@@ -81,7 +82,7 @@ class ChannelPublisher(LogicPublisher):
             "stream": None,
         }
 
-    @override
+    @overload
     async def publish(
         self,
         message: "SendableMessage" = None,
@@ -91,7 +92,31 @@ class ChannelPublisher(LogicPublisher):
         correlation_id: str | None = None,
         *,
         pipeline: Optional["Pipeline[bytes]"] = None,
-    ) -> int:
+    ) -> int: ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "int | ClusterPipeline[bytes]": ...
+
+    @override
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+    ) -> "int | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             message,
             channel=channel or self.channel.name,
@@ -102,7 +127,7 @@ class ChannelPublisher(LogicPublisher):
             _publish_type=PublishType.PUBLISH,
             message_format=self.config.message_format,
         )
-        result: int = await self._basic_publish(
+        result: int | ClusterPipeline[bytes] = await self._basic_publish(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),
@@ -181,7 +206,7 @@ class ListPublisher(LogicPublisher):
             "stream": None,
         }
 
-    @override
+    @overload
     async def publish(
         self,
         message: "SendableMessage" = None,
@@ -191,7 +216,31 @@ class ListPublisher(LogicPublisher):
         correlation_id: str | None = None,
         *,
         pipeline: Optional["Pipeline[bytes]"] = None,
-    ) -> int:
+    ) -> int: ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        list: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "int | ClusterPipeline[bytes]": ...
+
+    @override
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        list: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+    ) -> "int | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             message,
             list=list or self.list.name,
@@ -203,7 +252,7 @@ class ListPublisher(LogicPublisher):
             message_format=self.config.message_format,
         )
 
-        result: int = await self._basic_publish(
+        result: int | ClusterPipeline[bytes] = await self._basic_publish(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),
@@ -259,7 +308,7 @@ class ListPublisher(LogicPublisher):
 
 
 class ListBatchPublisher(ListPublisher):
-    @override
+    @overload
     async def publish(
         self,
         *messages: "SendableMessage",
@@ -268,7 +317,29 @@ class ListBatchPublisher(ListPublisher):
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
         pipeline: Optional["Pipeline[bytes]"] = None,
-    ) -> int:
+    ) -> int: ...
+
+    @overload
+    async def publish(
+        self,
+        *messages: "SendableMessage",
+        list: str | None = None,
+        correlation_id: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "int | ClusterPipeline[bytes]": ...
+
+    @override
+    async def publish(
+        self,
+        *messages: "SendableMessage",
+        list: str | None = None,
+        correlation_id: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+    ) -> "int | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             *messages,
             list=list or self.list.name,
@@ -280,7 +351,7 @@ class ListBatchPublisher(ListPublisher):
             message_format=self.config.message_format,
         )
 
-        result: int = await self._basic_publish_batch(
+        result: int | ClusterPipeline[bytes] = await self._basic_publish_batch(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),
@@ -339,7 +410,7 @@ class StreamPublisher(LogicPublisher):
             "stream": self.stream.name if name_only else self.stream,
         }
 
-    @override
+    @overload
     async def publish(
         self,
         message: "SendableMessage" = None,
@@ -350,7 +421,33 @@ class StreamPublisher(LogicPublisher):
         *,
         maxlen: int | None = None,
         pipeline: Optional["Pipeline[bytes]"] = None,
-    ) -> bytes:
+    ) -> bytes: ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        stream: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
+        maxlen: int | None = None,
+        pipeline: "ClusterPipeline[bytes]",
+    ) -> "bytes | ClusterPipeline[bytes]": ...
+
+    @override
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        stream: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
+        maxlen: int | None = None,
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
+    ) -> "bytes | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             message,
             stream=stream or self.stream.name,
@@ -363,7 +460,7 @@ class StreamPublisher(LogicPublisher):
             message_format=self.config.message_format,
         )
 
-        result: bytes = await self._basic_publish(
+        result: bytes | ClusterPipeline[bytes] = await self._basic_publish(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),

--- a/faststream/redis/publisher/usecase.py
+++ b/faststream/redis/publisher/usecase.py
@@ -91,7 +91,7 @@ class ChannelPublisher(LogicPublisher):
         headers: dict[str, Any] | None = None,
         correlation_id: str | None = None,
         *,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> int: ...
 
     @overload
@@ -103,8 +103,20 @@ class ChannelPublisher(LogicPublisher):
         headers: dict[str, Any] | None = None,
         correlation_id: str | None = None,
         *,
+        pipeline: "Pipeline[bytes]",
+    ) -> "Pipeline[bytes]": ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        channel: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
         pipeline: "ClusterPipeline[bytes]",
-    ) -> "int | ClusterPipeline[bytes]": ...
+    ) -> "ClusterPipeline[bytes]": ...
 
     @override
     async def publish(
@@ -116,7 +128,7 @@ class ChannelPublisher(LogicPublisher):
         correlation_id: str | None = None,
         *,
         pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
-    ) -> "int | ClusterPipeline[bytes]":
+    ) -> "int | Pipeline[bytes] | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             message,
             channel=channel or self.channel.name,
@@ -127,7 +139,9 @@ class ChannelPublisher(LogicPublisher):
             _publish_type=PublishType.PUBLISH,
             message_format=self.config.message_format,
         )
-        result: int | ClusterPipeline[bytes] = await self._basic_publish(
+        result: (
+            int | Pipeline[bytes] | ClusterPipeline[bytes]
+        ) = await self._basic_publish(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),
@@ -215,7 +229,7 @@ class ListPublisher(LogicPublisher):
         headers: dict[str, Any] | None = None,
         correlation_id: str | None = None,
         *,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> int: ...
 
     @overload
@@ -227,8 +241,20 @@ class ListPublisher(LogicPublisher):
         headers: dict[str, Any] | None = None,
         correlation_id: str | None = None,
         *,
+        pipeline: "Pipeline[bytes]",
+    ) -> "Pipeline[bytes]": ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        list: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
         pipeline: "ClusterPipeline[bytes]",
-    ) -> "int | ClusterPipeline[bytes]": ...
+    ) -> "ClusterPipeline[bytes]": ...
 
     @override
     async def publish(
@@ -240,7 +266,7 @@ class ListPublisher(LogicPublisher):
         correlation_id: str | None = None,
         *,
         pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
-    ) -> "int | ClusterPipeline[bytes]":
+    ) -> "int | Pipeline[bytes] | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             message,
             list=list or self.list.name,
@@ -252,7 +278,9 @@ class ListPublisher(LogicPublisher):
             message_format=self.config.message_format,
         )
 
-        result: int | ClusterPipeline[bytes] = await self._basic_publish(
+        result: (
+            int | Pipeline[bytes] | ClusterPipeline[bytes]
+        ) = await self._basic_publish(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),
@@ -316,7 +344,7 @@ class ListBatchPublisher(ListPublisher):
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> int: ...
 
     @overload
@@ -327,8 +355,19 @@ class ListBatchPublisher(ListPublisher):
         correlation_id: str | None = None,
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
+        pipeline: "Pipeline[bytes]",
+    ) -> "Pipeline[bytes]": ...
+
+    @overload
+    async def publish(
+        self,
+        *messages: "SendableMessage",
+        list: str | None = None,
+        correlation_id: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
         pipeline: "ClusterPipeline[bytes]",
-    ) -> "int | ClusterPipeline[bytes]": ...
+    ) -> "ClusterPipeline[bytes]": ...
 
     @override
     async def publish(
@@ -339,7 +378,7 @@ class ListBatchPublisher(ListPublisher):
         reply_to: str = "",
         headers: dict[str, Any] | None = None,
         pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
-    ) -> "int | ClusterPipeline[bytes]":
+    ) -> "int | Pipeline[bytes] | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             *messages,
             list=list or self.list.name,
@@ -351,7 +390,9 @@ class ListBatchPublisher(ListPublisher):
             message_format=self.config.message_format,
         )
 
-        result: int | ClusterPipeline[bytes] = await self._basic_publish_batch(
+        result: (
+            int | Pipeline[bytes] | ClusterPipeline[bytes]
+        ) = await self._basic_publish_batch(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),
@@ -420,7 +461,7 @@ class StreamPublisher(LogicPublisher):
         correlation_id: str | None = None,
         *,
         maxlen: int | None = None,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: None = None,
     ) -> bytes: ...
 
     @overload
@@ -433,8 +474,21 @@ class StreamPublisher(LogicPublisher):
         correlation_id: str | None = None,
         *,
         maxlen: int | None = None,
+        pipeline: "Pipeline[bytes]",
+    ) -> "Pipeline[bytes]": ...
+
+    @overload
+    async def publish(
+        self,
+        message: "SendableMessage" = None,
+        stream: str | None = None,
+        reply_to: str = "",
+        headers: dict[str, Any] | None = None,
+        correlation_id: str | None = None,
+        *,
+        maxlen: int | None = None,
         pipeline: "ClusterPipeline[bytes]",
-    ) -> "bytes | ClusterPipeline[bytes]": ...
+    ) -> "ClusterPipeline[bytes]": ...
 
     @override
     async def publish(
@@ -447,7 +501,7 @@ class StreamPublisher(LogicPublisher):
         *,
         maxlen: int | None = None,
         pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
-    ) -> "bytes | ClusterPipeline[bytes]":
+    ) -> "bytes | Pipeline[bytes] | ClusterPipeline[bytes]":
         cmd = RedisPublishCommand(
             message,
             stream=stream or self.stream.name,
@@ -460,7 +514,9 @@ class StreamPublisher(LogicPublisher):
             message_format=self.config.message_format,
         )
 
-        result: bytes | ClusterPipeline[bytes] = await self._basic_publish(
+        result: (
+            bytes | Pipeline[bytes] | ClusterPipeline[bytes]
+        ) = await self._basic_publish(
             cmd,
             producer=self.producer,
             _extra_middlewares=(),

--- a/faststream/redis/response.py
+++ b/faststream/redis/response.py
@@ -11,6 +11,7 @@ from faststream.response.response import BatchPublishCommand, PublishCommand, Re
 
 if TYPE_CHECKING:
     from redis.asyncio.client import Pipeline
+    from redis.asyncio.cluster import ClusterPipeline
 
     from faststream._internal.basic_types import SendableMessage
 
@@ -69,7 +70,7 @@ class RedisPublishCommand(BatchPublishCommand):
         headers: dict[str, Any] | None = None,
         reply_to: str = "",
         timeout: float | None = 30.0,
-        pipeline: Optional["Pipeline[bytes]"] = None,
+        pipeline: Optional["Pipeline[bytes] | ClusterPipeline[bytes]"] = None,
         message_format: type["MessageFormat"] = BinaryMessageFormatV1,
     ) -> None:
         super().__init__(

--- a/tests/brokers/redis/cluster/test_cluster_more_unit.py
+++ b/tests/brokers/redis/cluster/test_cluster_more_unit.py
@@ -43,24 +43,6 @@ class TestRedisClusterConnectionStateUnit:
         assert state._thread_pool is None
 
 
-class TestClusterBrokerWarnings:
-    """Tests for RuntimeWarning on pipeline usage."""
-
-    @pytest.mark.asyncio()
-    async def test_publish_with_pipeline_warns(self) -> None:
-        broker = RedisClusterBroker(url="redis://127.0.0.1:7001")
-        async with TestRedisBroker(broker) as br:
-            with pytest.warns(RuntimeWarning, match="Pipeline is not supported"):
-                await br.publish("hello", channel="ch", pipeline=None)
-
-    @pytest.mark.asyncio()
-    async def test_publish_batch_with_pipeline_warns(self) -> None:
-        broker = RedisClusterBroker(url="redis://127.0.0.1:7001")
-        async with TestRedisBroker(broker) as br:
-            with pytest.warns(RuntimeWarning, match="Pipeline is not supported"):
-                await br.publish_batch("x", list="l", pipeline=None)
-
-
 class TestClusterBrokerInheritanceExtra:
     """Additional inheritance/API compatibility tests."""
 

--- a/tests/brokers/redis/cluster/test_cluster_pipeline.py
+++ b/tests/brokers/redis/cluster/test_cluster_pipeline.py
@@ -1,0 +1,234 @@
+from importlib.metadata import version
+from typing import Literal
+from unittest.mock import AsyncMock
+
+import pytest
+from redis.asyncio.cluster import RedisCluster
+from redis.exceptions import RedisClusterException
+
+from faststream.redis import ListSub, RedisClusterBroker
+from faststream.redis.configs.state import RedisClusterConnectionState
+from tests.brokers.redis.basic import RedisClusterTestcaseConfig
+
+
+@pytest.mark.redis_cluster()
+@pytest.mark.asyncio()
+@pytest.mark.parametrize("kind", ("list", "stream", "batch"))
+async def test_pipeline_preserves_queued_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    queue: str,
+    kind: Literal["list", "stream", "batch"],
+) -> None:
+    """Fixes https://github.com/ag2ai/faststream/issues/3044.
+
+    Queue through the public broker without awaiting or executing the pipeline.
+    """
+    execute = AsyncMock(return_value=1)
+    monkeypatch.setattr(RedisCluster, "execute_command", execute)
+    monkeypatch.setattr(RedisCluster, "initialize", AsyncMock())
+    broker = RedisClusterBroker()
+    destination = f"{{{queue}}}:messages"
+    publisher = broker.publisher(
+        **(
+            {"list": ListSub(destination, batch=True)}
+            if kind == "batch"
+            else {
+                kind: destination,
+            }
+        )
+    )
+
+    pipe = RedisCluster(host="localhost").pipeline()
+    pipe.incr(f"{{{queue}}}:count")
+
+    if kind == "batch":
+        result = await broker.publish_batch("one", "two", list=destination, pipeline=pipe)
+        publisher_result = await publisher.publish("three", "four", pipeline=pipe)
+    else:
+        result = await broker.publish("one", **{kind: destination}, pipeline=pipe)
+        publisher_result = await publisher.publish("two", pipeline=pipe)
+
+    assert result is pipe
+    assert publisher_result is pipe
+    assert len(pipe) == 3
+    execute.assert_not_awaited()
+
+
+@pytest.mark.redis_cluster()
+@pytest.mark.asyncio()
+async def test_channel_pipeline_keeps_driver_restriction(
+    monkeypatch: pytest.MonkeyPatch,
+    queue: str,
+) -> None:
+    """Fixes https://github.com/ag2ai/faststream/issues/3044.
+
+    Unsupported commands must not bypass the pipeline and publish immediately.
+    """
+    publish = AsyncMock()
+    monkeypatch.setattr(RedisClusterConnectionState, "sync_publish", publish)
+    broker = RedisClusterBroker()
+    publisher = broker.publisher(channel=queue)
+
+    pipe = RedisCluster(host="localhost").pipeline()
+    pipe.incr(f"{{{queue}}}:count")
+
+    with pytest.raises(RedisClusterException, match=r"publish.*blocked"):
+        await broker.publish("one", channel=queue, pipeline=pipe)
+    with pytest.raises(RedisClusterException, match=r"publish.*blocked"):
+        await publisher.publish("two", pipeline=pipe)
+
+    assert len(pipe) == 1
+    publish.assert_not_awaited()
+
+
+@pytest.mark.connected()
+@pytest.mark.redis_cluster()
+@pytest.mark.asyncio()
+@pytest.mark.skipif(
+    tuple(map(int, version("redis").split(".")[:2])) < (6, 2),
+    reason=(
+        "https://github.com/ag2ai/faststream/issues/3044: "
+        "Redis Cluster transactions require redis-py >=6.2."
+    ),
+)
+class TestClusterPipeline(RedisClusterTestcaseConfig):
+    async def test_stream_transaction(self, queue: str) -> None:
+        """Fixes https://github.com/ag2ai/faststream/issues/3044.
+
+        State updates and stream publications stay in the same-slot transaction.
+        """
+        broker = self.get_broker()
+        counter = f"{{{queue}}}:count"
+        stream = f"{{{queue}}}:stream"
+        publisher = broker.publisher(stream=stream)
+
+        async with broker:
+            client = await broker.connect()
+            try:
+                async with client.pipeline(transaction=True) as pipe:
+                    pipe.incr(counter)
+                    await broker.publish(
+                        "one",
+                        stream=stream,
+                        correlation_id=queue,
+                        headers={"source": "broker"},
+                        pipeline=pipe,
+                    )
+                    await publisher.publish("two", pipeline=pipe)
+
+                    assert await client.exists(counter, stream) == 0
+                    results = await pipe.execute()
+
+                assert results[0] == 1
+                assert len(results) == 3
+                assert await client.get(counter) == b"1"
+                entries = await client.xrange(stream)
+                messages = [
+                    broker.message_format.parse(fields[b"__data__"])
+                    for _, fields in entries
+                ]
+                assert [body for body, _ in messages] == [b"one", b"two"]
+                assert messages[0][1]["correlation_id"] == queue
+                assert messages[0][1]["source"] == "broker"
+            finally:
+                await client.delete(counter, stream)
+
+    async def test_list_batch_transaction(self, queue: str) -> None:
+        """Fixes https://github.com/ag2ai/faststream/issues/3044.
+
+        Broker and batch-publisher calls append ordered messages at execution.
+        """
+        broker = self.get_broker()
+        counter = f"{{{queue}}}:count"
+        destination = f"{{{queue}}}:list"
+        publisher = broker.publisher(list=ListSub(destination, batch=True))
+
+        async with broker:
+            client = await broker.connect()
+            try:
+                async with client.pipeline(transaction=True) as pipe:
+                    pipe.incr(counter)
+                    await broker.publish_batch(
+                        "one", "two", list=destination, pipeline=pipe
+                    )
+                    await publisher.publish("three", "four", pipeline=pipe)
+
+                    assert await client.exists(counter, destination) == 0
+                    assert await pipe.execute() == [1, 2, 4]
+
+                assert await client.get(counter) == b"1"
+                messages = await client.lrange(destination, 0, -1)
+                assert [broker.message_format.parse(msg)[0] for msg in messages] == [
+                    b"one",
+                    b"two",
+                    b"three",
+                    b"four",
+                ]
+            finally:
+                await client.delete(counter, destination)
+
+    async def test_watched_pipeline_before_multi(self, queue: str) -> None:
+        """Fixes https://github.com/ag2ai/faststream/issues/3044.
+
+        Preserve redis-py's immediate commands between WATCH and MULTI.
+        """
+        broker = self.get_broker()
+        counter = f"{{{queue}}}:count"
+        stream = f"{{{queue}}}:stream"
+        publisher = broker.publisher(stream=stream)
+
+        async with broker:
+            client = await broker.connect()
+            try:
+                async with client.pipeline(transaction=True) as pipe:
+                    await pipe.watch(counter)
+                    result = await broker.publish(
+                        "immediate", stream=stream, pipeline=pipe
+                    )
+                    assert isinstance(result, bytes)
+                    assert await client.xlen(stream) == 1
+
+                    pipe.multi()
+                    pipe.incr(counter)
+                    await publisher.publish("queued", pipeline=pipe)
+                    assert await client.get(counter) is None
+                    assert await client.xlen(stream) == 1
+
+                    results = await pipe.execute()
+
+                assert results[0] == 1
+                assert len(results) == 2
+                assert await client.get(counter) == b"1"
+                entries = await client.xrange(stream)
+                assert [
+                    broker.message_format.parse(fields[b"__data__"])[0]
+                    for _, fields in entries
+                ] == [b"immediate", b"queued"]
+            finally:
+                await client.delete(counter, stream)
+
+    async def test_cross_slot_transaction_rejected(self, queue: str) -> None:
+        """Fixes https://github.com/ag2ai/faststream/issues/3044.
+
+        A cross-slot transaction must fail without publishing outside it.
+        """
+        from redis.exceptions import CrossSlotTransactionError
+
+        broker = self.get_broker()
+        counter = f"{{first}}:{queue}:count"
+        stream = f"{{second}}:{queue}:stream"
+
+        async with broker:
+            client = await broker.connect()
+            try:
+                async with client.pipeline(transaction=True) as pipe:
+                    pipe.incr(counter)
+                    await broker.publish("one", stream=stream, pipeline=pipe)
+                    with pytest.raises(CrossSlotTransactionError):
+                        await pipe.execute()
+
+                assert await client.get(counter) is None
+                assert await client.xlen(stream) == 0
+            finally:
+                await client.delete(counter)
+                await client.delete(stream)

--- a/tests/brokers/redis/cluster/test_cluster_publish.py
+++ b/tests/brokers/redis/cluster/test_cluster_publish.py
@@ -90,6 +90,26 @@ class TestClusterPublish(RedisClusterTestcaseConfig, BrokerPublishTestcase):
 
         assert {1, "hi"} == {r.result() for r in result}
 
+    async def test_list_publish_batch_connects_without_pipeline(self, queue: str) -> None:
+        """Fixes https://github.com/ag2ai/faststream/issues/3044.
+
+        Supporting external pipelines must preserve implicit batch connections.
+        """
+        broker = self.get_broker()
+        try:
+            assert await broker.publish_batch("one", "two", list=queue) == 2
+            client = await broker.connect()
+            try:
+                messages = await client.lrange(queue, 0, -1)
+                assert [broker.message_format.parse(msg)[0] for msg in messages] == [
+                    b"one",
+                    b"two",
+                ]
+            finally:
+                await client.delete(queue)
+        finally:
+            await broker.stop()
+
     async def test_response(
         self, queue: str, mock: MagicMock, event: asyncio.Event
     ) -> None:
@@ -133,26 +153,6 @@ class TestClusterPublish(RedisClusterTestcaseConfig, BrokerPublishTestcase):
                 timeout=self.timeout,
             )
             assert await response.decode() == "Hi!", response
-
-    async def test_pipeline_warns(
-        self,
-        queue: str,
-    ) -> None:
-        """Pipeline should emit RuntimeWarning in cluster mode."""
-        broker = self.get_broker()
-
-        with pytest.warns(RuntimeWarning, match="Pipeline is not supported"):
-            await broker.publish("hello", channel=queue, pipeline=None)  # type: ignore[arg-type]
-
-    async def test_publish_batch_with_pipeline_warns(
-        self,
-        queue: str,
-    ) -> None:
-        """Pipeline should emit RuntimeWarning for publish_batch in cluster."""
-        broker = self.get_broker()
-
-        with pytest.warns(RuntimeWarning, match="Pipeline is not supported"):
-            await broker.publish_batch("x", "y", list=queue, pipeline=None)  # type: ignore[arg-type]
 
     async def test_channel_publish(
         self,

--- a/tests/brokers/redis/test_publish.py
+++ b/tests/brokers/redis/test_publish.py
@@ -215,10 +215,13 @@ class TestPublish(RedisTestcaseConfig, BrokerPublishTestcase):
         async def m(msg: str, pipe: Pipeline) -> None:
             for _ in range(5):
                 # publish 5 messages by publisher
-                await publisher.publish(None, pipeline=pipe)
+                publisher_result = await publisher.publish(None, pipeline=pipe)
 
                 # and 5 by broker
-                await broker.publish(None, **destination, pipeline=pipe)
+                broker_result = await broker.publish(None, **destination, pipeline=pipe)
+
+                assert publisher_result is pipe
+                assert broker_result is pipe
 
             await pipe.execute()
 
@@ -250,7 +253,10 @@ class TestPublish(RedisTestcaseConfig, BrokerPublishTestcase):
 
         @broker.subscriber(channel=queue)
         async def m(msg: str, pipe: Pipeline) -> None:
-            await broker.publish_batch(*range(5), list=queue + "resp", pipeline=pipe)
+            result = await broker.publish_batch(
+                *range(5), list=queue + "resp", pipeline=pipe
+            )
+            assert result is pipe
             await pipe.execute()
 
         @broker.subscriber(list=ListSub(queue + "resp", batch=True, max_records=5))

--- a/tests/docs/redis/test_pipeline.py
+++ b/tests/docs/redis/test_pipeline.py
@@ -1,6 +1,9 @@
+from importlib.metadata import version
+
 import pytest
 
-from faststream.redis import TestApp, TestRedisBroker
+from faststream.redis import RedisClusterBroker, TestApp, TestRedisBroker
+from tests.brokers.redis.cluster.settings import SettingsCluster
 
 
 @pytest.mark.redis()
@@ -15,3 +18,37 @@ async def test_pipeline() -> None:
     broker.config.fd_config.serializer = None
     async with TestRedisBroker(broker), TestApp(app):
         handle.mock.assert_called_once_with("Hi!")
+
+
+@pytest.mark.connected()
+@pytest.mark.redis_cluster()
+@pytest.mark.asyncio()
+@pytest.mark.skipif(
+    tuple(map(int, version("redis").split(".")[:2])) < (6, 2),
+    reason=(
+        "https://github.com/ag2ai/faststream/issues/3044: "
+        "Redis Cluster transactions require redis-py >=6.2."
+    ),
+)
+async def test_cluster_pipeline(queue: str) -> None:
+    """Fixes https://github.com/ag2ai/faststream/issues/3044."""
+    from docs.docs_src.redis.pipeline.cluster_pipeline import increment_and_publish
+
+    broker = RedisClusterBroker(SettingsCluster().url)
+    counter = f"{{{queue}}}:count"
+    stream = f"{{{queue}}}:events"
+
+    async with broker:
+        client = await broker.connect()
+        try:
+            results = await increment_and_publish(broker, key=queue)
+
+            assert results[0] == 1
+            assert await client.get(counter) == b"1"
+            entries = await client.xrange(stream)
+            assert len(entries) == 1
+            entry_id, fields = entries[0]
+            assert results == [1, entry_id]
+            assert broker.message_format.parse(fields[b"__data__"])[0] == b"created"
+        finally:
+            await client.delete(counter, stream)

--- a/tests/mypy/redis.py
+++ b/tests/mypy/redis.py
@@ -1,6 +1,7 @@
 from collections.abc import Awaitable, Callable
 
 import prometheus_client
+from redis.asyncio.cluster import ClusterPipeline
 from typing_extensions import assert_type
 
 from faststream._internal.basic_types import DecodedMessage
@@ -10,6 +11,7 @@ from faststream.redis import (
     Redis,
     RedisBroker,
     RedisChannelMessage,
+    RedisClusterBroker,
     RedisListMessage,
     RedisMessage as Message,
     RedisPublisher,
@@ -358,6 +360,34 @@ async def check_publisher_publish_result_types(
     p3 = broker.publisher(stream="stream")
     assert_type(p3, StreamPublisher)
     assert_type(await p3.publish(None), bytes)
+
+
+async def check_cluster_pipeline_result_types(pipe: "ClusterPipeline[bytes]") -> None:
+    broker = RedisClusterBroker()
+    assert_type(await broker.publish(None, list="test"), int)
+    assert_type(await broker.publish(None, stream="test"), bytes)
+    assert_type(
+        await broker.publish(None, stream="test", pipeline=pipe),
+        int | bytes | ClusterPipeline[bytes],
+    )
+    assert_type(
+        await broker.publish_batch(None, list="test", pipeline=pipe),
+        int | ClusterPipeline[bytes],
+    )
+    assert_type(
+        await broker.publisher(list="test").publish(None, pipeline=pipe),
+        int | ClusterPipeline[bytes],
+    )
+    assert_type(
+        await broker.publisher(list=ListSub("test", batch=True)).publish(
+            None, pipeline=pipe
+        ),
+        int | ClusterPipeline[bytes],
+    )
+    assert_type(
+        await broker.publisher(stream="test").publish(None, pipeline=pipe),
+        bytes | ClusterPipeline[bytes],
+    )
 
 
 async def check_request_response_type(

--- a/tests/mypy/redis.py
+++ b/tests/mypy/redis.py
@@ -1,6 +1,7 @@
 from collections.abc import Awaitable, Callable
 
 import prometheus_client
+from redis.asyncio.client import Pipeline
 from redis.asyncio.cluster import ClusterPipeline
 from typing_extensions import assert_type
 
@@ -17,6 +18,7 @@ from faststream.redis import (
     RedisPublisher,
     RedisRoute as Route,
     RedisRouter,
+    RedisSentinelBroker,
     RedisStreamMessage,
     StreamSub,
     TestRedisBroker,
@@ -326,8 +328,14 @@ RedisBroker().add_middleware(prometheus_middleware)
 RedisBroker(middlewares=[prometheus_middleware])
 
 
-async def check_broker_publish_result_type(optional_stream: str | None = "test") -> None:
+async def check_broker_publish_result_type(
+    pipe: "Pipeline[bytes]", optional_stream: str | None = "test"
+) -> None:
     broker = RedisBroker()
+    sentinel_broker = RedisSentinelBroker(
+        sentinels=[("localhost", 26379)],
+        sentinel_master_name="mymaster",
+    )
 
     publish_with_confirm = await broker.publish(None)
     assert_type(publish_with_confirm, int)
@@ -341,25 +349,41 @@ async def check_broker_publish_result_type(optional_stream: str | None = "test")
     publish_with_confirm = await broker.publish_batch(None, list="test")
     assert_type(publish_with_confirm, int)
 
+    assert_type(await broker.publish(None, pipeline=pipe), Pipeline[bytes])
+    assert_type(await broker.publish(None, stream="test", pipeline=pipe), Pipeline[bytes])
+    assert_type(
+        await broker.publish_batch(None, list="test", pipeline=pipe), Pipeline[bytes]
+    )
+    assert_type(await sentinel_broker.publish(None, pipeline=pipe), Pipeline[bytes])
+    assert_type(
+        await sentinel_broker.publish_batch(None, list="test", pipeline=pipe),
+        Pipeline[bytes],
+    )
+
 
 async def check_publisher_publish_result_types(
     broker: RedisBroker | RedisRouter | FastAPIRouter,
+    pipe: "Pipeline[bytes]",
 ) -> None:
     p = broker.publisher(channel="test")
     assert_type(p, ChannelPublisher)
     assert_type(await p.publish(None), int)
+    assert_type(await p.publish(None, pipeline=pipe), Pipeline[bytes])
 
     p1 = broker.publisher(list="test")
     assert_type(p1, ListPublisher)
     assert_type(await p1.publish(None), int)
+    assert_type(await p1.publish(None, pipeline=pipe), Pipeline[bytes])
 
     p2 = broker.publisher(list=ListSub("test", batch=True))
     assert_type(p2, ListBatchPublisher | ListPublisher)
     assert_type(await p2.publish(None), int)
+    assert_type(await p2.publish(None, pipeline=pipe), Pipeline[bytes])
 
     p3 = broker.publisher(stream="stream")
     assert_type(p3, StreamPublisher)
     assert_type(await p3.publish(None), bytes)
+    assert_type(await p3.publish(None, pipeline=pipe), Pipeline[bytes])
 
 
 async def check_cluster_pipeline_result_types(pipe: "ClusterPipeline[bytes]") -> None:
@@ -368,25 +392,25 @@ async def check_cluster_pipeline_result_types(pipe: "ClusterPipeline[bytes]") ->
     assert_type(await broker.publish(None, stream="test"), bytes)
     assert_type(
         await broker.publish(None, stream="test", pipeline=pipe),
-        int | bytes | ClusterPipeline[bytes],
+        ClusterPipeline[bytes],
     )
     assert_type(
         await broker.publish_batch(None, list="test", pipeline=pipe),
-        int | ClusterPipeline[bytes],
+        ClusterPipeline[bytes],
     )
     assert_type(
         await broker.publisher(list="test").publish(None, pipeline=pipe),
-        int | ClusterPipeline[bytes],
+        ClusterPipeline[bytes],
     )
     assert_type(
         await broker.publisher(list=ListSub("test", batch=True)).publish(
             None, pipeline=pipe
         ),
-        int | ClusterPipeline[bytes],
+        ClusterPipeline[bytes],
     )
     assert_type(
         await broker.publisher(stream="test").publish(None, pipeline=pipe),
-        bytes | ClusterPipeline[bytes],
+        ClusterPipeline[bytes],
     )
 
 


### PR DESCRIPTION
# Description

Fixes #3044.

`RedisClusterBroker` currently ignores `pipeline=`, so a state update and a publication cannot share a transaction. Simply forwarding it is not enough: awaiting the `ClusterPipeline` returned by a queued command reinitializes the pipeline and clears its queued commands.

This change forwards the supplied pipeline through broker and publisher calls for lists, streams, and list batches. Queued calls return the pipeline without awaiting it; commands issued after `WATCH` but before `MULTI` still execute immediately. Publishing without a pipeline keeps its existing behavior, including automatic connection for cluster batch publishing.

Channel `PUBLISH` remains blocked by redis-py in cluster pipelines. There is no immediate-publish fallback. Atomic transactions require redis-py 6.2.0 or later and keys in the same hash slot; ordinary pipelines are not atomic.

## Type of change

- [x] New feature
- [x] Documentation update

## Validation

- 110 related tests passed, covering standalone Redis publishing, cluster publishing, producers, pipelines, and the documentation example. Redis 7.0.15 ran as a standalone server and a three-node cluster. Five existing slow tests were excluded.
- The standalone test broker used `127.0.0.1` locally. Windows/WSL's `localhost` IPv6 fallback exceeded existing timeouts; the same RPC timeout reproduced on unchanged main. No production code or test timeout was changed for this environment issue.
- redis-py 6.2.0: all nine focused cluster tests passed, including same-slot transactions, WATCH/MULTI, cross-slot rejection, and the runnable example.
- redis-py 5.0.0: all four non-connected queue-preservation and command-restriction cases passed. Transactions are not claimed for this version.
- All four deterministic regression cases fail on unchanged main.
- Ruff, codespell, Mypy, Pyright, Bandit, and Semgrep passed. The remaining pre-commit hooks passed; local `just` wrappers were checked through their underlying commands.

## Checklist

- [x] Reviewed the implementation and preserved existing no-pipeline behavior
- [x] Added regression tests and public API type checks
- [x] Updated the cluster and pipeline documentation with a tested example
- [x] Ran the affected tests and static analysis
