### PR TITLE
fix: a handler keeps its declared call apart from its composed one

### DIFF
--- a/faststream/_internal/endpoint/call_wrapper.py
+++ b/faststream/_internal/endpoint/call_wrapper.py
@@ -38,7 +38,11 @@ class HandlerCallWrapper(Generic[P_HandlerParams, T_HandlerReturn]):
 
     future: Optional["asyncio.Future[Any]"]
     _wrapped_call: Callable[..., Awaitable[Any]] | None
-    _original_call: Callable[P_HandlerParams, T_HandlerReturn]
+    # The handler as it was written, kept as written so that composing it again
+    # from an unchanged declaration produces an unchanged result.
+    _declared_call: Callable[P_HandlerParams, T_HandlerReturn]
+    # What the last composition made of it, decorators applied.
+    _composed_call: Callable[P_HandlerParams, T_HandlerReturn]
 
     _publishers: list["PublisherProto[Any]"]
 
@@ -47,7 +51,8 @@ class HandlerCallWrapper(Generic[P_HandlerParams, T_HandlerReturn]):
     _subscribers: list["SubscriberUsecase[Any]"]
 
     __slots__ = (
-        "_original_call",
+        "_composed_call",
+        "_declared_call",
         "_publishers",
         "_subscribers",
         "_wrapped_call",
@@ -61,7 +66,8 @@ class HandlerCallWrapper(Generic[P_HandlerParams, T_HandlerReturn]):
         call: Callable[P_HandlerParams, T_HandlerReturn],
     ) -> None:
         """Initialize a handler."""
-        self._original_call = call
+        self._declared_call = call
+        self._composed_call = call
         self._wrapped_call = None
 
         self._publishers = []
@@ -77,7 +83,12 @@ class HandlerCallWrapper(Generic[P_HandlerParams, T_HandlerReturn]):
         **kwargs: P_HandlerParams.kwargs,
     ) -> T_HandlerReturn:
         """Calls the object as a function."""
-        return self._original_call(*args, **kwargs)
+        return self._composed_call(*args, **kwargs)
+
+    @property
+    def _original_call(self) -> Callable[P_HandlerParams, T_HandlerReturn]:
+        """The composed call, under the name it had before the two were kept apart."""
+        return self._composed_call
 
     async def call_wrapped(
         self,
@@ -96,12 +107,15 @@ class HandlerCallWrapper(Generic[P_HandlerParams, T_HandlerReturn]):
         _call_decorators: Reversible["Decorator"],
         config: "FastDependsConfig",
     ) -> "CallModel":
+        # Composed from the declaration rather than from the last composition:
+        # `build_call` answers with the call it decorated, so reading that back
+        # as the input would decorate it again, one more layer per build.
         dependent = config.build_call(
-            self._original_call,
+            self._declared_call,
             dependencies=dependencies,
             call_decorators=_call_decorators,
         )
-        self._original_call = dependent.original_call
+        self._composed_call = dependent.original_call
         self._wrapped_call = dependent.wrapped_call
         return dependent.dependent
 

--- a/faststream/_internal/endpoint/publisher/usecase.py
+++ b/faststream/_internal/endpoint/publisher/usecase.py
@@ -71,7 +71,7 @@ class PublisherUsecase(Endpoint, PublisherProto):
         """Decorate user's function by current publisher."""
         handler = super().__call__(func)
         handler._publishers.append(self)
