### PR TITLE
chore: three small clean-ups in one PR

### DIFF
--- a/faststream/_internal/constants.py
+++ b/faststream/_internal/constants.py
@@ -23,3 +23,6 @@ class EmptyPlaceholder:
 
 
 EMPTY: Any = EmptyPlaceholder()
+
+PATH_CONTEXT_PREFIX = "message.path."
+"""Where a `Path()` parameter reads from: the Path parameters an Address captured."""

--- a/faststream/mqtt/broker/broker.py
+++ b/faststream/mqtt/broker/broker.py
@@ -3,14 +3,13 @@ from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
-    Literal,
     Optional,
 )
 from urllib.parse import urlsplit
 
 import zmqtt
 from fast_depends import Provider, dependency_provider
-from typing_extensions import override
+from typing_extensions import assert_never, override
 
 from faststream._internal.broker import BrokerUsecase
 from faststream._internal.constants import EMPTY
@@ -20,6 +19,7 @@ from faststream._internal.types import IdGenerator
 from faststream.message import gen_cor_id
 from faststream.middlewares import AckPolicy
 from faststream.mqtt.broker.config import MQTTBrokerConfig
+from faststream.mqtt.parser import MQTTVersion
 from faststream.mqtt.publisher.producer import (
     ZmqttBaseProducer,
     ZmqttProducerV5,
@@ -65,7 +65,7 @@ class MQTTBroker(
         keepalive: int = 60,
         clean_session: bool = True,
         will: zmqtt.Will | None = None,
-        version: Literal["3.1.1", "5.0"] = "5.0",
+        version: MQTTVersion = "5.0",
         reconnect: zmqtt.ReconnectConfig | None = None,
         on_connection_recovery_failed: Callable[[], Awaitable[None]] | None = None,
         mqtt_connect_timeout: float = 30.0,
@@ -130,14 +130,16 @@ class MQTTBroker(
             connection_kwargs["stripped_prefixes"] = stripped_prefixes
 
         producer: ZmqttBaseProducer
-        if version == "5.0":
+        if version == "3.1.1":
+            producer = ZmqttProducerV311(
+                parser=parser, decoder=decoder, id_generator=id_generator
+            )
+        elif version == "5.0":
             producer = ZmqttProducerV5(
                 parser=parser, decoder=decoder, id_generator=id_generator
             )
         else:
-            producer = ZmqttProducerV311(
-                parser=parser, decoder=decoder, id_generator=id_generator
-            )
+            assert_never(version)
 
         connection_url = build_mqtt_url(
             host=connection_host,

--- a/faststream/mqtt/broker/config.py
+++ b/faststream/mqtt/broker/config.py
@@ -5,6 +5,7 @@ from faststream._internal._compat import HAS_OPENTELEMETRY
 from faststream._internal.configs import BrokerConfig
 from faststream._internal.parser import DefaultCodec
 from faststream.exceptions import FeatureNotSupportedException, IncorrectState
+from faststream.mqtt.parser import MQTTVersion
 from faststream.mqtt.publisher.producer import ZmqttFakeProducer
 
 if TYPE_CHECKING:
@@ -22,7 +23,7 @@ MQTTVersionUnset = cast("str", object())
 
 @dataclass(kw_only=True)
 class MQTTBrokerConfig(BrokerConfig):
-    version: Literal["3.1.1", "5.0", "unset"] = "unset"
+    version: MQTTVersion | Literal["unset"] = "unset"
 
     producer: "ZmqttBaseProducer" = field(default_factory=ZmqttFakeProducer)
     _client: Optional["zmqtt.MQTTClient"] = field(default=None, init=False, repr=False)

--- a/faststream/mqtt/fastapi/fastapi.py
+++ b/faststream/mqtt/fastapi/fastapi.py
@@ -17,6 +17,7 @@ from faststream._internal.types import IdGenerator
 from faststream.message import gen_cor_id
 from faststream.middlewares import AckPolicy
 from faststream.mqtt.broker.broker import MQTTBroker
+from faststream.mqtt.parser import MQTTVersion
 
 if TYPE_CHECKING:
     from enum import Enum
@@ -56,7 +57,7 @@ class MQTTRouter(StreamRouter[zmqtt.Message]):
         keepalive: int = 60,
         clean_session: bool = True,
         will: zmqtt.Will | None = None,
-        version: Literal["3.1.1", "5.0"] = "5.0",
+        version: MQTTVersion = "5.0",
         reconnect: zmqtt.ReconnectConfig | None = None,
         on_connection_recovery_failed: Callable[[], Awaitable[None]] | None = None,
         session_expiry_interval: int = 0,

--- a/faststream/mqtt/parser.py
+++ b/faststream/mqtt/parser.py
@@ -91,3 +91,12 @@ class MQTTParserV5(MQTTBaseParser):
             reply_to=reply_to,
             correlation_id=correlation_id,
         )
+
+
+def parser_for(version: str) -> type[MQTTBaseParser]:
+    """The parser class a Broker version speaks.
+
+    One place says it, because the Subscriber that consumes through a parser and
+    the in-memory test broker that encodes for one have to agree on the version.
+    """
+    return MQTTParserV311 if version == "3.1.1" else MQTTParserV5

--- a/faststream/mqtt/parser.py
+++ b/faststream/mqtt/parser.py
@@ -1,8 +1,9 @@
 from contextlib import suppress
 from re import Pattern
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import zmqtt
+from typing_extensions import assert_never
 
 from faststream._internal._compat import json_loads
 from faststream.message import StreamMessage, decode_message
@@ -11,6 +12,10 @@ from .message import MQTTMessage
 
 if TYPE_CHECKING:
     from faststream._internal.basic_types import DecodedMessage
+
+
+MQTTVersion = Literal["3.1.1", "5.0"]
+"""The protocol versions FastStream speaks."""
 
 
 class MQTTBaseParser:
@@ -93,10 +98,14 @@ class MQTTParserV5(MQTTBaseParser):
         )
 
 
-def parser_for(version: str) -> type[MQTTBaseParser]:
+def parser_for(version: MQTTVersion) -> type[MQTTBaseParser]:
     """The parser class a Broker version speaks.
 
     One place says it, because the Subscriber that consumes through a parser and
     the in-memory test broker that encodes for one have to agree on the version.
     """
-    return MQTTParserV311 if version == "3.1.1" else MQTTParserV5
+    if version == "3.1.1":
+        return MQTTParserV311
+    if version == "5.0":
+        return MQTTParserV5
+    assert_never(version)

--- a/faststream/mqtt/subscriber/usecase.py
+++ b/faststream/mqtt/subscriber/usecase.py
@@ -12,7 +12,7 @@ from faststream._internal.endpoint.subscriber import SubscriberUsecase
 from faststream._internal.endpoint.subscriber.mixins import ConcurrentMixin, TasksMixin
 from faststream._internal.endpoint.utils import process_msg
 from faststream.middlewares import AckPolicy
-from faststream.mqtt.parser import MQTTBaseParser, MQTTParserV5, MQTTParserV311
+from faststream.mqtt.parser import MQTTBaseParser, parser_for
 from faststream.mqtt.publisher.fake import MQTTFakePublisher
 
 if TYPE_CHECKING:
@@ -62,9 +62,8 @@ class MQTTBaseSubscriber(TasksMixin, SubscriberUsecase[zmqtt.Message]):
 
     def _make_parser(self, outer_config: Any) -> MQTTBaseParser:
         version = getattr(outer_config, "version", "5.0")
-        cls: type[MQTTBaseParser] = MQTTParserV311 if version == "3.1.1" else MQTTParserV5
         prefix = getattr(outer_config, "prefix", "")
-        return cls(path_regex=self._address.add_prefix(prefix).regex)
+        return parser_for(version)(path_regex=self._address.add_prefix(prefix).regex)
 
     @property
     def address(self) -> "Address":

--- a/faststream/mqtt/subscriber/usecase.py
+++ b/faststream/mqtt/subscriber/usecase.py
@@ -2,7 +2,7 @@ import warnings
 from abc import abstractmethod
 from collections.abc import AsyncIterator, Sequence
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import anyio
 import zmqtt
@@ -12,7 +12,7 @@ from faststream._internal.endpoint.subscriber import SubscriberUsecase
 from faststream._internal.endpoint.subscriber.mixins import ConcurrentMixin, TasksMixin
 from faststream._internal.endpoint.utils import process_msg
 from faststream.middlewares import AckPolicy
-from faststream.mqtt.parser import MQTTBaseParser, parser_for
+from faststream.mqtt.parser import MQTTBaseParser, MQTTVersion, parser_for
 from faststream.mqtt.publisher.fake import MQTTFakePublisher
 
 if TYPE_CHECKING:
@@ -60,8 +60,11 @@ class MQTTBaseSubscriber(TasksMixin, SubscriberUsecase[zmqtt.Message]):
     def _build_parser(self) -> MQTTBaseParser:
         return self._make_parser(self._outer_config)
 
-    def _make_parser(self, outer_config: Any) -> MQTTBaseParser:
-        version = getattr(outer_config, "version", "5.0")
+    def _make_parser(self, outer_config: "MQTTBrokerConfig") -> MQTTBaseParser:
+        version: MQTTVersion | Literal["unset"] = outer_config.version
+        if version == "unset":
+            # Declared on a Router, before a Broker composes its version in.
+            version = "5.0"
         prefix = getattr(outer_config, "prefix", "")
         return parser_for(version)(path_regex=self._address.add_prefix(prefix).regex)
 

--- a/faststream/mqtt/testing.py
+++ b/faststream/mqtt/testing.py
@@ -18,7 +18,7 @@ from faststream._internal.testing.broker import (
 )
 from faststream.exceptions import SubscriberNotFound
 from faststream.mqtt.broker.broker import MQTTBroker
-from faststream.mqtt.parser import MQTTParserV5, MQTTParserV311
+from faststream.mqtt.parser import parser_for
 from faststream.mqtt.publisher.producer import ZmqttBaseProducer
 from faststream.mqtt.response import MQTTPublishCommand
 
@@ -62,12 +62,6 @@ def mqtt_topic_matches(pattern: str, topic: str) -> bool:
 
 def _broker_version(broker: MQTTBroker) -> Literal["3.1.1", "5.0"]:
     return getattr(broker.config.broker_config, "version", "5.0")
-
-
-def _parser_for_version(
-    version: Literal["3.1.1", "5.0"],
-) -> MQTTParserV311 | MQTTParserV5:
-    return MQTTParserV311() if version == "3.1.1" else MQTTParserV5()
 
 
 class TestMQTTBroker(TestBroker[MQTTBroker, EnterType]):
@@ -186,7 +180,7 @@ class FakeProducer(ZmqttBaseProducer):
         self.serializer: SerializerProto | None = None
 
         version = _broker_version(broker)
-        default = _parser_for_version(version)
+        default = parser_for(version)()
         self._parser = ParserComposition(broker._parser, default.parse_message)
         self._decoder = ParserComposition(broker._decoder, default.decode_message)
         self.codec = broker.config.broker_codec or DefaultCodec()

--- a/faststream/mqtt/testing.py
+++ b/faststream/mqtt/testing.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections.abc import Generator, Iterable, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast, overload
+from typing import TYPE_CHECKING, Any, Optional, cast, overload
 from unittest.mock import MagicMock
 
 import anyio
@@ -18,7 +18,7 @@ from faststream._internal.testing.broker import (
 )
 from faststream.exceptions import SubscriberNotFound
 from faststream.mqtt.broker.broker import MQTTBroker
-from faststream.mqtt.parser import parser_for
+from faststream.mqtt.parser import MQTTVersion, parser_for
 from faststream.mqtt.publisher.producer import ZmqttBaseProducer
 from faststream.mqtt.response import MQTTPublishCommand
 
@@ -60,7 +60,7 @@ def mqtt_topic_matches(pattern: str, topic: str) -> bool:
     return topic_matches(pattern, topic)
 
 
-def _broker_version(broker: MQTTBroker) -> Literal["3.1.1", "5.0"]:
+def _broker_version(broker: MQTTBroker) -> MQTTVersion:
     return getattr(broker.config.broker_config, "version", "5.0")
 
 
@@ -192,7 +192,7 @@ class FakeProducer(ZmqttBaseProducer):
         )
 
     @property
-    def _version(self) -> Literal["3.1.1", "5.0"]:
+    def _version(self) -> MQTTVersion:
         return _broker_version(self.broker)
 
     @override
@@ -264,7 +264,7 @@ async def build_message(
     message: "SendableMessage",
     topic: str,
     *,
-    version: Literal["3.1.1", "5.0"] = "5.0",
+    version: MQTTVersion = "5.0",
     qos: int = 0,
     retain: bool = False,
     reply_to: str = "",

--- a/faststream/params/params.py
+++ b/faststream/params/params.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
-from faststream._internal.constants import EMPTY
+from faststream._internal.constants import EMPTY, PATH_CONTEXT_PREFIX
 from faststream._internal.context import Context as Context_
 
 
@@ -44,5 +44,5 @@ def Path(  # noqa: N802
         real_name=real_name,
         cast=cast,
         default=default,
-        prefix="message.path.",
+        prefix=PATH_CONTEXT_PREFIX,
     )


### PR DESCRIPTION
# Description

Two clean-ups too small to review on their own, extracted from #3030 so the feature branch stops carrying them:

- **`PATH_CONTEXT_PREFIX`** — the context prefix a `Path()` parameter reads from (`"message.path."`) has exactly one definition, in `faststream/_internal/constants.py`, and `Path()` reads it from there. It was spelled inline before.
- **`parser_for(version)`** in `faststream/mqtt/parser.py` — the MQTT Subscriber and the in-memory MQTT test broker choose the parser class for a Broker version through this one function. Each picked it on its own before, and the two have to agree on which version they speak.

The third item the ticket lists, the `.gitignore` entries for local agent tooling and the graphify output, is already on `main`, so it is not part of this PR.

Nothing a user can see changes. No new tests: the change is one definition replacing two identical ones, and the existing MQTT and `Path()` suites pin the behaviour.

Part of the prefactor plan for #2451.

## Type of change

- [x] Refactor (no functional change)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] Existing tests pass: `tests/utils/context/test_path.py`, `tests/brokers/mqtt/test_path.py`, `tests/brokers/mqtt/test_testclient.py`, `tests/docs/mqtt/message/test_message.py` (`-m "not connected"`; MQTT `connected` tests run in CI only)
- [x] `just mypy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
