### PR TITLE
fix(cli): stop the supervisor deadlocking on shutdown

### DIFF
--- a/.github/workflows/pr_tests.yaml
+++ b/.github/workflows/pr_tests.yaml
@@ -26,6 +26,7 @@ jobs:
   test-basic:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -62,6 +63,7 @@ jobs:
   test-macos-latest:
     if: github.event.pull_request.draft == false
     runs-on: macos-latest
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -93,6 +95,7 @@ jobs:
   test-windows-latest:
     if: github.event.pull_request.draft == false
     runs-on: windows-latest
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -124,6 +127,7 @@ jobs:
   test-kafka-smoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -149,6 +153,7 @@ jobs:
       - test-basic
       - test-kafka-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       kafka:
         image: confluentinc/cp-kafka:8.0.0
@@ -197,6 +202,7 @@ jobs:
   test-confluent-smoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -222,6 +228,7 @@ jobs:
       - test-basic
       - test-confluent-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       kafka:
         image: confluentinc/cp-kafka:8.0.0
@@ -270,6 +277,7 @@ jobs:
   test-rabbit-smoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -295,6 +303,7 @@ jobs:
       - test-basic
       - test-rabbit-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       rabbitmq:
         image: rabbitmq:3.13-alpine
@@ -331,6 +340,7 @@ jobs:
   test-nats-smoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -356,6 +366,7 @@ jobs:
       - test-basic
       - test-nats-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Start NATS with JetStream
         run: |
@@ -398,6 +409,7 @@ jobs:
   test-mqtt-smoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -423,6 +435,7 @@ jobs:
       - test-basic
       - test-mqtt-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       artemis:
         image: apache/activemq-artemis:latest-alpine
@@ -461,6 +474,7 @@ jobs:
   test-redis-smoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -483,6 +497,7 @@ jobs:
   test-redis-real:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - test-basic
       - test-redis-smoke
@@ -522,6 +537,7 @@ jobs:
   test-redis-cluster-smoke:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -547,6 +563,7 @@ jobs:
       - test-basic
       - test-redis-cluster-smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Start Redis Cluster
         run: |
@@ -605,6 +622,7 @@ jobs:
       - test-redis-cluster-real
       - test-mqtt-real
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/faststream/_internal/cli/supervisors/basereload.py
+++ b/faststream/_internal/cli/supervisors/basereload.py
@@ -3,7 +3,11 @@ import threading
 from multiprocessing.context import SpawnProcess
 from typing import TYPE_CHECKING
 
-from faststream._internal.cli.supervisors.utils import get_subprocess, set_exit
+from faststream._internal.cli.supervisors.utils import (
+    get_subprocess,
+    set_exit,
+    stop_process,
+)
 from faststream._internal.logger import logger
 
 if TYPE_CHECKING:
@@ -60,8 +64,7 @@ class BaseReload:
         logger.info("Stopping reloader process [%s]", self.pid)
 
     def _stop_process(self) -> None:
-        self._process.terminate()
-        self._process.join()
+        stop_process(self._process)
 
     def start_process(self, worker_id: int | None = None) -> SpawnProcess:
         self._args.extra_options["worker_id"] = worker_id

--- a/faststream/_internal/cli/supervisors/basereload.py
+++ b/faststream/_internal/cli/supervisors/basereload.py
@@ -1,9 +1,9 @@
 import os
