### PR TITLE
refactor(rabbit): read queue, exchange and routing key through one layer

### DIFF
--- a/faststream/rabbit/address.py
+++ b/faststream/rabbit/address.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from faststream._internal.utils.path import Address
+    from faststream.rabbit.configs import RabbitBrokerConfig
+    from faststream.rabbit.schemas import RabbitExchange, RabbitQueue
+
+T = TypeVar("T")
+
+
+# Functions taking the config, not methods on it: at runtime `_outer_config` is a
+# `ConfigComposition` whose `__getattr__` binds a method to one level's prefix only.
+def broker_queue(config: "RabbitBrokerConfig", queue: "RabbitQueue") -> "RabbitQueue":
+    """Return the queue as it reaches the broker, with the Router prefix."""
+    return queue.add_prefix(config.prefix)
+
+
+def broker_exchange(
+    config: "RabbitBrokerConfig",
+    exchange: "RabbitExchange",
+) -> "RabbitExchange":
+    """Return the exchange as it reaches the broker; the Router prefix never applies."""
+    return exchange
+
+
+def broker_routing_key(config: "RabbitBrokerConfig", routing_address: "Address") -> str:
+    """Return a Publisher's routing key as it reaches the broker, with the Router prefix."""
+    routing_key = routing_address.template
+    if not routing_key:
+        # No key declared: the queue names the binding, and there is nothing to prefix.
+        return routing_key
+
+    return f"{config.prefix}{routing_key}"
+
+
+def as_declared(config: "RabbitBrokerConfig", address: T) -> T:
+    """Return an address as the endpoint declared it, without the Router prefix."""
+    return address

--- a/faststream/rabbit/publisher/specification.py
+++ b/faststream/rabbit/publisher/specification.py
@@ -1,4 +1,12 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.endpoint.publisher import PublisherSpecification
+from faststream.rabbit.address import (
+    as_declared,
+    broker_exchange,
+    broker_queue,
+    broker_routing_key,
+)
 from faststream.rabbit.configs import RabbitBrokerConfig
 from faststream.rabbit.utils import is_routing_exchange
 from faststream.specification.asyncapi.utils import resolve_payloads
