### PR TITLE
Update who-uses.md

### DIFF
--- a/docs/docs/en/who-uses.md
+++ b/docs/docs/en/who-uses.md
@@ -89,6 +89,7 @@ Packages built on top of **FastStream** by the community:
 * [`litestar-faststream`](https://github.com/hasansezertasan/litestar-faststream){.external-link target="_blank"} - **Litestar** integration for **FastStream** message brokers
 * [`fast-healthchecks`](https://github.com/ZYLVEXT/fast-healthchecks){.external-link target="_blank"} - framework-agnostic health checks
 * [`awesome-faststream`](https://github.com/lesnik512/awesome-faststream){.external-link target="_blank"} - curated list of libraries, tools, templates and resources
+* [`faststream-celery`](https://github.com/C3EQUALZz/faststream-celery){.external-link target="_blank"} - connects **FastStream** to the **Celery (kombu)** broker. 
 
 ## Add Your Project
 

--- a/docs/docs/en/who-uses.md
+++ b/docs/docs/en/who-uses.md
@@ -89,7 +89,7 @@ Packages built on top of **FastStream** by the community:
 * [`litestar-faststream`](https://github.com/hasansezertasan/litestar-faststream){.external-link target="_blank"} - **Litestar** integration for **FastStream** message brokers
 * [`fast-healthchecks`](https://github.com/ZYLVEXT/fast-healthchecks){.external-link target="_blank"} - framework-agnostic health checks
 * [`awesome-faststream`](https://github.com/lesnik512/awesome-faststream){.external-link target="_blank"} - curated list of libraries, tools, templates and resources
-* [`faststream-celery`](https://github.com/C3EQUALZz/faststream-celery){.external-link target="_blank"} - connects **FastStream** to the **Celery (kombu)** broker. 
+* [`faststream-celery`](https://github.com/C3EQUALZz/faststream-celery){.external-link target="_blank"} - connects **FastStream** to the **Celery (kombu)** broker.
 
 ## Add Your Project
 


### PR DESCRIPTION
Adding new integration - faststream-celery - in docs

# Description

This PR adds a link to a new integration: faststream-celery. It introduces a new broker built on top of Kombu. 
The motivation behind this is that many legacy services rely on a combination of an async HTTP framework and Celery. Due to Python's "colored functions" problem, developers are often forced to either duplicate logic for sync and async contexts or rely on various workarounds like asgiref, palitra, or aio-celery. 
This integration enables writing fully asynchronous code, facilitating a gradual migration from Celery to FastStream. Furthermore, since many teams use Celery not just as a task worker but also as a message bus between services, this integration specifically addresses that use case.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)


## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
