### PR TITLE
fix(nats): clean up failed JetStream request subscriptions

### DIFF
--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -1,5 +1,6 @@
 import asyncio
 from abc import abstractmethod
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional
 
 import anyio
@@ -183,31 +184,44 @@ class NatsJSFastProducer(NatsFastProducer):
             future=future,
             max_msgs=1,
         )
-        await sub.unsubscribe(limit=1)
+        try:
+            await sub.unsubscribe(limit=1)
 
-        headers_to_send = {
-            "content-type": content_type or "",
-            "reply_to": reply_to,
-            **cmd.headers_to_publish(js=False),
-        }
+            headers_to_send = {
+                "content-type": content_type or "",
+                "reply_to": reply_to,
+                **cmd.headers_to_publish(js=False),
+            }
 
-        with anyio.fail_after(cmd.timeout):
-            await self.__state.connection.publish(
-                subject=cmd.destination,
-                payload=payload,
-                headers=headers_to_send,
-                stream=cmd.stream,
-                timeout=cmd.timeout,
-            )
+            with anyio.fail_after(cmd.timeout):
+                await self.__state.connection.publish(
+                    subject=cmd.destination,
+                    payload=payload,
+                    headers=headers_to_send,
+                    stream=cmd.stream,
+                    timeout=cmd.timeout,
+                )
 
-            msg = await future
+                msg = await future
 