@@ -15,65 +23,78 @@ from faststream.specification.schema.bindings import (
 
 from .config import RabbitPublisherSpecificationConfig
 
+if TYPE_CHECKING:
+    from faststream.rabbit.schemas import RabbitExchange, RabbitQueue
+
 
 class RabbitPublisherSpecification(
     PublisherSpecification[RabbitBrokerConfig, RabbitPublisherSpecificationConfig],
 ):
     @property
+    def queue(self) -> "RabbitQueue":
+        return broker_queue(self._outer_config, self.config.queue)
+
+    @property
+    def exchange(self) -> "RabbitExchange":
+        return broker_exchange(self._outer_config, self.config.exchange)
+
+    @property
+    def routing_key(self) -> str:
+        return broker_routing_key(self._outer_config, self.config.routing_address)
+
+    @property
+    def declared_queue(self) -> "RabbitQueue":
+        return as_declared(self._outer_config, self.config.queue)
+
+    @property
+    def declared_routing_key(self) -> str:
+        return as_declared(self._outer_config, self.config.routing_address).template
+
+    @property
     def routing(self) -> str | None:
-        """The routing key this publisher was declared with, as the name reads it.
+        """The routing key as declared, for the channel name; `address` is the prefixed one."""
+        # An explicit key names the channel whatever the exchange does with it.
+        if routing_key := self.declared_routing_key:
+            return routing_key
 
-        This is the channel name's question, not the address's: an explicit
-        `routing_key` names the channel whatever the exchange does with it. See
-        `address` for the string a message actually travels by.
-        """
-        if self.config.routing_address:
-            return self.config.routing_address.template
-
-        if is_routing_exchange(self.config.exchange):
-            return self.config.queue.routing_template()
+        if is_routing_exchange(self.exchange):
+            return self.declared_queue.routing_template()
 
         return None
 
     @property
     def address(self) -> str | None:
-        """The routing key a message published here travels by, prefixed.
-
-        The exchange decides first, not the declaration: a fanout reaches every
-        queue bound to it and ignores any routing key handed to it, so one declared
-        anyway still addresses nothing. The subscriber gates on the same question,
-        which is what keeps both ends of an address showing one string.
-
-        `None` rather than `""` for that case: AsyncAPI reads an absent address as
-        unknown, and an empty one as an address zero characters long.
-        """
-        if not is_routing_exchange(self.config.exchange):
+        """The routing key a message published here travels by, with the Router prefix."""
+        # The exchange decides first: a fanout ignores routing keys, so one declared
+        # anyway addresses nothing. The subscriber gates on the same question.
+        if not is_routing_exchange(self.exchange):
             return None
 
-        routing = self.routing
-        return f"{self._outer_config.prefix}{routing}" if routing else None
+        # `None` rather than `""`: AsyncAPI reads an absent address as unknown and an
+        # empty one as an address zero characters long.
+        if not self.routing:
+            return None
+
+        return self.routing_key or self.queue.routing_template()
 
     @property
     def name(self) -> str:
         if self.config.title_:
             return self.config.title_
 
-        exchange_name = getattr(self.config.exchange, "name", None)
+        exchange_name = getattr(self.exchange, "name", None)
 
         return f"{self.routing or '_'}:{exchange_name or '_'}:Publisher"
 
     def get_schema(self) -> dict[str, "PublisherSpec"]:
         payloads = self.get_payloads()
 
-        exchange_binding = amqp.Exchange.from_exchange(self.config.exchange)
-        queue_binding = amqp.Queue.from_queue(self.config.queue)
+        exchange_binding = amqp.Exchange.from_exchange(self.exchange)
+        queue_binding = amqp.Queue.from_queue(self.declared_queue)
 
-        # deliberately not `self.address`: the binding hands the routing key over
-        # whatever the exchange type, and the renderer is what drops it where the
-        # exchange ignores one. `address` answers for the document instead, so it
-        # has to make that call itself.
-        r = self.config.routing_address.template or self.config.queue.routing_template()
-        routing_key = f"{self._outer_config.prefix}{r}"
+        # Not `self.address`: the binding hands the key over whatever the exchange
+        # type, and the renderer is what drops it where the exchange ignores one.
+        routing_key = self.routing_key or self.queue.routing_template()
 
         return {
             self.name: PublisherSpec(

--- a/faststream/rabbit/publisher/usecase.py
+++ b/faststream/rabbit/publisher/usecase.py
@@ -5,6 +5,11 @@ from typing_extensions import Unpack, override
 
 from faststream._internal.endpoint.publisher import PublisherUsecase
 from faststream._internal.utils.data import filter_by_dict
+from faststream.rabbit.address import (
+    broker_exchange,
+    broker_queue,
+    broker_routing_key,
+)
 from faststream.rabbit.response import RabbitPublishCommand
 from faststream.rabbit.schemas import RabbitExchange, RabbitQueue
 from faststream.response.publish_type import PublishType
@@ -36,10 +41,9 @@ class RabbitPublisher(PublisherUsecase):
     ) -> None:
         super().__init__(config, specification)
 
-        self.queue = config.queue
-        self.routing_key = config.routing_address.template
-
-        self.exchange = config.exchange
+        self._queue = config.queue
+        self._routing_address = config.routing_address
+        self._exchange = config.exchange
 
         self.headers = config.message_kwargs.pop("headers") or {}
         self.reply_to = config.message_kwargs.pop("reply_to", None) or ""
@@ -53,6 +57,18 @@ class RabbitPublisher(PublisherUsecase):
 
         publish_options, _ = filter_by_dict(PublishOptions, dict(config.message_kwargs))
         self.publish_options = publish_options
+
+    @property
+    def queue(self) -> "RabbitQueue":
+        return broker_queue(self._outer_config, self._queue)
+
+    @property
+    def exchange(self) -> "RabbitExchange":
+        return broker_exchange(self._outer_config, self._exchange)
+
+    @property
+    def routing_key(self) -> str:
+        return broker_routing_key(self._outer_config, self._routing_address)
 
     @property
     def message_options(self) -> "BasicMessageOptions":
@@ -73,8 +89,7 @@ class RabbitPublisher(PublisherUsecase):
             if q := RabbitQueue.validate(queue):
                 routing_key = q.routing()
             else:
-                r = self.routing_key or self.queue.routing()
-                routing_key = f"{self._outer_config.prefix}{r}"
+                routing_key = self.routing_key or self.queue.routing()
 
         return routing_key
 

--- a/faststream/rabbit/subscriber/specification.py
+++ b/faststream/rabbit/subscriber/specification.py
@@ -1,4 +1,7 @@
+from typing import TYPE_CHECKING
+
 from faststream._internal.endpoint.subscriber import SubscriberSpecification
+from faststream.rabbit.address import broker_exchange, broker_queue
 from faststream.rabbit.configs import RabbitBrokerConfig
 from faststream.rabbit.utils import is_routing_exchange
 from faststream.specification.asyncapi.utils import resolve_payloads
@@ -15,46 +18,46 @@ from faststream.specification.schema.bindings import (
 
 from .config import RabbitSubscriberSpecificationConfig
 
+if TYPE_CHECKING:
+    from faststream.rabbit.schemas import RabbitExchange, RabbitQueue
+
 
 class RabbitSubscriberSpecification(
     SubscriberSpecification[RabbitBrokerConfig, RabbitSubscriberSpecificationConfig],
 ):
     @property
+    def queue(self) -> "RabbitQueue":
+        return broker_queue(self._outer_config, self.config.queue)
+
+    @property
+    def exchange(self) -> "RabbitExchange":
+        return broker_exchange(self._outer_config, self.config.exchange)
+
+    @property
     def channel_labels(self) -> list[str]:
-        """A queue and the exchange it is bound to, which is not the address.
+        """The queue and its exchange: both are needed to tell two subscribers apart."""
+        queue_name = self.queue.name
 
-        The address is the routing key; a queue is a place to read from. Both are
-        needed to tell two subscribers apart, so the label carries both.
-        """
-        queue_name = self.config.queue.name
+        exchange_name = getattr(self.exchange, "name", None)
 
-        exchange_name = getattr(self.config.exchange, "name", None)
-
-        return [f"{self._outer_config.prefix}{queue_name}:{exchange_name or '_'}"]
+        return [f"{queue_name}:{exchange_name or '_'}"]
 
     @property
     def address(self) -> str | None:
-        """The routing key the queue is bound by, prefixed.
-
-        `None` where the exchange ignores routing keys: a fanout reaches every queue
-        bound to it, so the queue this subscriber reads from names nothing a message
-        is routed by. The document drops the queue binding for the same reason, and
-        drops the address rather than giving an empty one — AsyncAPI reads an absent
-        address as unknown, which `""` does not say.
-        """
-        if not is_routing_exchange(self.config.exchange):
+        """The routing key the queue is bound by, with the Router prefix."""
+        # A fanout ignores routing keys, so the queue names nothing a message is routed
+        # by; `None` rather than `""` because AsyncAPI reads an absent address as unknown.
+        if not is_routing_exchange(self.exchange):
             return None
 
-        return self.config.queue.add_prefix(
-            self._outer_config.prefix,
-        ).routing_template()
+        return self.queue.routing_template()
 
     def get_schema(self) -> dict[str, SubscriberSpec]:
         payloads = self.get_payloads()
 
-        queue = self.config.queue.add_prefix(self._outer_config.prefix)
+        queue = self.queue
 
-        exchange_binding = amqp.Exchange.from_exchange(self.config.exchange)
+        exchange_binding = amqp.Exchange.from_exchange(self.exchange)
         queue_binding = amqp.Queue.from_queue(queue)
 
         channel_name = self.name

--- a/faststream/rabbit/subscriber/usecase.py
+++ b/faststream/rabbit/subscriber/usecase.py
@@ -8,6 +8,7 @@ from typing_extensions import override
 
 from faststream._internal.endpoint.subscriber import SubscriberUsecase
 from faststream._internal.endpoint.utils import process_msg
+from faststream.rabbit.address import as_declared, broker_exchange, broker_queue
 from faststream.rabbit.parser import AioPikaParser
 from faststream.rabbit.publisher.fake import RabbitFakePublisher
 from faststream.rabbit.schemas import RabbitExchange
@@ -40,7 +41,10 @@ class RabbitSubscriber(SubscriberUsecase["IncomingMessage"]):
         specification: "SubscriberSpecification[Any, Any]",
         calls: "CallsCollection[IncomingMessage]",
     ) -> None:
-        parser = AioPikaParser(pattern=config.queue.path_regex)
+        # Path parameters are captured by the declared key; `^.*?` absorbs any prefix.
+        parser = AioPikaParser(
+            pattern=as_declared(config._outer_config, config.queue).path_regex,
+        )
         config.decoder = parser.decode_message
         config.parser = parser.parse_message
         super().__init__(
@@ -49,8 +53,8 @@ class RabbitSubscriber(SubscriberUsecase["IncomingMessage"]):
             calls=calls,
         )
 
-        self.queue = config.queue
-        self.exchange = config.exchange
+        self._queue = config.queue
+        self._exchange = config.exchange
 
         self.consume_args = config.consume_args or {}
 
@@ -64,15 +68,28 @@ class RabbitSubscriber(SubscriberUsecase["IncomingMessage"]):
     def app_id(self) -> str | None:
         return self._outer_config.app_id
 
+    @property
+    def queue(self) -> "RabbitQueue":
+        return broker_queue(self._outer_config, self._queue)
+
+    @property
+    def exchange(self) -> "RabbitExchange":
+        return broker_exchange(self._outer_config, self._exchange)
+
+    @property
+    def declared_queue(self) -> "RabbitQueue":
+        return as_declared(self._outer_config, self._queue)
+
     def routing(self) -> str:
-        return f"{self._outer_config.prefix}{self.queue.routing()}"
+        return self.queue.routing()
 
     @override
     async def start(self) -> None:
         """Starts the consumer for the RabbitMQ queue."""
         await super().start()
 
-        queue_to_bind = self.queue.add_prefix(self._outer_config.prefix)
+        queue_to_bind = self.queue
+        exchange_to_bind = self.exchange
 
         declarer = self._outer_config.declarer
 
@@ -82,12 +99,12 @@ class RabbitSubscriber(SubscriberUsecase["IncomingMessage"]):
         )
 
         if (
-            self.exchange is not None
-            and queue_to_bind.declare  # queue just getted from RMQ
-            and self.exchange.name  # check Exchange is not default
+            exchange_to_bind is not None
+            and queue_to_bind.declare  # a queue only looked up is not ours to bind
+            and exchange_to_bind.name  # the default exchange binds every queue itself
         ):
             exchange = await declarer.declare_exchange(
-                self.exchange,
+                exchange_to_bind,
                 channel=self.channel,
             )
 
@@ -96,7 +113,7 @@ class RabbitSubscriber(SubscriberUsecase["IncomingMessage"]):
                 routing_key=queue_to_bind.routing(),
                 arguments=queue_to_bind.bind_arguments,
                 timeout=queue_to_bind.timeout,
-                robust=self.queue.robust,
+                robust=queue_to_bind.robust,
             )
 
         if self.calls:
