### PR TITLE
docs: keep Context7 chat keystrokes away from Material's shortcuts

### DIFF
--- a/docs/docs/javascripts/context7-widget.js
+++ b/docs/docs/javascripts/context7-widget.js
@@ -1,0 +1,14 @@
+// Material for MkDocs treats a keystroke as a global shortcut (s, f and /
+// open search; p and n switch pages) unless focus is in an input. The Context7
+// widget renders in a closed shadow root, so from the outside the focused
+// element is the widget host, not its input, and every such letter typed into
+// the chat opens site search instead.
+//
+// Stop the event on `document`, before it bubbles to Material's `window`
+// listener. Bubble phase only: stopping it during capture would keep the
+// keystroke from reaching the widget's input at all.
+document.addEventListener("keydown", (event) => {
+  if (event.target instanceof Element && event.target.id === "context7-widget") {
+    event.stopPropagation();
+  }
+});

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -64,6 +64,9 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - javascripts/context7-widget.js
+
 plugins:
   - search:
       separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'


### PR DESCRIPTION
# Description

Follow-up to #3119. Typing into the Context7 chat on the docs site opens the site search as soon as you hit `s`, `f` or `/`, and `p`, `n`, `,` or `.` jump to the previous or next page. It only shows up on a Latin layout, which is why it looked like a keyboard-language bug: Cyrillic keys never match a Material shortcut.

Material for MkDocs listens for `keydown` on `window` and skips its single-key shortcuts only when the active element is an input. It finds that element through `document.activeElement.shadowRoot?.activeElement`. The widget renders into a **closed** shadow root, so `shadowRoot` is `null`, Material sees the plain host `div#context7-widget`, and the keystroke counts as a global shortcut.

The fix is a nine-line `docs/docs/javascripts/context7-widget.js`, wired back through `extra_javascript`: a bubble-phase `keydown` listener on `document` that calls `stopPropagation()` when the event's target is the widget host. That is where an event from inside a closed shadow tree is retargeted to, and `document` bubbles before `window`, so Material never sees it while the widget's input still gets the character. Capture phase would be wrong here: stopping the event there would keep it from the input too.

Reported upstream as upstash/context7#3189; the workaround can go once the widget stops its own keyboard events.

Checked on a local `just docs-build` with headless Chromium, clicking the bubble and typing into the chat:

| | focus after typing `Fas` | search overlay |
|---|---|---|
| before | `.md-search__input` | open |
| after | `#context7-widget` | closed |

With the fix, `faststream, plus . and / and n` followed by Enter reaches the widget's chat request intact, and the page URL does not change.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