-        self.specification.add_call(handler._original_call)
+        self.specification.add_call(handler._declared_call)
         return handler
 
     async def _basic_publish(

--- a/faststream/_internal/endpoint/subscriber/call_item.py
+++ b/faststream/_internal/endpoint/subscriber/call_item.py
@@ -33,15 +33,24 @@ class HandlerItem(Generic[MsgType]):
     """A class representing handler overloaded item."""
 
     __slots__ = (
+        "decoder",
         "dependant",
         "dependencies",
         "filter",
         "handler",
         "item_decoder",
         "item_parser",
+        "parser",
     )
 
     dependant: Any | None
+    # What the handler declared, kept as declared so that composing them again
+    # from an unchanged declaration produces an unchanged result.
+    item_parser: Optional["CustomCallable"]
+    item_decoder: Optional["CustomCallable"]
+    # What the last composition made of them.
+    parser: Optional["AsyncCallable"]
+    decoder: Optional["AsyncCallable"]
 
     def __init__(
         self,
@@ -56,6 +65,8 @@ class HandlerItem(Generic[MsgType]):
         self.filter = filter
         self.item_parser = item_parser
         self.item_decoder = item_decoder
+        self.parser = None
+        self.decoder = None
         self.dependencies = dependencies
         self.dependant = None
 
@@ -73,9 +84,8 @@ class HandlerItem(Generic[MsgType]):
         broker_dependencies: Iterable["Dependant"],
         _call_decorators: Reversible["Decorator"],
     ) -> None:
-        if self.dependant is None:
-            self.item_parser = parser
-            self.item_decoder = decoder
+        self.parser = parser
+        self.decoder = decoder
 
         self.dependant = self.handler.set_wrapped(
             dependencies=(*broker_dependencies, *self.dependencies),
@@ -89,7 +99,7 @@ class HandlerItem(Generic[MsgType]):
         if self.handler is None:
             return ""
 
-        caller = unwrap(self.handler._original_call)
+        caller = unwrap(self.handler._composed_call)
         return getattr(caller, "__name__", str(caller))
 
     @property
@@ -98,7 +108,7 @@ class HandlerItem(Generic[MsgType]):
         if self.handler is None:
             return None
 
-        caller = unwrap(self.handler._original_call)
+        caller = unwrap(self.handler._composed_call)
         return getattr(caller, "__doc__", None)
 
     async def is_suitable(
@@ -107,9 +117,7 @@ class HandlerItem(Generic[MsgType]):
         cache: dict[Any, Any],
     ) -> Optional["StreamMessage[MsgType]"]:
         """Check is message suite for current filter."""
-        if not (parser := cast("AsyncCallable | None", self.item_parser)) or not (
-            decoder := cast("AsyncCallable | None", self.item_decoder)
-        ):
+        if not (parser := self.parser) or not (decoder := self.decoder):
             error_msg = "You should setup `HandlerItem` at first."
             raise SetupError(error_msg)
 

--- a/tests/brokers/base/codec.py
+++ b/tests/brokers/base/codec.py
@@ -53,6 +53,33 @@ class CodecTestcase(BaseTestcaseConfig):
 
         mock.assert_called_once_with({"key": "value"})
 
+    async def test_codec_survives_building_the_model_twice(
+        self,
+        mock: MagicMock,
+        queue: str,
+    ) -> None:
+        class TrackingCodec(DefaultCodec):
+            async def decode(self, msg):
+                mock()
+                return await super().decode(msg)
+
+        broker = self.get_broker()
+
+        args, kwargs = self.get_subscriber_params(queue, codec=TrackingCodec())
+
+        @broker.subscriber(*args, **kwargs)
+        async def handle(m) -> None:
+            pass
+
+        # Rendering the schema composes the model once; starting composes it again
+        subscriber = next(iter(broker.subscribers))
+        subscriber.schema()
+
+        async with self.patch_broker(broker) as br:
+            await br.publish(b"hello", queue)
+
+        mock.assert_called_once()
+
     async def test_codec_and_decoder_conflict_raises(
         self,
         queue: str,

--- a/tests/utils/test_handler_call_wrapper.py
+++ b/tests/utils/test_handler_call_wrapper.py
@@ -1,7 +1,11 @@
 import gc
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
 
 import pytest
 
+from faststream._internal.di import FastDependsConfig
 from faststream._internal.endpoint.call_wrapper import HandlerCallWrapper
 
 
@@ -37,3 +41,27 @@ async def test_handler_exception_remains_available_to_wait_call() -> None:
         await wrapper.wait_call()
 
     assert exc_info.value is error
+
+
+def test_composing_twice_decorates_once() -> None:
+    async def handler() -> None:
+        return None
+
+    def layer(call: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(call)
+        async def wrapped(*args: Any, **kwargs: Any) -> Any:
+            return await call(*args, **kwargs)
+
+        wrapped.layers = getattr(call, "layers", 0) + 1  # type: ignore[attr-defined]
+        return wrapped
+
+    wrapper = HandlerCallWrapper(handler)
+    for _ in range(2):
+        wrapper.set_wrapped(
+            dependencies=(),
+            _call_decorators=(layer,),
+            config=FastDependsConfig(),
+        )
+
+    # The old name still reads, and answers the composed call
+    assert wrapper._original_call.layers == 1  # type: ignore[attr-defined]


### PR DESCRIPTION
# Description

Composing a Subscriber's FastDepends model twice now produces the same result as composing it once. The model is built from more than one place (`schema()`, `start()`, the in-memory test broker's patching), so building twice is reachable: a Subscriber whose schema is rendered before start-up.

Two overwrites made the second build differ from the first:

- **The handler wrapper** replaced the call it was declared with by the call the composition produced, so the second composition decorated an already decorated call: one more layer per build. A FastAPI-mounted Subscriber got its compatibility wrapper applied twice.
- **The handler item** replaced its declared parser and decoder by the composed ones on the first build, so a Subscriber declaring `codec` was read on the second build as declaring both `codec` and a decoder, which is the conflict the build refuses with `ValueError`.

Now the wrapper holds the declared call and the composed call as two fields, composing always from the declared one; `_original_call` stays readable as a property alias for the composed call, so nothing outside the package that reaches for it breaks. The item holds `item_parser` / `item_decoder` as declared and `parser` / `decoder` as composed, rewriting the composed pair on every build. Constructor keyword names are unchanged.

Extracted from #3030, where the feature branch met this while making its Preparation phase idempotent.

## Tests

Both regression tests go red on `main` and green here:

- `tests/utils/test_handler_call_wrapper.py::test_composing_twice_decorates_once` — two builds with a call decorator in place leave the handler decorated once, read through the old `_original_call` name.
- `tests/brokers/base/codec.py::test_codec_survives_building_the_model_twice` — a Subscriber declaring `codec` has its schema rendered, then starts under the test broker and decodes once. Inherited by every broker.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] `just lint` shows no errors
- [x] `just mypy` passes
- [x] Existing tests pass: `tests/brokers/kafka/test_codec.py`, `tests/brokers/rabbit/test_codec.py`, `tests/brokers/kafka/test_fastapi.py`, `tests/brokers/kafka/test_test_client.py`, `tests/asyncapi/kafka/v3_0_0/test_publisher.py`, `tests/utils/test_handler_call_wrapper.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