@@ -227,6 +244,7 @@ class RabbitSubscriber(SubscriberUsecase["IncomingMessage"]):
     ) -> dict[str, str]:
         return self.build_log_context(
             message=message,
-            queue=self.queue,
+            # The log has always named the queue as declared, prefix left out.
+            queue=self.declared_queue,
             exchange=self.exchange,
         )


### PR DESCRIPTION
# Description

RabbitMQ endpoints now read their queue, exchange and routing key through one module, `faststream/rabbit/address.py`, the way Redis reads its channel through one property: the Router prefix is composed at the point of use. Before, the Subscriber's `start()`, the Publisher's `routing()`, both Specifications and the in-memory test broker each read the options object and applied the prefix on their own.

The module has four functions. `broker_queue`, `broker_exchange` and `broker_routing_key` return an address as it reaches the broker. `as_declared` returns one as the user wrote it, for the reads that describe the declaration: the Subscriber's log context and parser pattern, and the Publisher's channel name and queue binding in the AsyncAPI document. Those are unprefixed on `main` today and stay unprefixed here. This PR moves reads and decides nothing.

`broker_exchange` and `as_declared` are identity functions. They exist so the Config-value ticket in the same plan has one place per address to hook into.

The endpoints' `queue`, `exchange` and `routing_key` become properties. On `main` they were plain attributes holding the declared value; now they return the value as it reaches the broker, so under a prefixed router `sub.queue.name` reads `pre_orders` where it read `orders`. Nothing in the docs, examples or tests reads them. `RabbitQueue.add_prefix` copies, so a Publisher's `routing()` now copies its queue on each publish without an explicit routing key. Redis pays the same per read.

Extracted from #3030, part of the prefactor plan for #2451. Rebuilt on #3074's `routing_address` rather than cherry-picked.

## Tests

None added: the RabbitMQ router, test-client and AsyncAPI suites already fail on a missing or doubled prefix. For the byte-for-byte claim I dumped both AsyncAPI versions, `routing()`, `get_log_context()` and every specification's name and address for endpoints under plain, prefixed and nested routers, on `main` and on this branch. Identical.

## Type of change

- [x] Refactor (no functional change)

## Checklist

- [x] `just lint` shows no errors
- [x] `just mypy` passes
- [x] Existing tests pass, no test edited: `tests/brokers/rabbit/{test_test_client,test_router,test_publish,test_consume,test_address,test_config,test_connect,test_fastapi,test_requests,test_schemas}.py`, `tests/asyncapi/rabbit/v2_6_0`, `tests/asyncapi/rabbit/v3_0_0`, `tests/opentelemetry/rabbit`, `tests/prometheus/rabbit`, in memory and against a local RabbitMQ. The one exception is `test_consume_cancel_skips_ack_nack_reject` in the opentelemetry and prometheus files, which drops the connection to my local container on `main` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
