### PR TITLE
refactor: one base for the Subscriber and Publisher Specifications

### DIFF
--- a/faststream/_internal/endpoint/publisher/specification.py
+++ b/faststream/_internal/endpoint/publisher/specification.py
@@ -1,11 +1,12 @@
 from inspect import Parameter, unwrap
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any
 
 from fast_depends.core import build_call_model
 from fast_depends.pydantic._compat import create_model, get_config_base
 from typing_extensions import TypeVar as TypeVar313
 
 from faststream._internal.configs import BrokerConfig, PublisherSpecificationConfig
+from faststream._internal.endpoint.specification import EndpointSpecification
 from faststream.specification.asyncapi.message import get_model_schema
 from faststream.specification.asyncapi.utils import to_camelcase
 
@@ -22,25 +23,20 @@ T_SpecificationConfig = TypeVar313(
 T_BrokerConfig = TypeVar313("T_BrokerConfig", bound=BrokerConfig, default=BrokerConfig)
 
 
-class PublisherSpecification(Generic[T_BrokerConfig, T_SpecificationConfig]):
+class PublisherSpecification(
+    EndpointSpecification[T_BrokerConfig, T_SpecificationConfig],
+):
     def __init__(
         self,
         _outer_config: "T_BrokerConfig",
         specification_config: "T_SpecificationConfig",
     ) -> None:
-        self.config = specification_config
-        self._outer_config = _outer_config
+        super().__init__(_outer_config, specification_config)
 
         self.calls: list[AnyCallable] = []
 
     def add_call(self, call: "AnyCallable") -> None:
         self.calls.append(call)
-
-    @property
-    def include_in_schema(self) -> bool:
-        return bool(
-            self._outer_config.include_in_schema and self.config.include_in_schema,
-        )
 
     def get_payloads(self) -> list[tuple[dict[str, Any], str]]:
         payloads: list[tuple[dict[str, Any], str]] = []

--- a/faststream/_internal/endpoint/specification.py
+++ b/faststream/_internal/endpoint/specification.py
@@ -1,0 +1,36 @@
+from typing import Generic
+
+from typing_extensions import TypeVar as TypeVar313
+
+from faststream._internal.configs import BrokerConfig
+from faststream._internal.configs.specification import SpecificationConfig
+
+T_SpecificationConfig = TypeVar313(
+    "T_SpecificationConfig",
+    bound=SpecificationConfig,
+    default=SpecificationConfig,
+)
+T_BrokerConfig = TypeVar313("T_BrokerConfig", bound=BrokerConfig, default=BrokerConfig)
+
+
+class EndpointSpecification(Generic[T_BrokerConfig, T_SpecificationConfig]):
+    """What a Subscriber's and a Publisher's Specification have in common.
+
+    Both document an endpoint from the same two configs: the composition the
+    endpoint reads through and the endpoint's own, and one rule decides whether
+    the document lists it at all.
+    """
+
+    def __init__(
+        self,
+        _outer_config: "T_BrokerConfig",
+        specification_config: "T_SpecificationConfig",
+    ) -> None:
+        self.config = specification_config
+        self._outer_config = _outer_config
+
+    @property
+    def include_in_schema(self) -> bool:
+        return bool(
+            self._outer_config.include_in_schema and self.config.include_in_schema,
+        )

--- a/faststream/_internal/endpoint/subscriber/specification.py
+++ b/faststream/_internal/endpoint/subscriber/specification.py
@@ -1,11 +1,12 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import (
     TypeVar as TypeVar313,
 )
 
 from faststream._internal.configs import BrokerConfig, SubscriberSpecificationConfig
+from faststream._internal.endpoint.specification import EndpointSpecification
 from faststream.exceptions import SetupError
 from faststream.specification.asyncapi.message import parse_handler_params
 from faststream.specification.asyncapi.utils import to_camelcase
@@ -25,22 +26,17 @@ T_SpecificationConfig = TypeVar313(
 T_BrokerConfig = TypeVar313("T_BrokerConfig", bound=BrokerConfig, default=BrokerConfig)
 
 
-class SubscriberSpecification(Generic[T_BrokerConfig, T_SpecificationConfig]):
+class SubscriberSpecification(
+    EndpointSpecification[T_BrokerConfig, T_SpecificationConfig],
+):
     def __init__(
         self,
         _outer_config: "T_BrokerConfig",
         specification_config: "T_SpecificationConfig",
         calls: "CallsCollection[Any]",
     ) -> None:
+        super().__init__(_outer_config, specification_config)
         self.calls = calls
-        self.config = specification_config
-        self._outer_config = _outer_config
-
-    @property
-    def include_in_schema(self) -> bool:
-        return bool(
-            self._outer_config.include_in_schema and self.config.include_in_schema,
-        )
 
     @property
     def description(self) -> str | None:


### PR DESCRIPTION
# Description

The Subscriber Specification and the Publisher Specification share what they have in common through one base class, `EndpointSpecification` in `faststream/_internal/endpoint/specification.py`: the outer config, the specification config, and the `include_in_schema` rule composing the two. Each spelled the rule out on its own before.

A pure refactor, extracted from #3030. Constructor signatures stay as they are, so a third-party broker's Specification subclasses construct exactly as before. The base is generic over the same two parameters, bound to `SpecificationConfig` (the config both `SubscriberSpecificationConfig` and `PublisherSpecificationConfig` descend from); each subclass keeps its own narrower TypeVars. NATS's `NotIncludeSpecifation` override of `include_in_schema` is untouched.

No new tests: the AsyncAPI suites for both schema versions already pin `include_in_schema` end to end, and the snapshot tests pin the rendered documents.

## Type of change

- [x] Refactor (no functional change)

## Checklist

- [x] `just lint` shows no errors
- [x] `just mypy` passes
- [x] Existing tests pass: `tests/asyncapi/kafka/v{2_6_0,3_0_0}/test_publisher.py`, `.../test_router.py`, `tests/asyncapi/nats/v{2_6_0,3_0_0}/test_router.py`, `tests/asyncapi/test_fastapi_router.py`, `tests/asyncapi/test_asgi.py`, `tests/brokers/kafka/test_include_router.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