-            if (  # pragma: no cover
-                msg.headers and (msg.headers.get(Header.STATUS) == NO_RESPONDERS_STATUS)
+                if (  # pragma: no cover
+                    msg.headers
+                    and (msg.headers.get(Header.STATUS) == NO_RESPONDERS_STATUS)
+                ):
+                    raise nats.errors.NoRespondersError
+
+                return msg
+        finally:
+            future.cancel()
+            # The one-message limit cannot remove an inbox that never receives a reply.
+            with (
+                anyio.CancelScope(shield=True),
+                suppress(
+                    nats.errors.ConnectionClosedError,
+                    nats.errors.ConnectionDrainingError,
+                ),
             ):
-                raise nats.errors.NoRespondersError
-
-            return msg
+                await sub.unsubscribe()
 
 
 class FakeNatsFastProducer(NatsFastProducer):

--- a/tests/brokers/nats/test_request_cleanup.py
+++ b/tests/brokers/nats/test_request_cleanup.py
@@ -12,10 +12,11 @@ from nats.js.api import PubAck
 
 from faststream.nats import NatsBroker
 
+from .settings import Settings
+
 pytestmark = [pytest.mark.asyncio(), pytest.mark.nats()]
 
 RequestTransport: TypeAlias = tuple[NatsBroker, Client, list[bytes]]
-RealRequestTransport: TypeAlias = tuple[NatsBroker, Client, set[int]]
 
 
 @pytest_asyncio.fixture()
@@ -40,52 +41,6 @@ async def request_transport(
         await connection.close()
 
 
-@pytest_asyncio.fixture()
-async def real_request_transport(queue: str) -> AsyncIterator[RealRequestTransport]:
-    async with NatsBroker() as broker:
-        connection = broker._connection
-        assert connection is not None
-        jetstream = connection.jetstream()
-        await jetstream.add_stream(name=queue, subjects=[queue])
-        try:
-            # Creating the stream also initializes the shared JetStream reply mux.
-            yield broker, connection, set(connection._subs)
-        finally:
-            await jetstream.delete_stream(queue)
-
-
-async def test_timed_out_jetstream_request_removes_reply_subscription(
-    request_transport: RequestTransport,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    broker, connection, commands = request_transport
-    monkeypatch.setattr(
-        JetStreamContext, "publish", AsyncMock(return_value=PubAck(stream="jobs", seq=1))
-    )
-
-    with pytest.raises(TimeoutError):
-        await broker.request("request", "jobs", stream="jobs", timeout=0.01)
-
-    assert not connection._subs
-    assert commands[-1].split() == [b"UNSUB", b"1"]
-
-
-async def test_failed_jetstream_publish_removes_reply_subscription(
-    request_transport: RequestTransport,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    broker, connection, commands = request_transport
-    monkeypatch.setattr(
-        JetStreamContext, "publish", AsyncMock(side_effect=nats.errors.NoRespondersError)
-    )
-
-    with pytest.raises(nats.errors.NoRespondersError):
-        await broker.request("request", "jobs", stream="jobs", timeout=0.01)
-
-    assert not connection._subs
-    assert commands[-1].split() == [b"UNSUB", b"1"]
-
-
 async def test_failed_reply_limit_setup_removes_reply_subscription(
     request_transport: RequestTransport,
     monkeypatch: pytest.MonkeyPatch,
@@ -103,51 +58,29 @@ async def test_failed_reply_limit_setup_removes_reply_subscription(
     with pytest.raises(RuntimeError):
         await broker.request("request", "jobs", stream="jobs", timeout=0.01)
 
-    assert not connection._subs
-    assert commands[-1].split() == [b"UNSUB", b"1"]
+    assert (connection._subs, commands[-1].split()) == ({}, [b"UNSUB", b"1"])
 
 
 @pytest.mark.connected()
 async def test_real_timed_out_requests_remove_reply_subscriptions(
-    real_request_transport: RealRequestTransport,
+    settings: Settings,
     queue: str,
 ) -> None:
-    broker, connection, subscriptions = real_request_transport
-    for _ in range(3):
-        with pytest.raises(TimeoutError):
-            await broker.request("request", queue, stream=queue, timeout=0.05)
+    async with NatsBroker(settings.url) as broker:
+        connection = broker._connection
+        assert connection is not None
+        jetstream = connection.jetstream()
+        await jetstream.add_stream(name=queue, subjects=[queue])
+        try:
+            # Creating the stream first includes the shared JetStream reply mux.
+            subscriptions = set(connection._subs)
+            with pytest.raises(TimeoutError):
+                await broker.request("request", queue, stream=queue, timeout=0.05)
 
-        await connection.flush()
-        assert set(connection._subs) == subscriptions
-
-
-@pytest.mark.connected()
-async def test_real_failed_publishes_remove_reply_subscriptions(
-    real_request_transport: RealRequestTransport,
-    queue: str,
-) -> None:
-    broker, connection, subscriptions = real_request_transport
-    for _ in range(3):
-        with pytest.raises(nats.js.errors.NoStreamResponseError):
-            await broker.request("request", f"{queue}.missing", stream=queue, timeout=3)
-
-        await connection.flush()
-        assert set(connection._subs) == subscriptions
-
-
-@pytest.mark.connected()
-async def test_real_cancelled_requests_remove_reply_subscriptions(
-    real_request_transport: RealRequestTransport,
-    queue: str,
-) -> None:
-    broker, connection, subscriptions = real_request_transport
-    for _ in range(3):
-        with anyio.move_on_after(0.05) as scope:
-            await broker.request("request", queue, stream=queue, timeout=10)
-        assert scope.cancelled_caught
-
-        await connection.flush()
-        assert set(connection._subs) == subscriptions
+            await connection.flush()
+            assert set(connection._subs) == subscriptions
+        finally:
+            await jetstream.delete_stream(queue)
 
 
 async def test_cancelled_jetstream_request_unsubscribes_under_cancel_scope(
@@ -164,27 +97,11 @@ async def test_cancelled_jetstream_request_unsubscribes_under_cancel_scope(
     with anyio.CancelScope() as scope:
         await broker.request("request", "jobs", stream="jobs")
 
-    assert scope.cancelled_caught
-    assert not connection._subs
-    assert commands[-1].split() == [b"UNSUB", b"1"]
-
-
-async def test_successful_jetstream_request_keeps_reply(
-    request_transport: RequestTransport,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    broker, connection, _ = request_transport
-
-    async def publish(*args: object, headers: dict[str, str], **kwargs: object) -> PubAck:
-        inbox = headers["reply_to"]
-        await connection._process_msg(1, inbox.encode(), b"", b"response", b"")
-        return PubAck(stream="jobs", seq=1)
-
-    monkeypatch.setattr(JetStreamContext, "publish", publish)
-    response = await broker.request("request", "jobs", stream="jobs")
-
-    assert response.body == b"response"
-    assert not connection._subs
+    assert (scope.cancelled_caught, connection._subs, commands[-1].split()) == (
+        True,
+        {},
+        [b"UNSUB", b"1"],
+    )
 
 
 async def test_closed_connection_preserves_publish_error(

--- a/tests/brokers/nats/test_request_cleanup.py
+++ b/tests/brokers/nats/test_request_cleanup.py
@@ -1,0 +1,156 @@
+from unittest.mock import AsyncMock
+
+import anyio
+import nats
+import pytest
+import pytest_asyncio
+from nats.js import JetStreamContext
+from nats.js.api import PubAck
+
+from faststream.nats import NatsBroker
+
+pytestmark = [pytest.mark.asyncio(), pytest.mark.nats()]
+
+
+@pytest_asyncio.fixture()
+async def request_transport(monkeypatch):
+    connection = nats.NATS()
+    commands = []
+
+    async def send_command(command):
+        await anyio.lowlevel.checkpoint()
+        commands.append(command)
+
+    monkeypatch.setattr(connection, "_send_command", send_command)
+    monkeypatch.setattr(connection, "_flush_pending", AsyncMock())
+    monkeypatch.setattr(nats, "connect", AsyncMock(return_value=connection))
+    broker = NatsBroker()
+    await broker.connect()
+    try:
+        yield broker, connection, commands
+    finally:
+        await connection.close()
+
+
+@pytest.mark.parametrize("failure", ("timeout", "publish", "unsubscribe"))
+async def test_failed_jetstream_request_removes_reply_subscription(
+    request_transport,
+    monkeypatch,
+    failure: str,
+) -> None:
+    broker, connection, commands = request_transport
+    publish = AsyncMock(return_value=PubAck(stream="jobs", seq=1))
+    monkeypatch.setattr(JetStreamContext, "publish", publish)
+    expected_error = TimeoutError
+    if failure == "publish":
+        publish.side_effect = nats.errors.NoRespondersError
+        expected_error = nats.errors.NoRespondersError
+    elif failure == "unsubscribe":
+        send_unsubscribe = connection._send_unsubscribe
+
+        async def fail_initial_unsubscribe(sid, limit=0):
+            if limit:
+                raise RuntimeError
+            await send_unsubscribe(sid, limit)
+
+        monkeypatch.setattr(connection, "_send_unsubscribe", fail_initial_unsubscribe)
+        expected_error = RuntimeError
+
+    with pytest.raises(expected_error):
+        await broker.request("request", "jobs", stream="jobs", timeout=0.01)
+
+    assert not connection._subs
+    assert commands[-1].split() == [b"UNSUB", b"1"]
+
+
+@pytest.mark.connected()
+@pytest.mark.parametrize("failure", ("timeout", "publish", "cancel"))
+async def test_real_failed_jetstream_requests_remove_reply_subscriptions(
+    queue: str,
+    failure: str,
+) -> None:
+    async with NatsBroker() as broker:
+        connection = broker._connection
+        jetstream = connection.jetstream()
+        await jetstream.add_stream(name=queue, subjects=[queue])
+        try:
+            # Creating the stream also initializes the shared JetStream reply mux.
+            subscriptions = set(connection._subs)
+            for _ in range(3):
+                if failure == "cancel":
+                    with anyio.move_on_after(0.05) as scope:
+                        await broker.request("request", queue, stream=queue, timeout=10)
+                    assert scope.cancelled_caught
+                else:
+                    subject = queue if failure == "timeout" else f"{queue}.missing"
+                    expected_error = (
+                        TimeoutError
+                        if failure == "timeout"
+                        else nats.js.errors.NoStreamResponseError
+                    )
+                    with pytest.raises(expected_error):
+                        await broker.request(
+                            "request",
+                            subject,
+                            stream=queue,
+                            timeout=0.05 if failure == "timeout" else 3,
+                        )
+
+                await connection.flush()
+                assert set(connection._subs) == subscriptions
+        finally:
+            await jetstream.delete_stream(queue)
+
+
+async def test_cancelled_jetstream_request_unsubscribes_under_cancel_scope(
+    request_transport,
+    monkeypatch,
+) -> None:
+    broker, connection, commands = request_transport
+
+    async def publish(*args, **kwargs):
+        scope.cancel()
+        await anyio.sleep_forever()
+
+    monkeypatch.setattr(JetStreamContext, "publish", publish)
+    with anyio.CancelScope() as scope:
+        await broker.request("request", "jobs", stream="jobs")
+
+    assert scope.cancelled_caught
+    assert not connection._subs
+    assert commands[-1].split() == [b"UNSUB", b"1"]
+
+
+async def test_successful_jetstream_request_keeps_reply(
+    request_transport,
+    monkeypatch,
+) -> None:
+    broker, connection, _ = request_transport
+
+    async def publish(*args, **kwargs):
+        inbox = kwargs["headers"]["reply_to"]
+        await connection._process_msg(1, inbox.encode(), b"", b"response", None)
+        return PubAck(stream="jobs", seq=1)
+
+    monkeypatch.setattr(JetStreamContext, "publish", publish)
+    response = await broker.request("request", "jobs", stream="jobs")
+
+    assert response.body == b"response"
+    assert not connection._subs
+
+
+async def test_closed_connection_preserves_publish_error(
+    request_transport,
+    monkeypatch,
+) -> None:
+    broker, connection, _ = request_transport
+
+    async def publish(*args, **kwargs):
+        await connection.close()
+        raise nats.errors.TimeoutError
+
+    monkeypatch.setattr(JetStreamContext, "publish", publish)
+    with pytest.raises(nats.errors.TimeoutError):
+        await broker.request("request", "jobs", stream="jobs")
+
+    assert not connection._subs

--- a/tests/brokers/nats/test_request_cleanup.py
+++ b/tests/brokers/nats/test_request_cleanup.py
@@ -1,9 +1,12 @@
+from collections.abc import AsyncIterator
+from typing import TypeAlias
 from unittest.mock import AsyncMock
 
 import anyio
 import nats
 import pytest
 import pytest_asyncio
+from nats.aio.client import Client
 from nats.js import JetStreamContext
 from nats.js.api import PubAck
 
@@ -11,13 +14,18 @@ from faststream.nats import NatsBroker
 
 pytestmark = [pytest.mark.asyncio(), pytest.mark.nats()]
 
+RequestTransport: TypeAlias = tuple[NatsBroker, Client, list[bytes]]
+RealRequestTransport: TypeAlias = tuple[NatsBroker, Client, set[int]]
+
 
 @pytest_asyncio.fixture()
-async def request_transport(monkeypatch):
-    connection = nats.NATS()
-    commands = []
+async def request_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[RequestTransport]:
+    connection = Client()
+    commands: list[bytes] = []
 
-    async def send_command(command):
+    async def send_command(command: bytes) -> None:
         await anyio.lowlevel.checkpoint()
         commands.append(command)
 
@@ -32,31 +40,67 @@ async def request_transport(monkeypatch):
         await connection.close()
 
 
-@pytest.mark.parametrize("failure", ("timeout", "publish", "unsubscribe"))
-async def test_failed_jetstream_request_removes_reply_subscription(
-    request_transport,
-    monkeypatch,
-    failure: str,
+@pytest_asyncio.fixture()
+async def real_request_transport(queue: str) -> AsyncIterator[RealRequestTransport]:
+    async with NatsBroker() as broker:
+        connection = broker._connection
+        assert connection is not None
+        jetstream = connection.jetstream()
+        await jetstream.add_stream(name=queue, subjects=[queue])
+        try:
+            # Creating the stream also initializes the shared JetStream reply mux.
+            yield broker, connection, set(connection._subs)
+        finally:
+            await jetstream.delete_stream(queue)
+
+
+async def test_timed_out_jetstream_request_removes_reply_subscription(
+    request_transport: RequestTransport,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broker, connection, commands = request_transport
-    publish = AsyncMock(return_value=PubAck(stream="jobs", seq=1))
-    monkeypatch.setattr(JetStreamContext, "publish", publish)
-    expected_error = TimeoutError
-    if failure == "publish":
-        publish.side_effect = nats.errors.NoRespondersError
-        expected_error = nats.errors.NoRespondersError
-    elif failure == "unsubscribe":
-        send_unsubscribe = connection._send_unsubscribe
+    monkeypatch.setattr(
+        JetStreamContext, "publish", AsyncMock(return_value=PubAck(stream="jobs", seq=1))
+    )
 
-        async def fail_initial_unsubscribe(sid, limit=0):
-            if limit:
-                raise RuntimeError
-            await send_unsubscribe(sid, limit)
+    with pytest.raises(TimeoutError):
+        await broker.request("request", "jobs", stream="jobs", timeout=0.01)
 
-        monkeypatch.setattr(connection, "_send_unsubscribe", fail_initial_unsubscribe)
-        expected_error = RuntimeError
+    assert not connection._subs
+    assert commands[-1].split() == [b"UNSUB", b"1"]
 
-    with pytest.raises(expected_error):
+
+async def test_failed_jetstream_publish_removes_reply_subscription(
+    request_transport: RequestTransport,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker, connection, commands = request_transport
+    monkeypatch.setattr(
+        JetStreamContext, "publish", AsyncMock(side_effect=nats.errors.NoRespondersError)
+    )
+
+    with pytest.raises(nats.errors.NoRespondersError):
+        await broker.request("request", "jobs", stream="jobs", timeout=0.01)
+
+    assert not connection._subs
+    assert commands[-1].split() == [b"UNSUB", b"1"]
+
+
+async def test_failed_reply_limit_setup_removes_reply_subscription(
+    request_transport: RequestTransport,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker, connection, commands = request_transport
+    send_unsubscribe = connection._send_unsubscribe
+
+    async def fail_initial_unsubscribe(sid: int, limit: int = 0) -> None:
+        if limit:
+            raise RuntimeError
+        await send_unsubscribe(sid, limit)
+
+    monkeypatch.setattr(connection, "_send_unsubscribe", fail_initial_unsubscribe)
+
+    with pytest.raises(RuntimeError):
         await broker.request("request", "jobs", stream="jobs", timeout=0.01)
 
     assert not connection._subs
@@ -64,51 +108,55 @@ async def test_failed_jetstream_request_removes_reply_subscription(
 
 
 @pytest.mark.connected()
-@pytest.mark.parametrize("failure", ("timeout", "publish", "cancel"))
-async def test_real_failed_jetstream_requests_remove_reply_subscriptions(
+async def test_real_timed_out_requests_remove_reply_subscriptions(
+    real_request_transport: RealRequestTransport,
     queue: str,
-    failure: str,
 ) -> None:
-    async with NatsBroker() as broker:
-        connection = broker._connection
-        jetstream = connection.jetstream()
-        await jetstream.add_stream(name=queue, subjects=[queue])
-        try:
-            # Creating the stream also initializes the shared JetStream reply mux.
-            subscriptions = set(connection._subs)
-            for _ in range(3):
-                if failure == "cancel":
-                    with anyio.move_on_after(0.05) as scope:
-                        await broker.request("request", queue, stream=queue, timeout=10)
-                    assert scope.cancelled_caught
-                else:
-                    subject = queue if failure == "timeout" else f"{queue}.missing"
-                    expected_error = (
-                        TimeoutError
-                        if failure == "timeout"
-                        else nats.js.errors.NoStreamResponseError
-                    )
-                    with pytest.raises(expected_error):
-                        await broker.request(
-                            "request",
-                            subject,
-                            stream=queue,
-                            timeout=0.05 if failure == "timeout" else 3,
-                        )
+    broker, connection, subscriptions = real_request_transport
+    for _ in range(3):
+        with pytest.raises(TimeoutError):
+            await broker.request("request", queue, stream=queue, timeout=0.05)
 
-                await connection.flush()
-                assert set(connection._subs) == subscriptions
-        finally:
-            await jetstream.delete_stream(queue)
+        await connection.flush()
+        assert set(connection._subs) == subscriptions
+
+
+@pytest.mark.connected()
+async def test_real_failed_publishes_remove_reply_subscriptions(
+    real_request_transport: RealRequestTransport,
+    queue: str,
+) -> None:
+    broker, connection, subscriptions = real_request_transport
+    for _ in range(3):
+        with pytest.raises(nats.js.errors.NoStreamResponseError):
+            await broker.request("request", f"{queue}.missing", stream=queue, timeout=3)
+
+        await connection.flush()
+        assert set(connection._subs) == subscriptions
+
+
+@pytest.mark.connected()
+async def test_real_cancelled_requests_remove_reply_subscriptions(
+    real_request_transport: RealRequestTransport,
+    queue: str,
+) -> None:
+    broker, connection, subscriptions = real_request_transport
+    for _ in range(3):
+        with anyio.move_on_after(0.05) as scope:
+            await broker.request("request", queue, stream=queue, timeout=10)
+        assert scope.cancelled_caught
+
+        await connection.flush()
+        assert set(connection._subs) == subscriptions
 
 
 async def test_cancelled_jetstream_request_unsubscribes_under_cancel_scope(
-    request_transport,
-    monkeypatch,
+    request_transport: RequestTransport,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broker, connection, commands = request_transport
 
-    async def publish(*args, **kwargs):
+    async def publish(*args: object, **kwargs: object) -> None:
         scope.cancel()
         await anyio.sleep_forever()
 
@@ -122,14 +170,14 @@ async def test_cancelled_jetstream_request_unsubscribes_under_cancel_scope(
 
 
 async def test_successful_jetstream_request_keeps_reply(
-    request_transport,
-    monkeypatch,
+    request_transport: RequestTransport,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broker, connection, _ = request_transport
 
-    async def publish(*args, **kwargs):
-        inbox = kwargs["headers"]["reply_to"]
-        await connection._process_msg(1, inbox.encode(), b"", b"response", None)
+    async def publish(*args: object, headers: dict[str, str], **kwargs: object) -> PubAck:
+        inbox = headers["reply_to"]
+        await connection._process_msg(1, inbox.encode(), b"", b"response", b"")
         return PubAck(stream="jobs", seq=1)
 
     monkeypatch.setattr(JetStreamContext, "publish", publish)
@@ -140,12 +188,12 @@ async def test_successful_jetstream_request_keeps_reply(
 
 
 async def test_closed_connection_preserves_publish_error(
-    request_transport,
-    monkeypatch,
+    request_transport: RequestTransport,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     broker, connection, _ = request_transport
 
-    async def publish(*args, **kwargs):
+    async def publish(*args: object, **kwargs: object) -> PubAck:
         await connection.close()
         raise nats.errors.TimeoutError
 


### PR DESCRIPTION
# Description

JetStream requests leave reply inbox subscriptions behind when they time out, fail to publish, or are cancelled before a response arrives. `unsubscribe(limit=1)` only removes interest after a message is received, so failed requests accumulate subscriptions for the lifetime of the connection.

Clean up the reply future and subscription in `finally`, including failures while setting the reply limit. Shield unsubscribe from AnyIO cancellation so the final `UNSUB` can be sent. Preserve the original request error if the connection has already closed or started draining.

## Type of change

- [x] Bug fix

## Validation

Python 3.13.14, nats-py 2.14.0, and a real local NATS 2.14.6 server with JetStream:

```text
uv run --no-sync pytest tests/brokers/nats/test_request_cleanup.py tests/brokers/nats/test_requests.py -q -o addopts='' --timeout=15
Original source: 3 failed, 19 passed
Fixed source:    22 passed
```

Following the repository's `testing-patterns` skill, the cleanup tests are reduced from nine to four distinct boundaries:

- A real request timeout removes the unused inbox subscription.
- Failure while setting the reply limit still cleans up the subscription.
- Cancellation during publish still sends the final unsubscribe command.
- Connection closure does not replace the original publish error.

The cancellation case also fails when shielding is disabled. The error-preservation case fails when suppression of connection-closed/draining errors is removed. Existing connected and in-memory request tests cover successful broker/publisher responses; duplicate success and failure cases were removed. The connected case uses the existing `settings` and unique `queue` fixtures.

Ruff lint/format, codespell, strict mypy for the changed test module, and the configured mypy check over 516 source files pass. Applicable pre-commit file checks, typos, and detect-secrets pass; the `just` wrapper hooks were skipped, with lint and type checks executed directly. The production code is unchanged by this test-review follow-up.

These checks run natively on Windows. The full multi-broker Docker matrix was not run.

## Checklist

- [x] Focused implementation and regression tests reviewed
- [x] Tests demonstrate the original failure and pass with the fix
- [x] Existing real and in-memory NATS request tests pass
- [x] Formatting, type checks, and file checks pass as described above
