### PR TITLE
docs(skills): one dirty-equals equality per behaviour in testing-patterns

### DIFF
--- a/.agents/skills/testing-patterns/SKILL.md
+++ b/.agents/skills/testing-patterns/SKILL.md
@@ -123,6 +123,32 @@ exception is the regression pattern below, whose docstring is the issue URL and 
 else. When an assertion needs explaining, a single `#` comment sits directly over it, not
 prose in a docstring.
 
+## One equality per behaviour
+
+When a test checks one value from several angles — a tuple's fields, a few keys of a
+dict, a length and an element — build the expected shape from `dirty-equals` matchers
+and compare once. The failure then prints the whole shape, and the test reads as a single
+statement of the behaviour:
+
+```python
+# Claimed entries come first, with their previous deliveries and idle time
+assert received[:2] == [
+    ("pending_message", IsInt(ge=1), IsInt(ge=100)),
+    ("new_message", 0, 0),
+]
+
+assert snapshot == IsPartialDict({
+    "delivery_counts": HasLen(size),
+    "idle_times": HasLen(size),
+})
+```
+
+A chain of `assert x[0] ...`, `assert x[1] ...`, or a loop carrying a `found` flag, is this
+shape spelled out one field at a time: collapse it into the one equality. `IsPartialDict`
+takes a dict literal, so dotted keys and enum values read the same as the config they
+mirror. An equality that already fails on a missing delivery stands alone; the
+`assert event.is_set()` in front of it says nothing more.
+
 ## Regression tests
 
 A test defending a fixed bug names the issue by **full URL**, so the case it pins is one click away:
@@ -156,7 +182,7 @@ The same run grades the tests already there, and it is how a suite shrinks. Two 
 - `tests/marks.py`: conditional skips — `skip_windows`, `skip_macos`, `pydantic_v1`/`pydantic_v2`, `require_aiokafka`, `require_confluent`, `require_aiopika`, `require_redis`, `require_nats`, `require_mqtt`.
 - `tests/tools.py`: `spy_decorator` — wraps a real method with a mock spy (call assertions via `.mock`) while preserving behavior.
 - `tests/mocks.py`: `mock_pydantic_settings_env` for env-driven settings tests.
-- `dirty-equals` and `freezegun` are available as test deps.
+- `freezegun` is available as a test dep.
 
 **Never import from a `conftest.py`.** pytest loads conftest modules specially (their fixtures are injected into the collected files), so importing from one — `from .conftest import Settings` or `from tests.brokers.redis.conftest import ...` — can produce a duplicated/mismatched module and confusing collection errors. When conftest and a test file need the same object, declare it in a plain helper module next to them (e.g. `tests/brokers/redis/settings.py`, `basic.py`) and import it from both.
 


### PR DESCRIPTION
# Description

Adds one section to the `testing-patterns` skill, following up on #3094: a test that checks one value from several angles builds the expected shape from `dirty-equals` matchers and compares once. The failure then prints the whole shape, and the test reads as a single statement of the behaviour. Chains of `assert x[0] ...` and loops carrying a `found` flag collapse into that one equality; `IsPartialDict` takes a dict literal; an `assert event.is_set()` in front of an equality that already fails on a missing delivery goes.

The example is lifted from #3049, where the rule came up in review.

## Type of change

- [x] Documentation (agent skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
