### PR TITLE
chore: Context7 replaces Gurubase

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/ag2ai/faststream",
+  "public_key": "pk_CqFilRsqSpmkpPAWrwP5Z"
+}


### PR DESCRIPTION
Switches the docs' AI assistant from Gurubase to [Context7](https://context7.com/ag2ai/faststream).

- `context7.json` at the repo root, so Context7 indexes this repo's docs.
- The widget script goes into the `scripts` block of `docs/overrides/main.html`, so it loads on every page. It is tinted `#003257` — the docs' primary color, same as the old widget.
- `gurubase-widget.js` and `theme-switch.js` are gone: the latter existed only to sync the Gurubase widget's light/dark mode, and Context7 handles its own theme.
- The Gurubase badge in the README and on the docs index now points at Context7.