### PR TITLE
fix(redis): stop the subscriber on terminal stream errors instead of restarting

### DIFF
--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -107,8 +107,9 @@ class _StreamHandlerMixin(LogicSubscriber):
             try:
                 await self._get_msgs(*args)
 
-            except StreamClaimUnsupportedError:  # noqa: PERF203
-                raise
+            except StreamClaimUnsupportedError as e:  # noqa: PERF203
+                await self._stop_on_terminal_error(e, str(e))
+                return
 
             except ResponseError as e:
                 if "NOGROUP" in str(e):
@@ -118,7 +119,8 @@ class _StreamHandlerMixin(LogicSubscriber):
                         "The stream was likely deleted or flushed. "
                         "Stopping subscriber — restart the application to recreate the group."
                     )
-                    raise StreamGroupNotFoundError(msg) from e
+                    await self._stop_on_terminal_error(StreamGroupNotFoundError(msg), msg)
+                    return
 
                 raise
 
@@ -133,6 +135,15 @@ class _StreamHandlerMixin(LogicSubscriber):
             finally:
                 if not start_signal.is_set():
                     start_signal.set()
+
+    async def _stop_on_terminal_error(self, exc: Exception, msg: str) -> None:
+        # A terminal error: re-running the read cannot fix it, and raising it
+        # would make the task supervisor restart the read in a hot loop. Stop
+        # the subscriber for good and, if the broker runs inside an app, exit.
+        self._log(log_level=logging.CRITICAL, message=msg, exc_info=exc)
+        await self.stop()
+        if app := self._outer_config.fd_config.context.get("app"):
+            app.exit()
 
     @override
     async def start(self) -> None:

--- a/tests/brokers/redis/stream_claim.py
+++ b/tests/brokers/redis/stream_claim.py
@@ -1,14 +1,14 @@
 import asyncio
 from contextlib import suppress
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from dirty_equals import HasLen, IsInstance, IsInt, IsPartialDict
+from dirty_equals import HasLen, IsInt, IsPartialDict
 from redis.asyncio import Redis, RedisCluster
 from redis.exceptions import ResponseError
 
-from faststream.redis import RedisBroker, StreamClaimUnsupportedError, StreamSub
+from faststream.redis import RedisBroker, StreamSub
 from faststream.redis.annotations import RedisBatchStreamMessage, RedisStreamMessage
 from tests.brokers.base.basic import BaseTestcaseConfig
 from tests.marks import require_redis_v710
@@ -236,10 +236,15 @@ class StreamClaimTestcase(BaseTestcaseConfig):
 
     @pytest.mark.slow()
     @require_redis_v710
