### PR TITLE
refactor: `Address.literal` and `Address.describe`

### DIFF
--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -36,11 +36,24 @@ class Address:
         self._declaration = declaration
         """The declaration verbatim, escapes and all: what the parser reads."""
 
-        self.template = _restore_literal_braces(declaration)
+        self.template = (
+            declaration if syntax.verbatim else _restore_literal_braces(declaration)
+        )
         """The address as it was declared, e.g. `logs.{level}`."""
 
         self._syntax = syntax
         self._compiled: tuple[Pattern[str] | None, str] | None = None
+
+    @classmethod
+    def literal(cls, value: str) -> "Address":
+        """An Address read as characters: what it says is what it names.
+
+        Kafka topics are the case this exists for. A topic is handed to the broker
+        verbatim, so reading one as a template would report capture groups that
+        nothing ever fills. The verbatim syntax travels with the address, so a
+        Router prefix decorating it later leaves it verbatim too.
+        """
+        return cls(value, VERBATIM_ADDRESS_SYNTAX)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._declaration!r})"
@@ -59,6 +72,10 @@ class Address:
         """Captures each Path parameter out of an incoming message's address."""
         return self._compile()[0]
 
+    def describe(self) -> str:
+        """Name this address the way an error message should."""
+        return repr(self.template)
+
     def add_prefix(self, prefix: str) -> "Address":
         """Decorate the template with a Router prefix; the Broker address follows."""
         if not prefix:
@@ -68,17 +85,12 @@ class Address:
 
     def _compile(self) -> tuple[Pattern[str] | None, str]:
         if self._compiled is None:
-            self._compiled = compile_path(
-                self._declaration,
-                replace_symbol=self._syntax.replace_symbol,
-                patch_regex=self._syntax.patch_regex,
-                param_regex=self._syntax.param_regex,
-            )
+            self._compiled = self._syntax.compile(self._declaration)
 
         return self._compiled
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AddressSyntax:
     """How one broker spells a wildcard where an Address template has a Path parameter.
 
@@ -87,11 +99,34 @@ class AddressSyntax:
         patch_regex: Broker-specific fixups applied to the compiled capture regex.
         param_regex: What a `{param}` may capture — one whole segment, which means
             everything up to whatever this broker separates segments with.
+        verbatim: Whether addresses in this syntax are read as characters rather
+            than as templates, so that a `{` in one is a `{` and nothing more.
     """
 
     replace_symbol: str
     patch_regex: Callable[[str], str]
     param_regex: str = "[^.]+"
