### PR TITLE
fix(testing): stop fake subscribers before hiding them from the real broker

### DIFF
--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -140,9 +140,8 @@ class TestBroker(Generic[Broker, EnterType]):
 
         finally:
             if self.with_real:
-                # The real `broker.start()` started our fakes too, and we are about to
-                # hide them from `broker.stop()`: stop them here, or their consumers
-                # outlive the test and stall every later member of their group.
+                # The real `broker.start()` started the fakes, and `_fake_close` hides
+                # them from `broker.stop()` (see #3046): stop them here or they leak.
                 for sub in self._fake_subscribers:
                     await sub.stop()
 

--- a/faststream/_internal/testing/broker.py
+++ b/faststream/_internal/testing/broker.py
@@ -139,6 +139,13 @@ class TestBroker(Generic[Broker, EnterType]):
             yield broker
 
         finally:
+            if self.with_real:
+                # The real `broker.start()` started our fakes too, and we are about to
+                # hide them from `broker.stop()`: stop them here, or their consumers
+                # outlive the test and stall every later member of their group.
+                for sub in self._fake_subscribers:
+                    await sub.stop()
+
             self._fake_close(broker)
 
     @contextmanager

--- a/tests/brokers/base/testclient.py
+++ b/tests/brokers/base/testclient.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock
 import anyio
 import pytest
 
+from tests.tools import spy_decorator
+
 from .consume import BrokerConsumeTestcase
 from .publish import BrokerPublishTestcase
 
@@ -232,6 +234,24 @@ class BrokerTestclientTestcase(BrokerPublishTestcase, BrokerConsumeTestcase):
                     await asyncio.sleep(0.1)
 
                 publisher.mock.assert_called_once_with("response: hello")
+
+    @pytest.mark.asyncio()
+    async def test_broker_with_real_stops_fake_subscribers(self, queue: str) -> None:
+        """A fake started against the real broker is stopped with it.
+
+        A fake left running keeps its consumer alive after the test, and every
+        later subscriber sharing its consumer group waits for it to die.
+        """
+        test_broker = self.get_broker()
+
+        publisher = test_broker.publisher(queue)  # noqa: F841
+
+        test_client = self.patch_broker(test_broker, with_real=True)
+        async with test_client:
+            (fake,) = test_client._fake_subscribers
+            fake.stop = spy_decorator(fake.stop)
+
+        fake.stop.mock.assert_awaited_once()
 
     @pytest.mark.asyncio()
     async def test_publisher_response_with_model(self, queue: str) -> None:

--- a/tests/brokers/base/testclient.py
+++ b/tests/brokers/base/testclient.py
@@ -235,6 +235,7 @@ class BrokerTestclientTestcase(BrokerPublishTestcase, BrokerConsumeTestcase):
 
                 publisher.mock.assert_called_once_with("response: hello")
 
+    @pytest.mark.connected()
     @pytest.mark.asyncio()
     async def test_broker_with_real_stops_fake_subscribers(self, queue: str) -> None:
         test_broker = self.get_broker()

--- a/tests/brokers/base/testclient.py
+++ b/tests/brokers/base/testclient.py
@@ -237,11 +237,6 @@ class BrokerTestclientTestcase(BrokerPublishTestcase, BrokerConsumeTestcase):
 
     @pytest.mark.asyncio()
     async def test_broker_with_real_stops_fake_subscribers(self, queue: str) -> None:
-        """A fake started against the real broker is stopped with it.
-
-        A fake left running keeps its consumer alive after the test, and every
-        later subscriber sharing its consumer group waits for it to die.
-        """
         test_broker = self.get_broker()
 
         publisher = test_broker.publisher(queue)  # noqa: F841
@@ -251,6 +246,7 @@ class BrokerTestclientTestcase(BrokerPublishTestcase, BrokerConsumeTestcase):
             (fake,) = test_client._fake_subscribers
             fake.stop = spy_decorator(fake.stop)
 
+        # A fake left running stays in its consumer group and blocks later members
         fake.stop.mock.assert_awaited_once()
 
     @pytest.mark.asyncio()


### PR DESCRIPTION
## Why

The `test-confluent-real` job goes red repo-wide on three docs tests (`test_broker_context_confluent`, `test_handle_confluent`, `test_validate_confluent`), see #3104 and the `main` merge-queue run for #3049.

## Root cause

With `with_real=True` the TestBroker registers a fake subscriber for every publisher that has no handler. The real `broker.start()` starts it as a real consumer in the default `faststream-consumer-group`. Since #3046, `_fake_close` discards those fakes from `broker._subscribers` before `broker.stop()` runs, so the fake was never stopped and its consumer outlived the test as a zombie group member.

`tests/brokers/confluent/test_test_client.py::test_broker_with_real_patches_publishers_and_subscribers` runs right before the docs tests in CI and leaves such a zombie. The docs tests do not set `group_id`, so their join puts the group into `PreparingRebalance`, waiting for the zombie to rejoin. librdkafka cannot rejoin without a `poll()` from the application, so what happens next depends on garbage collection:

- zombie object collected: broker expires it after `session.timeout.ms` (10 s), the docs test passes at ~9.8 s of its 10 s budget (the "green but needs reruns" mode);
- zombie object still alive (the case under `--cov`, as in CI): it keeps heartbeating but never rejoins, the group is stuck for `max.poll.interval.ms` (300 s), all four attempts of test 1 fail, tests 2 and 3 cascade in the same group. The CI broker log shows the zombie joining at 21:33:01 and leaving via an explicit `LeaveGroup` at 21:38:01, the exact second the group stabilised.

## Fix

Stop the fakes in `_do_start` before `_fake_close` hides them from `broker.stop()`.

## Verification

- New base testcase `test_broker_with_real_stops_fake_subscribers`: red before the fix (`stop` awaited 0 times), green after; run for confluent, kafka and redis locally.
- Original repro (the test client test followed by the three docs tests, under `--cov`): all four pass in ~3 s each, no session-timeout expiries in the broker log.
- `ruff format`, `ruff check`, `mypy` on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