-    async def test_unsupported_server_stops_subscriber(
+    async def test_unsupported_server_stops_app(
         self,
         queue: str,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # The global conftest disables the task supervisor; this test is about
+        # not entering its restart loop, so turn it back on.
+        monkeypatch.setenv("FASTSTREAM_SUPERVISOR_DISABLED", "0")
+
         consume_broker = self.get_broker(apply_types=True)
 
         @consume_broker.subscriber(
@@ -253,6 +258,9 @@ class StreamClaimTestcase(BaseTestcaseConfig):
         async def handler(msg: str) -> None: ...
 
         async with self.patch_broker(consume_broker) as br:
+            fake_app = MagicMock()
+            br.context.set_global("app", fake_app)
+
             reject = AsyncMock(side_effect=ResponseError("syntax error"))
             with patch.object(self.client_cls, "xreadgroup", reject):
                 await br.start()
@@ -260,15 +268,12 @@ class StreamClaimTestcase(BaseTestcaseConfig):
 
                 calls_after_stop = reject.call_count
                 await asyncio.sleep(0.3)
-                # Stopped after the rejection instead of retrying in a hot loop
+                # The supervisor is live: a stable count proves the rejection
+                # stops the subscriber instead of restarting it in a hot loop
                 assert reject.call_count == calls_after_stop
 
-                errors = [
-                    task.exception()
-                    for task in br.subscribers[0].tasks
-                    if task.done() and not task.cancelled()
-                ]
-                assert errors == [IsInstance(StreamClaimUnsupportedError)]
+                assert not br.subscribers[0].running
+                fake_app.exit.assert_called_once()
 
     @pytest.mark.slow()
     @require_redis_v710

--- a/tests/brokers/redis/test_consume.py
+++ b/tests/brokers/redis/test_consume.py
@@ -14,7 +14,6 @@ from faststream.redis import (
     RedisStreamMessage,
     StreamSub,
 )
-from faststream.redis.exceptions import StreamGroupNotFoundError
 from tests.brokers.base.consume import BrokerRealConsumeTestcase
 from tests.tools import spy_decorator
 
@@ -1037,8 +1036,13 @@ class TestConsumeStream(RedisTestcaseConfig):
         queue: str,
         mock: MagicMock,
         event: asyncio.Event,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Subscriber stops when the consumer group is deleted (NOGROUP)."""
+        """Subscriber stops the app when the consumer group is deleted (NOGROUP)."""
+        # The global conftest disables the task supervisor; this test is about
+        # not entering its restart loop, so turn it back on.
+        monkeypatch.setenv("FASTSTREAM_SUPERVISOR_DISABLED", "0")
+
         consume_broker = self.get_broker(apply_types=True)
 
         @consume_broker.subscriber(
@@ -1049,6 +1053,9 @@ class TestConsumeStream(RedisTestcaseConfig):
             event.set()
 
         async with self.patch_broker(consume_broker) as br:
+            fake_app = MagicMock()
+            br.context.set_global("app", fake_app)
+
             await br.start()
 
             # Publish a message so the subscriber reads and starts consuming
@@ -1069,16 +1076,6 @@ class TestConsumeStream(RedisTestcaseConfig):
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(event.wait(), timeout=1)
 
-            # The subscriber task should have finished with StreamGroupNotFoundError
-            tasks = br.subscribers[0].tasks
-            assert all(t.done() for t in tasks)
-            found = False
-            for t in tasks:
-                try:
-                    exc = t.exception()
-                    if isinstance(exc, StreamGroupNotFoundError):
-                        found = True
-                        break
-                except (asyncio.CancelledError, asyncio.InvalidStateError):
-                    pass
-            assert found, "Expected at least one task to raise StreamGroupNotFoundError"
+            # Stopped instead of restarting in a hot loop, and asked the app to exit
+            assert not br.subscribers[0].running
+            fake_app.exit.assert_called_once()


### PR DESCRIPTION
# Description

Terminal errors in the Redis stream consume loop currently re-raise, which kills the consume task and lets `TaskCallbackSupervisor` (`restart_on_failure=True` by default) restart it into the same error — a hot loop with no backoff. This stops the subscriber for good and, when the broker runs inside an app, exits the app instead.

Fixes #3106

Two paths in `_consume` were terminal but re-raised:

- `StreamGroupNotFoundError` (NOGROUP) — the stream/group was deleted or flushed at runtime.
- `StreamClaimUnsupportedError` — a `claim_min_idle_time` subscriber against a pre-8.4 server (from #3049).

Both now route through one `_stop_on_terminal_error` helper: log the reason at CRITICAL, `await self.stop()` (which ends the restart loop), and call `app.exit()` when an app is in the context. A standalone broker (no `FastStream` app) has no app in the context, so only the subscriber is stopped. This reuses the existing `SystemExit` precedent in `SubscriberUsecase.consume()`. `StreamGroupNotFoundError` stays a public exception; it is now passed to the log instead of raised.

**Runtime check** (Redis 7.4.10, before → after), ~5s after triggering each path:

| | supervisor restarts | `XREADGROUP` reaching the server |
|---|---|---|
| NOGROUP, before | 8,290 | 8,288 (~1,650/s) |
| claim, before | 13,087 | 13,086 (~2,070/s) |
| both, after | 1 | 1 |

After the fix the reason is logged once at CRITICAL and the app shuts down gracefully on its own.

The `test_unsupported_server_stops_app` and `test_consume_stream_group_deleted` tests now run with the supervisor enabled (the global conftest disables it, which is why the old assertions couldn't catch the loop) and assert the subscriber stops and `app.exit()` is called.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