+    verbatim: bool = False
+
+    def compile(self, declaration: str) -> tuple[Pattern[str] | None, str]:
+        """Turn an Address declaration into its capture regex and its Broker address."""
+        if self.verbatim:
+            return None, declaration
+
+        return compile_path(
+            declaration,
+            replace_symbol=self.replace_symbol,
+            patch_regex=self.patch_regex,
+            param_regex=self.param_regex,
+        )
+
+
+VERBATIM_ADDRESS_SYNTAX = AddressSyntax(
+    replace_symbol="",
+    patch_regex=str,
+    verbatim=True,
+)
+"""The syntax of an address that is not a template: what it says is what it names."""
 
 
 def compile_path(

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -82,12 +82,17 @@ class Address:
 
     def _compile(self) -> tuple[Pattern[str] | None, str]:
         if self._compiled is None:
-            self._compiled = self._syntax.compile(self._declaration)
+            self._compiled = compile_path(
+                self._declaration,
+                replace_symbol=self._syntax.replace_symbol,
+                patch_regex=self._syntax.patch_regex,
+                param_regex=self._syntax.param_regex,
+            )
 
         return self._compiled
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class AddressSyntax:
     """How one broker spells a wildcard where an Address template has a Path parameter.
 
@@ -101,15 +106,6 @@ class AddressSyntax:
     replace_symbol: str
     patch_regex: Callable[[str], str]
     param_regex: str = "[^.]+"
-
-    def compile(self, declaration: str) -> tuple[Pattern[str] | None, str]:
-        """Turn an Address declaration into its capture regex and its Broker address."""
-        return compile_path(
-            declaration,
-            replace_symbol=self.replace_symbol,
-            patch_regex=self.patch_regex,
-            param_regex=self.param_regex,
-        )
 
 
 def compile_path(

--- a/faststream/_internal/utils/path.py
+++ b/faststream/_internal/utils/path.py
@@ -36,9 +36,7 @@ class Address:
         self._declaration = declaration
         """The declaration verbatim, escapes and all: what the parser reads."""
 
-        self.template = (
-            declaration if syntax.verbatim else _restore_literal_braces(declaration)
-        )
+        self.template = _restore_literal_braces(declaration)
         """The address as it was declared, e.g. `logs.{level}`."""
 
         self._syntax = syntax
@@ -49,11 +47,10 @@ class Address:
         """An Address read as characters: what it says is what it names.
 
         Kafka topics are the case this exists for. A topic is handed to the broker
-        verbatim, so reading one as a template would report capture groups that
-        nothing ever fills. The verbatim syntax travels with the address, so a
-        Router prefix decorating it later leaves it verbatim too.
+        as written, so reading one as a template would report capture groups that
+        nothing ever fills. A Router prefix added later keeps the address literal.
         """
-        return cls(value, VERBATIM_ADDRESS_SYNTAX)
+        return _LiteralAddress(value)
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._declaration!r})"
@@ -99,34 +96,20 @@ class AddressSyntax:
         patch_regex: Broker-specific fixups applied to the compiled capture regex.
         param_regex: What a `{param}` may capture — one whole segment, which means
             everything up to whatever this broker separates segments with.
-        verbatim: Whether addresses in this syntax are read as characters rather
-            than as templates, so that a `{` in one is a `{` and nothing more.
     """
 
     replace_symbol: str
     patch_regex: Callable[[str], str]
     param_regex: str = "[^.]+"
-    verbatim: bool = False
 
     def compile(self, declaration: str) -> tuple[Pattern[str] | None, str]:
         """Turn an Address declaration into its capture regex and its Broker address."""
-        if self.verbatim:
-            return None, declaration
-
         return compile_path(
             declaration,
             replace_symbol=self.replace_symbol,
             patch_regex=self.patch_regex,
             param_regex=self.param_regex,
         )
-
-
-VERBATIM_ADDRESS_SYNTAX = AddressSyntax(
-    replace_symbol="",
-    patch_regex=str,
-    verbatim=True,
-)
-"""The syntax of an address that is not a template: what it says is what it names."""
 
 
 def compile_path(
@@ -180,6 +163,26 @@ def match_path(pattern: Pattern[str] | None, subject: str) -> dict[str, Any]:
     if pattern is not None and (match := pattern.match(subject)):
         return match.groupdict()
     return {}
+
+
+class _LiteralAddress(Address):
+    """An Address that is not a template: its declaration is its Broker address.
+
+    Nothing is compiled, so a `{` in it is a character, and `{{` is two of them.
+    """
+
+    __slots__ = ()
+
+    def __init__(self, value: str) -> None:
+        self._declaration = value
+        self.template = value
+        self._compiled = (None, value)
+
+    def add_prefix(self, prefix: str) -> Address:
+        if not prefix:
+            return self
+
+        return _LiteralAddress(f"{prefix}{self._declaration}")
 
 
 def _escape_literal_braces(path: str) -> str:

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,0 +1,89 @@
+from importlib import import_module
+
+import pytest
+
+from faststream._internal.utils.path import Address, AddressSyntax, compile_path
+from tests.marks import require_aiokafka, require_aiopika, require_nats, require_redis
+
+SYNTAX = AddressSyntax(
+    replace_symbol="*",
+    patch_regex=lambda x: x.replace(r"\*", ".*"),
+)
+
+
+@pytest.mark.parametrize(
+    ("module", "name", "declaration"),
+    (
+        pytest.param(
+            "faststream.kafka.subscriber.usecase",
+            "KAFKA_ADDRESS_SYNTAX",
+            "logs.{{2}}.{level}",
+            marks=require_aiokafka,
+            id="kafka",
+        ),
+        pytest.param(
+            "faststream.nats.schemas.js_stream",
+            "NATS_ADDRESS_SYNTAX",
+            "logs.{{2}}.{level}",
+            marks=require_nats,
+            id="nats",
+        ),
+        pytest.param(
+            "faststream.rabbit.schemas.queue",
+            "RABBIT_ADDRESS_SYNTAX",
+            "logs.{{2}}.{level}",
+            marks=require_aiopika,
+            id="rabbit",
+        ),
+        pytest.param(
+            "faststream.redis.schemas.pub_sub",
+            "REDIS_ADDRESS_SYNTAX",
+            "logs.{{2}}.{level}",
+            marks=require_redis,
+            id="redis",
+        ),
+        pytest.param(
+            "faststream.mqtt.path",
+            "MQTT_ADDRESS_SYNTAX",
+            "logs/{{2}}/{level}",
+            id="mqtt",
+        ),
+    ),
+)
+def test_a_syntax_compiles_the_way_the_module_function_does(
+    module: str,
+    name: str,
+    declaration: str,
+) -> None:
+    syntax: AddressSyntax = getattr(import_module(module), name)
+
+    assert syntax.compile(declaration) == compile_path(
+        declaration,
+        replace_symbol=syntax.replace_symbol,
+        patch_regex=syntax.patch_regex,
+        param_regex=syntax.param_regex,
+    )
+
+
+def test_a_literal_address_is_read_as_characters_rather_than_a_template() -> None:
+    address = Address.literal("logs.{level}")
+
+    assert (address.template, address.broker_address, address.regex) == (
+        "logs.{level}",
+        "logs.{level}",
+        None,
+    )
+
+
+def test_a_router_prefix_leaves_a_literal_address_literal() -> None:
+    address = Address.literal("logs.{level}").add_prefix("prefix_")
+
+    assert (address.template, address.broker_address, address.regex) == (
+        "prefix_logs.{level}",
+        "prefix_logs.{level}",
+        None,
+    )
+
+
+def test_describe_names_the_template_as_it_was_declared() -> None:
+    assert Address("logs.{level}", SYNTAX).describe() == "'logs.{level}'"

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -3,7 +3,13 @@ from importlib import import_module
 import pytest
 
 from faststream._internal.utils.path import Address, AddressSyntax, compile_path
-from tests.marks import require_aiokafka, require_aiopika, require_nats, require_redis
+from tests.marks import (
+    require_aiokafka,
+    require_aiopika,
+    require_mqtt,
+    require_nats,
+    require_redis,
+)
 
 SYNTAX = AddressSyntax(
     replace_symbol="*",
@@ -46,6 +52,7 @@ SYNTAX = AddressSyntax(
             "faststream.mqtt.path",
             "MQTT_ADDRESS_SYNTAX",
             "logs/{{2}}/{level}",
+            marks=require_mqtt,
             id="mqtt",
         ),
     ),
@@ -66,21 +73,21 @@ def test_a_syntax_compiles_the_way_the_module_function_does(
 
 
 def test_a_literal_address_is_read_as_characters_rather_than_a_template() -> None:
-    address = Address.literal("logs.{level}")
+    address = Address.literal("logs.{{2}}.{level}")
 
     assert (address.template, address.broker_address, address.regex) == (
-        "logs.{level}",
-        "logs.{level}",
+        "logs.{{2}}.{level}",
+        "logs.{{2}}.{level}",
         None,
     )
 
 
 def test_a_router_prefix_leaves_a_literal_address_literal() -> None:
-    address = Address.literal("logs.{level}").add_prefix("prefix_")
+    address = Address.literal("logs.{{2}}.{level}").add_prefix("prefix_")
 
     assert (address.template, address.broker_address, address.regex) == (
-        "prefix_logs.{level}",
-        "prefix_logs.{level}",
+        "prefix_logs.{{2}}.{level}",
+        "prefix_logs.{{2}}.{level}",
         None,
     )
 

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,15 +1,4 @@
-from importlib import import_module
-
-import pytest
-
-from faststream._internal.utils.path import Address, AddressSyntax, compile_path
-from tests.marks import (
-    require_aiokafka,
-    require_aiopika,
-    require_mqtt,
-    require_nats,
-    require_redis,
-)
+from faststream._internal.utils.path import Address, AddressSyntax
 
 SYNTAX = AddressSyntax(
     replace_symbol="*",
@@ -17,72 +6,7 @@ SYNTAX = AddressSyntax(
 )
 
 
-@pytest.mark.parametrize(
-    ("module", "name", "declaration"),
-    (
-        pytest.param(
-            "faststream.kafka.subscriber.usecase",
-            "KAFKA_ADDRESS_SYNTAX",
-            "logs.{{2}}.{level}",
-            marks=require_aiokafka,
-            id="kafka",
-        ),
-        pytest.param(
-            "faststream.nats.schemas.js_stream",
-            "NATS_ADDRESS_SYNTAX",
-            "logs.{{2}}.{level}",
-            marks=require_nats,
-            id="nats",
-        ),
-        pytest.param(
-            "faststream.rabbit.schemas.queue",
-            "RABBIT_ADDRESS_SYNTAX",
-            "logs.{{2}}.{level}",
-            marks=require_aiopika,
-            id="rabbit",
-        ),
-        pytest.param(
-            "faststream.redis.schemas.pub_sub",
-            "REDIS_ADDRESS_SYNTAX",
-            "logs.{{2}}.{level}",
-            marks=require_redis,
-            id="redis",
-        ),
-        pytest.param(
-            "faststream.mqtt.path",
-            "MQTT_ADDRESS_SYNTAX",
-            "logs/{{2}}/{level}",
-            marks=require_mqtt,
-            id="mqtt",
-        ),
-    ),
-)
-def test_a_syntax_compiles_the_way_the_module_function_does(
-    module: str,
-    name: str,
-    declaration: str,
-) -> None:
-    syntax: AddressSyntax = getattr(import_module(module), name)
-
-    assert syntax.compile(declaration) == compile_path(
-        declaration,
-        replace_symbol=syntax.replace_symbol,
-        patch_regex=syntax.patch_regex,
-        param_regex=syntax.param_regex,
-    )
-
-
-def test_a_literal_address_is_read_as_characters_rather_than_a_template() -> None:
-    address = Address.literal("logs.{{2}}.{level}")
-
-    assert (address.template, address.broker_address, address.regex) == (
-        "logs.{{2}}.{level}",
-        "logs.{{2}}.{level}",
-        None,
-    )
-
-
-def test_a_router_prefix_leaves_a_literal_address_literal() -> None:
+def test_a_literal_address_stays_characters_under_a_router_prefix() -> None:
     address = Address.literal("logs.{{2}}.{level}").add_prefix("prefix_")
 
     assert (address.template, address.broker_address, address.regex) == (


### PR DESCRIPTION
# Description

`Address` in `faststream/_internal/utils/path.py` gets two additions. The Config-value work in #3030 (#2451) calls both, and neither changes current behaviour.

- `Address.literal(value)` builds an address that is not a template: no regex, `broker_address` equal to `template`, and `template` equal to the declaration as written, so `{{` stays two characters there. It is a private `Address` subclass, `_LiteralAddress`, so `AddressSyntax` is untouched. Kafka topics are the use case: the broker gets the topic string as written, and parsing it as a template would report capture groups nothing fills. `add_prefix` on a literal address returns a literal address.
- `Address.describe()` returns `repr(self.template)`, for error messages.

No production code calls either yet. Their callers are the `Path()` start-up check and the Config-value resolution layer, each coming in its own PR from the same plan. The feature branch's `AddressSyntax.compile` and its MQTT syntax subclass are not ported: #3074 already handles MQTT's whole-level check on `main`, and nothing else calls `compile`.

Extracted from #3030, part of the prefactor plan for #2451.

## Tests

New `tests/utils/test_path.py`, one test per addition:

- a literal address declared with `{{` and given a Router prefix has `regex is None` and `broker_address == template == declaration`;
- `describe()` on `Address("logs.{level}", syntax)` returns `'logs.{level}'`, quotes included.

## Type of change

- [x] Refactor (no user-visible change)

## Checklist

- [x] `just lint` shows no errors
- [x] `just mypy` passes
- [x] Existing tests pass: `tests/utils/context/test_path.py`, `tests/brokers/{kafka,nats,rabbit,redis,mqtt}/test_address.py`, `tests/brokers/mqtt/test_path.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