-import threading
 from multiprocessing.context import SpawnProcess
 from typing import TYPE_CHECKING
 
 from faststream._internal.cli.supervisors.utils import (
+    ExitEvent,
     get_subprocess,
     set_exit,
     stop_process,
@@ -20,7 +20,7 @@ class BaseReload:
     _process: SpawnProcess
 
     reload_delay: float | None
-    should_exit: threading.Event
+    should_exit: ExitEvent
     pid: int
     reloader_name: str = ""
 
@@ -33,7 +33,7 @@ class BaseReload:
         self._target = target
         self._args = args
 
-        self.should_exit = threading.Event()
+        self.should_exit = ExitEvent()
         self.pid = os.getpid()
         self.reload_delay = reload_delay
 

--- a/faststream/_internal/cli/supervisors/multiprocess.py
+++ b/faststream/_internal/cli/supervisors/multiprocess.py
@@ -2,6 +2,7 @@ import signal
 from typing import TYPE_CHECKING
 
 from faststream._internal.cli.supervisors.basereload import BaseReload
+from faststream._internal.cli.supervisors.utils import stop_process
 from faststream._internal.logger import logger
 
 SIGKILL: int | None = getattr(signal, "SIGKILL", None)
@@ -37,9 +38,8 @@ class Multiprocess(BaseReload):
 
     def shutdown(self) -> None:
         for worker_id, process in enumerate(self.processes):
-            process.terminate()
             logger.info("Stopping child process %s [%s]", worker_id, process.pid)
-            process.join()
+            stop_process(process)
 
         logger.info("Stopping parent process [%s]", self.pid)
 

--- a/faststream/_internal/cli/supervisors/utils.py
+++ b/faststream/_internal/cli/supervisors/utils.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import signal
 import sys
+import time
 from collections.abc import Callable
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional
@@ -23,6 +24,9 @@ spawn = multiprocessing.get_context("spawn")
 # enough that a stuck one cannot hold the supervisor hostage.
 SHUTDOWN_TIMEOUT = 30.0
 
+# How often a lock-free wait re-reads its flag.
+EXIT_POLL_INTERVAL = 0.05
+
 HANDLED_SIGNALS: tuple[int, ...] = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
@@ -32,6 +36,40 @@ if IS_WINDOWS:  # pragma: py-not-win32
     sigbreak: int | None = getattr(signal, "SIGBREAK", None)
     if sigbreak is not None:
         HANDLED_SIGNALS += (sigbreak,)
+
+
+class ExitEvent:
+    """A `threading.Event` a signal handler can set, because nothing here takes a lock.
+
+    `threading.Event.set()` holds the condition's lock while it notifies waiters. A
+    second signal arriving in that window re-enters the handler and deadlocks the
+    process on a lock it already owns (see issue #3119).
+    """
+
+    def __init__(self) -> None:
+        self._is_set = False
+
+    def set(self) -> None:
+        self._is_set = True
+
+    def is_set(self) -> bool:
+        return self._is_set
+
+    def wait(self, timeout: float | None = None) -> bool:
+        deadline = None if timeout is None else time.monotonic() + timeout
+
+        while not self._is_set:
+            if deadline is None:
+                time.sleep(EXIT_POLL_INTERVAL)
+                continue
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+
+            time.sleep(min(EXIT_POLL_INTERVAL, remaining))
+
+        return True
 
 
 def set_exit(

--- a/faststream/_internal/cli/supervisors/utils.py
+++ b/faststream/_internal/cli/supervisors/utils.py
@@ -19,6 +19,10 @@ multiprocessing.allow_connection_pickling()
 spawn = multiprocessing.get_context("spawn")
 
 
+# Matches gunicorn's graceful timeout: long enough for a worker to drain, short
+# enough that a stuck one cannot hold the supervisor hostage.
+SHUTDOWN_TIMEOUT = 30.0
+
 HANDLED_SIGNALS: tuple[int, ...] = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
@@ -70,6 +74,17 @@ def get_subprocess(
         args=args,
         kwargs={"t": target, "stdin_fileno": stdin_fileno},
     )
+
+
+def stop_process(process: "SpawnProcess", timeout: float = SHUTDOWN_TIMEOUT) -> None:
+    """Terminate a worker, escalating to SIGKILL if it outlives the timeout."""
+    process.terminate()
+    process.join(timeout)
+
+    if process.is_alive():
+        # An unbounded join hangs the supervisor forever on a worker deaf to SIGTERM.
+        process.kill()
+        process.join()
 
 
 def subprocess_started(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,9 @@ typeCheckingMode = "strict"
 [tool.pytest.ini_options]
 minversion = "7.0"
 timeout = 30
+# Per phase, so a `flaky` rerun gets its own timer: pytest-timeout cancels a
+# whole-item one on the first failure, and rerunfailures retries inside it.
+timeout_func_only = true
 addopts = "--strict-markers --strict-config -q -m 'not slow'"
 testpaths = ["tests"]
 markers = [

--- a/tests/cli/supervisors/test_multiprocess.py
+++ b/tests/cli/supervisors/test_multiprocess.py
@@ -1,6 +1,9 @@
+import os
 import signal
 import threading
 import time
+
+import pytest
 
 from faststream._internal.cli.dto import RunArgs
 from faststream._internal.cli.supervisors.multiprocess import Multiprocess
@@ -12,10 +15,15 @@ def sleep_forever(args: RunArgs) -> None:  # pragma: no cover
 
 
 @skip_windows
-def test_workers_are_terminated_on_shutdown() -> None:
+@pytest.mark.parametrize("sig", (signal.SIGINT, signal.SIGTERM))
+def test_workers_are_terminated_on_exit_signal(sig: signal.Signals) -> None:
     processor = Multiprocess(target=sleep_forever, args=RunArgs(app=""), workers=2)
-    threading.Timer(0.1, processor.should_exit.set).start()
+    # sent from here, not from a worker, so it cannot outlive the test and land
+    # on the handler the next one installs
+    sender = threading.Timer(0.1, os.kill, args=(processor.pid, sig))
+    sender.start()
 
     processor.run()
+    sender.join()
 
     assert [p.exitcode for p in processor.processes] == [-signal.SIGTERM] * 2

--- a/tests/cli/supervisors/test_multiprocess.py
+++ b/tests/cli/supervisors/test_multiprocess.py
@@ -1,30 +1,21 @@
-import os
 import signal
-
-import pytest
+import threading
+import time
 
 from faststream._internal.cli.dto import RunArgs
 from faststream._internal.cli.supervisors.multiprocess import Multiprocess
 from tests.marks import skip_windows
 
 
-def exit(args: RunArgs) -> None:  # pragma: no cover
-    os.kill(
-        int(args.extra_options["parent_id"]),
-        signal.SIGINT,
-    )
-    raise SyntaxError
+def sleep_forever(args: RunArgs) -> None:  # pragma: no cover
+    time.sleep(60)
 
 
 @skip_windows
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
-def test_base() -> None:
-    args = RunArgs(app="")
-    processor = Multiprocess(target=exit, args=args, workers=2)
-    processor._args.extra_options = {"parent_id": processor.pid}
+def test_workers_are_terminated_on_shutdown() -> None:
+    processor = Multiprocess(target=sleep_forever, args=RunArgs(app=""), workers=2)
+    threading.Timer(0.1, processor.should_exit.set).start()
+
     processor.run()
 
-    for p in processor.processes:
-        assert p.exitcode
-        code = abs(p.exitcode)
-        assert code in {signal.SIGTERM.value, 0}
+    assert [p.exitcode for p in processor.processes] == [-signal.SIGTERM] * 2

--- a/tests/cli/supervisors/test_utils.py
+++ b/tests/cli/supervisors/test_utils.py
@@ -24,6 +24,6 @@ def test_stop_process_kills_worker_deaf_to_sigterm() -> None:
     process.start()
     assert ready.wait(timeout=10)
 
-    stop_process(process, timeout=0.5)
+    stop_process(process, timeout=0.1)
 
     assert process.exitcode == -signal.SIGKILL

--- a/tests/cli/supervisors/test_utils.py
+++ b/tests/cli/supervisors/test_utils.py
@@ -1,0 +1,29 @@
+import signal
+import time
+from multiprocessing.synchronize import Event
+
+from faststream._internal.cli.supervisors.utils import (
+    get_subprocess,
+    spawn,
+    stop_process,
+)
+from tests.marks import skip_windows
+
+
+def deaf_to_sigterm(ready: Event) -> None:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    ready.set()
+    time.sleep(60)
+
+
+@skip_windows
+def test_stop_process_kills_worker_deaf_to_sigterm() -> None:
+    ready = spawn.Event()
+
+    process = get_subprocess(target=deaf_to_sigterm, args=(ready,))
+    process.start()
+    assert ready.wait(timeout=10)
+
+    stop_process(process, timeout=0.5)
+
+    assert process.exitcode == -signal.SIGKILL

--- a/tests/cli/supervisors/test_watchfiles.py
+++ b/tests/cli/supervisors/test_watchfiles.py
@@ -1,5 +1,5 @@
-import os
 import signal
+import threading
 import time
 from multiprocessing.context import SpawnProcess
 from pathlib import Path
@@ -28,17 +28,15 @@ class PatchedWatchReloader(WatchReloader):
 def test_base(generate_template: interfaces.GenerateTemplateFactory) -> None:
     with generate_template("") as file_path:
         processor = PatchedWatchReloader(
-            target=exit,
+            target=sleep_forever,
             args=RunArgs(app=""),
             reload_dirs=[str(file_path.parent)],
         )
+        threading.Timer(0.1, processor.should_exit.set).start()
 
-        processor._args.extra_options = {"parent_id": processor.pid}
         processor.run()
 
-        code = abs(processor._process.exitcode or 0)
-
-    assert code in {signal.SIGTERM.value, 0}, code
+    assert processor._process.exitcode == -signal.SIGTERM
 
 
 @pytest.mark.slow()
@@ -52,10 +50,8 @@ def test_restart(
             args=RunArgs(app=str(file_path)),
             reload_dirs=[file_path.parent],
         )
-
-        mock.side_effect = lambda: exit(
-            RunArgs(app="", extra_options={"parent_id": processor.pid})
-        )
+        # one reload is all this pins, so stop before the watcher reports another
+        mock.side_effect = processor.should_exit.set
 
         with patch.object(processor, "restart", mock):
             processor.run()
@@ -63,11 +59,11 @@ def test_restart(
     mock.assert_called_once()
 
 
-def touch_file(args: RunArgs) -> None:
+def sleep_forever(args: RunArgs) -> None:  # pragma: no cover
+    time.sleep(60)
+
+
+def touch_file(args: RunArgs) -> None:  # pragma: no cover
     while True:
         time.sleep(0.1)
         Path(args.app).write_text("hello", encoding="utf-8")
-
-
-def exit(args: RunArgs) -> None:
-    os.kill(int(args.extra_options["parent_id"]), signal.SIGINT)

--- a/tests/cli/supervisors/test_watchfiles.py
+++ b/tests/cli/supervisors/test_watchfiles.py
@@ -1,8 +1,10 @@
+import os
 import signal
 import threading
 import time
 from multiprocessing.context import SpawnProcess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,24 +19,36 @@ DIR = Path(__file__).resolve().parent
 
 
 class PatchedWatchReloader(WatchReloader):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.watching = threading.Event()
+
     def start_process(self, worker_id: int | None = None) -> SpawnProcess:
         process = get_subprocess(target=self._target, args=(self._args,))
         process.start()
         return process
 
+    def should_restart(self) -> bool:
+        self.watching.set()
+        return super().should_restart()
+
 
 @pytest.mark.slow()
 @skip_windows
-def test_base(generate_template: interfaces.GenerateTemplateFactory) -> None:
+def test_watcher_stops_on_exit_signal(
+    generate_template: interfaces.GenerateTemplateFactory,
+) -> None:
     with generate_template("") as file_path:
         processor = PatchedWatchReloader(
             target=sleep_forever,
             args=RunArgs(app=""),
             reload_dirs=[str(file_path.parent)],
         )
-        threading.Timer(0.1, processor.should_exit.set).start()
+        sender = threading.Thread(target=signal_while_watching, args=(processor,))
+        sender.start()
 
         processor.run()
+        sender.join()
 
     assert processor._process.exitcode == -signal.SIGTERM
 
@@ -57,6 +71,14 @@ def test_restart(
             processor.run()
 
     mock.assert_called_once()
+
+
+def signal_while_watching(processor: PatchedWatchReloader) -> None:
+    # the watcher blocks the run loop, and watchfiles brings its own interrupt
+    # handling — only `stop_event` gets the reloader out of that step cleanly
+    assert processor.watching.wait(timeout=10)
+    time.sleep(0.2)
+    os.kill(processor.pid, signal.SIGINT)
 
 
 def sleep_forever(args: RunArgs) -> None:  # pragma: no cover


### PR DESCRIPTION
# Description

A CI job on #3116 hung for six hours and was killed by GitHub's ceiling: [run 34510929785](https://github.com/ag2ai/faststream/actions/runs/34510929785/job/102984574093). That PR only touched one line of `who-uses.md`, so the hang is ours.

The job's last line was `tests/cli/supervisors/test_base_reloader.py::test_base PASSED`, then silence. The passing 3.12 job runs `tests/cli/supervisors/test_multiprocess.py::test_base` next, so that is where it stopped. It reproduces: **1 hang in 167 runs** of `tests/cli/supervisors` on Linux/3.13, and `timeout = 30` from `pyproject.toml` never fired — the process had to be SIGKILLed.

## The deadlock

Running the flake with reruns off finally printed a stack:

```
run() -> should_exit.wait(delay) -> waiter.acquire(...)
  <- SIGINT from worker 0, handler -> Event.set() -> notify_all()
    <- SIGINT from worker 1, handler -> Event.set() -> with self._cond   # deadlock
```

`threading.Event.set()` holds the condition's lock while it notifies waiters, and the exit handler called it straight from a signal:

```python
set_exit(lambda *_: self.should_exit.set(), sync=True)
```

A second signal landing in that window re-enters the handler and blocks the process on a lock it already owns. Nothing gets out of that: no timeout fires, nothing is logged, and only an external SIGKILL ends it.

This is not only a test problem. `faststream run --workers N` deadlocks the same way — systemd's SIGTERM followed by an impatient Ctrl+C is enough, and so are two workers dying at once.

`ExitEvent` keeps the same surface — `set`, `is_set`, `wait` — over a plain flag, so a handler can set it without taking a lock. watchfiles accepts it as a `stop_event`, which only needs `is_set()`.

## The unbounded join

While reading the same code: `Multiprocess.shutdown()` called `terminate()` and then `join()` with no timeout, so a worker that outlives SIGTERM keeps the supervisor waiting forever. `BaseReload._stop_process()` had the same shape. `stop_process` now allows 30 seconds — gunicorn's grace — then escalates to SIGKILL.

## The tests that signalled the pytest process

`test_multiprocess.py::test_base` had a spawn worker send SIGINT to the pytest process, then asserted on a race between the worker's own exit and the SIGTERM chasing it. That is what earned it `@pytest.mark.flaky(reruns=3)`, and it was the vehicle for the deadlock. `test_watchfiles.py` did the same, with a second failure mode: a signal arriving after its test lands on whichever handler the next test installed, and watchfiles turns one into a `KeyboardInterrupt` that kills the session.

What made them flaky was not the signal, it was everything around it: the worker chose when to send, and the assertion raced the worker's own exit against the SIGTERM chasing it. So the signal stays where it carries the coverage — `set_exit` → handler → the event the run loop waits on, the very path the deadlock lived in — and the rest goes:

- the signal is sent from the test process, at a known moment, and cannot outlive the test;
- workers only sleep, so nothing races the SIGTERM that reaps them and both exit codes are exact;
- both handled signals are covered, where the old test only sent SIGINT.

`test_watchfiles.py` drives `should_exit` directly instead: its subject is the watcher, and a signal there would be testing watchfiles' own interrupt handling, not ours. `require_broker/test_app.py` still signals the pytest process deliberately, which is why the `pytest_keyboard_interrupt` hook in `tests/conftest.py` stays.

## Why 30s did not stop it

**pytest-timeout does not cover flaky reruns.** It cancels the timer on the first failure (`pytest_exception_interact` → `pytest_timeout_cancel_timer`) while pytest-rerunfailures retries inside the same `pytest_runtest_protocol`, so every retry ran with no timeout at all. That is the difference between failing at 30s and running to GitHub's ceiling.

`timeout_func_only = true` arms the timer per phase instead of per item, so each retry gets its own. Against the repro — a test that fails once and then sleeps, `--timeout=5` — it goes from hanging forever to `1 failed, 3 rerun in 18s`. The trade is that setup and teardown are no longer covered; the job caps below are the backstop for those.

## CI runtime caps

No job carried `timeout-minutes`, which is why one stuck test cost six hours. Measured over the last six green runs — in-memory peaks at 2.9 min, broker-backed at 4.5 (kafka), smoke under 1 — the caps are 7 minutes for in-memory jobs and 10 for everything broker-backed, roughly double the observed worst case.

## Verification

- `tests/cli` is green (106 passed, 3 skipped), and `tests/cli/supervisors` runs in ~3s.
- The Linux/3.13 stress loop that reproduced the hang (1 in 167) ran 800 times against this branch: no hang, every run green.
- Removing the SIGKILL escalation makes `test_stop_process_kills_worker_deaf_to_sigterm` hang into the pytest timeout, so that path is actually covered.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix
- [x] Both new and existing unit tests pass successfully on my local environment
- [x] I have ensured that static analysis tests are passing
