### PR TITLE
Document graceful shutdown and default graceful_timeout to 15s everywhere

### DIFF
--- a/docs/docs/en/confluent/message.md
+++ b/docs/docs/en/confluent/message.md
@@ -57,7 +57,7 @@ async def base_handler(
 ## Message Fields Access
 
 In most cases, you don't need all message fields; you need to know just a part of them.
-You can use [Context Fields access](../getting-started/context.md#existing_fields) feature for this.
+You can use [Context Fields access](../getting-started/context.md#existing-fields) feature for this.
 
 For example, you can get access to the `headers` like this:
 

--- a/docs/docs/en/getting-started/cli.md
+++ b/docs/docs/en/getting-started/cli.md
@@ -26,7 +26,7 @@ pip install 'faststream[cli]'
 
 ## AsyncAPI Schema
 
-Generate your AsyncAPI document as a `.json` or `.yaml` file from your code, or host it directly as a styled HTML page. Learn more about [hosting options](../asyncapi/hosting){.internal-link}
+Generate your AsyncAPI document as a `.json` or `.yaml` file from your code, or host it directly as a styled HTML page. Learn more about [hosting options](asyncapi/hosting.md){.internal-link}
 
 ## Publishing messages
 
@@ -41,11 +41,11 @@ faststream publish main:app '{"name": "John"}' --subject 'my-subject'
 The primary command to launch a **FastStream** application `faststream run`.
 This command supports a variety of options to customize your application runtime:
 
-* [Scaling](.#scaling){.internal-link}
-* [ASGI Support](.#asgi-support){.internal-link}
-* [Extra options](.#extra-options){.internal-link}
-* [Environment Management](.#environment-management){.internal-link}
-* [Logging Configuration](.#logging-configuration){.internal-link}
+* [Scaling](#scaling){.internal-link}
+* [ASGI Support](#asgi-support){.internal-link}
+* [Extra options](#extra-options){.internal-link}
+* [Environment Management](#environment-management){.internal-link}
+* [Logging Configuration](#logging-configuration){.internal-link}
 
 ### Scaling
 
@@ -73,7 +73,7 @@ Worker 2 started
 
 ### ASGI Support
 
-Running your app as ASGI. For details, see [*ASGI Support*](../asgi){.internal-link}
+Running your app as ASGI. For details, see [*ASGI Support*](asgi.md){.internal-link}
 
 ### Hot Reload
 
@@ -128,7 +128,7 @@ All passed values can be of type `#!python bool`, `#!python str` or `#!python li
 
 ### Logging Configuration
 
-You can pass any custom flags for logging configuration, it's `--log-level` or `--log-config` for detailed logging configuration. See [here](../observability/logging#logging-levels){.internal-link}
+You can pass any custom flags for logging configuration, it's `--log-level` or `--log-config` for detailed logging configuration. See [here](observability/logging.md#logging-levels){.internal-link}
 
 ### Event Loop
 

--- a/docs/docs/en/getting-started/context.md
+++ b/docs/docs/en/getting-started/context.md
@@ -114,7 +114,7 @@ context.reset_global("my_key")
 
 ## Local
 
-To set a local context (available only within the message processing scope), use the context manager `scope`. It could me extremely uselful to fill context with additional options in [Middlewares](../middlewares/){.internal-link}
+To set a local context (available only within the message processing scope), use the context manager `scope`. It could me extremely uselful to fill context with additional options in [Middlewares](middlewares/index.md){.internal-link}
 
 === "AIOKafka"
     ```python linenums="1" hl_lines="13 22"
@@ -538,7 +538,7 @@ Or even to a dict key
 
 **FastStreams** has its own Dependency Injection container - **Context**, used to store application runtime objects and variables.
 
-With this container, you can access both application scope and message processing scope objects. This functionality is similar to [`Depends`](../dependencies/index.md){.internal-link} usage.
+With this container, you can access both application scope and message processing scope objects. This functionality is similar to [`Depends`](dependencies/index.md){.internal-link} usage.
 
 === "AIOKafka"
     ```python linenums="1" hl_lines="2 4 12"
@@ -579,4 +579,4 @@ By default, the context is available in the same place as `Depends`:
 * nested dependencies
 
 !!! tip
-    You can get access to the **Context** in [Middlewares](../middlewares/#context-access){.internal-link} as `#!python self.context`
+    You can get access to the **Context** in [Middlewares](middlewares/index.md#context-access){.internal-link} as `#!python self.context`

--- a/docs/docs/en/getting-started/lifespan/hooks.md
+++ b/docs/docs/en/getting-started/lifespan/hooks.md
@@ -83,6 +83,68 @@ This allows you to safely separate logic and resource initialization across diff
 !!! note ""
    You can also specify multiple hooks. All your registered hooks will be added to a list and executed.
 
+## Graceful Shutdown
+
+When the application stops, **FastStream** does not drop messages that are already being processed. Shutdown happens in this order:
+
+1. `on_shutdown` hooks are called.
+2. Every subscriber stops consuming new messages.
+3. **FastStream** waits for in-flight handlers to finish, up to `graceful_timeout` seconds. Once the timeout expires, the remaining handlers are no longer awaited.
+4. The broker connection is closed.
+5. `after_shutdown` hooks are called.
+6. The `lifespan` context manager (if any) exits.
+
+So, `on_shutdown` runs while your handlers may still be working, and `after_shutdown` runs only after all of them have finished (or the timeout has expired).
+
+The timeout is configured on the broker:
+
+=== "AIOKafka"
+    ```python hl_lines="3"
+    from faststream.kafka import KafkaBroker
+
+    broker = KafkaBroker(graceful_timeout=30.0)
+    ```
+
+=== "Confluent"
+    ```python hl_lines="3"
+    from faststream.confluent import KafkaBroker
+
+    broker = KafkaBroker(graceful_timeout=30.0)
+    ```
+
+=== "RabbitMQ"
+    ```python hl_lines="3"
+    from faststream.rabbit import RabbitBroker
+
+    broker = RabbitBroker(graceful_timeout=30.0)
+    ```
+
+=== "NATS"
+    ```python hl_lines="3"
+    from faststream.nats import NatsBroker
+
+    broker = NatsBroker(graceful_timeout=30.0)
+    ```
+
+=== "Redis"
+    ```python hl_lines="3"
+    from faststream.redis import RedisBroker
+
+    broker = RedisBroker(graceful_timeout=30.0)
+    ```
+
+=== "MQTT"
+    ```python hl_lines="3"
+    from faststream.mqtt import MQTTBroker
+
+    broker = MQTTBroker(graceful_timeout=30.0)
+    ```
+
+!!! warning "Default values differ between brokers"
+    **Kafka** (both **AIOKafka** and **Confluent**), **Redis** and **MQTT** brokers wait up to `15.0` seconds by default.
+    **RabbitMQ** and **NATS** brokers default to `#!python None`, which means the broker **does not wait at all**: the connection is closed right away and running handlers are interrupted.
+    Set `graceful_timeout` explicitly if your handlers must finish their work before the application exits.
+
 ## Usage example
 
 Let's imagine that your application uses **pydantic** as your settings manager.

--- a/docs/docs/en/getting-started/lifespan/hooks.md
+++ b/docs/docs/en/getting-started/lifespan/hooks.md
@@ -190,7 +190,7 @@ The `env` argument will be passed to the `setup` function from the user-provided
 
 !!! tip
     All lifecycle functions always apply `#!python @apply_types` decorator,
-    therefore, all [context fields](../context/index.md){.internal-link} and [dependencies](../dependencies/index.md){.internal-link} are available in them
+    therefore, all [context fields](../context.md){.internal-link} and [dependencies](../dependencies/index.md){.internal-link} are available in them
 
 Then, we initialize the settings of our application using the file passed to us from the command line:
 

--- a/docs/docs/en/getting-started/lifespan/hooks.md
+++ b/docs/docs/en/getting-started/lifespan/hooks.md
@@ -140,10 +140,8 @@ The timeout is configured on the broker:
     broker = MQTTBroker(graceful_timeout=30.0)
     ```
 
-!!! warning "Default values differ between brokers"
-    **Kafka** (both **AIOKafka** and **Confluent**), **Redis** and **MQTT** brokers wait up to `15.0` seconds by default.
-    **RabbitMQ** and **NATS** brokers default to `#!python None`, which means the broker **does not wait at all**: the connection is closed right away and running handlers are interrupted.
-    Set `graceful_timeout` explicitly if your handlers must finish their work before the application exits.
+!!! note
+    The default is `15.0` seconds for every broker. Pass `#!python graceful_timeout=None` to skip the wait entirely: the connection is closed right away and running handlers are interrupted.
 
 ## Usage example
 

--- a/docs/docs/en/getting-started/lifespan/test.md
+++ b/docs/docs/en/getting-started/lifespan/test.md
@@ -10,7 +10,7 @@ search:
 
 # Events Testing
 
-In the most cases you are testing your subscriber/publisher functions, but sometimes you need to trigger some lifespan hooks in your tests too.
+In most cases you are testing your [subscriber](../subscription/test.md){.internal-link} and [publisher](../publishing/test.md){.internal-link} functions, but sometimes you need to trigger some lifespan hooks in your tests too.
 
 For this reason, **FastStream** has a special **TestApp** patcher working as a regular async context manager.
 

--- a/docs/docs/en/getting-started/middlewares/exception.md
+++ b/docs/docs/en/getting-started/middlewares/exception.md
@@ -85,7 +85,7 @@ They can be registered in the same two ways as the previous one, but with a slig
 Your registered exception handlers are also wrapped by the **FastDepends** serialization mechanism, so they can be:
 
 * Either sync or async
-* Able to access the [Context](../context/index.md){.internal-link} feature
+* Able to access the [Context](../context.md){.internal-link} feature
 
 This works in the same way as a regular message handler.
 

--- a/docs/docs/en/getting-started/middlewares/index.md
+++ b/docs/docs/en/getting-started/middlewares/index.md
@@ -289,7 +289,7 @@ To differentiate between different types of publishers, you can use `cmd.publish
 
 ## 📦 Context Access
 
-Middlewares can access the [Context](../context/){.internal-link} for all available methods. For example:
+Middlewares can access the [Context](../context.md){.internal-link} for all available methods. For example:
 
 ```python linenums="1" hl_lines="13"
 from collections.abc import Awaitable, Callable
@@ -357,7 +357,7 @@ Middlewares in **FastStream** offer a powerful mechanism to hook into the messag
 1. [**Order of execution matters**](#basic-middlewares-flow){.internal-link} - Methods are called in a specific sequence: `on_receive` → parser → filter → `consume_scope` → decoder → handler → `publish_scope` → publish → `after_processed`.
 2. **Comprehensive Publishing Hook**: The `publish_scope` method intercepts all outgoing messages, regardless of whether they are from a `#!python @publisher` decorator, a direct `#!python broker.publish()` or `#!python publisher.publish()` call, or an RPC `#!python broker.request()`.
 3. **Chain of Responsibility**: In order to ensure that the message continues through the processing pipeline, your middleware must call the next component in the chain. This is typically done by calling the `call_next()` method with the message or command as an argument, or by using the `super()` function to call the implementation of the next method in the chain.
-4. [**Context Access**](../context/){.internal-link}: All middleware methods have access to the FastStream context via `#!python self.context`.
-5. [**Broker-specific extensions**](#if-the-basic-publishcommand-does-not-meet-your-needs-you-can-use-the-extended-option-here-is-an-example){.internal-link}: If the basic publish command does not meet your needs, you can use the extended option. Here is an example: Use typed publish commands (`KafkaPublishCommand` and `RabbitPublishCommand`) to access and manipulate broker-specific attributes when publishing messages.
+4. [**Context Access**](../context.md){.internal-link}: All middleware methods have access to the FastStream context via `#!python self.context`.
+5. [**Broker-specific extensions**](#important-information-about-publish_scope){.internal-link}: If the basic publish command does not meet your needs, you can use the extended option. Here is an example: Use typed publish commands (`KafkaPublishCommand` and `RabbitPublishCommand`) to access and manipulate broker-specific attributes when publishing messages.
 
 To choose the right method for your needs, think about the stage you want to intervene in: **on_receive** for the initial message arrival, **consume_scope** to wrap the core processing logic, **publish_scope** for outgoing messages, and **after_processed** for post-processing and cleanup.

--- a/docs/docs/en/getting-started/observability/logging.md
+++ b/docs/docs/en/getting-started/observability/logging.md
@@ -12,7 +12,7 @@ search:
 
 ## Logging Requests
 
-To log requests, it is strongly recommended to use the `access_logger` of your broker, as it is available from the [Context](../getting-started/context.md#existing-fields){.internal-link} of your application.
+To log requests, it is strongly recommended to use the `access_logger` of your broker, as it is available from the [Context](../context.md#existing-fields){.internal-link} of your application.
 
 ```python
 from faststream import Logger

--- a/docs/docs/en/getting-started/publishing/broker.md
+++ b/docs/docs/en/getting-started/publishing/broker.md
@@ -18,7 +18,7 @@ In the **FastStream** project, this call is not represented in the **AsyncAPI** 
 
     :material-checkbox-marked:{.checked_mark} **Easy to use** - Publishing messages in **FastStream** is intuitive and requires minimal effort.
 
-    :material-checkbox-marked:{.checked_mark} **Broker availability from Context** - You can leverage **FastStream's** [`Context`](../context/index.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
+    :material-checkbox-marked:{.checked_mark} **Broker availability from Context** - You can leverage **FastStream's** [`Context`](../context.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
 
     :fontawesome-solid-square-xmark:{.x_mark} **No AsyncAPI support** - [`AsyncAPI`](../asyncapi/export.md) is a specification for describing asynchronous APIs used in messaging applications. This method currently does not support this standard.
 

--- a/docs/docs/en/getting-started/publishing/decorator.md
+++ b/docs/docs/en/getting-started/publishing/decorator.md
@@ -25,7 +25,7 @@ It creates a structured DataPipeline unit with an input and output. The order of
 
     :fontawesome-solid-square-xmark:{.x_mark} **No testing support** - This method lacks full [`Testing`](./test.md) support.
 
-    :fontawesome-solid-square-xmark:{.x_mark} **No broker availability from Context** - You cannot leverage **FastStream's** [`Context`](../context/index.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
+    :fontawesome-solid-square-xmark:{.x_mark} **No broker availability from Context** - You cannot leverage **FastStream's** [`Context`](../context.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
 
     :fontawesome-solid-square-xmark:{.x_mark} **Not reusable** - This method cannot be reused.
 

--- a/docs/docs/en/getting-started/publishing/direct.md
+++ b/docs/docs/en/getting-started/publishing/direct.md
@@ -65,6 +65,66 @@ async def handle(msg) -> str:
     await publisher2.publish("Response-2")
 ```
 
+### Overriding the Destination
+
+The destination passed to `#!python broker.publisher(...)` is only a default. Every `#!python publisher.publish(...)` call accepts the same destination arguments as `#!python broker.publish(...)`, and a value passed there **overrides** the one from the constructor for that single call:
+
+=== "AIOKafka"
+    ```python hl_lines="5"
+    publisher = broker.publisher("another-topic")
+
+    @broker.subscriber("in")
+    async def handle(msg: str) -> None:
+        await publisher.publish(msg, topic=f"another-topic.{msg}")
+    ```
+
+=== "Confluent"
+    ```python hl_lines="5"
+    publisher = broker.publisher("another-topic")
+
+    @broker.subscriber("in")
+    async def handle(msg: str) -> None:
+        await publisher.publish(msg, topic=f"another-topic.{msg}")
+    ```
+
+=== "RabbitMQ"
+    ```python hl_lines="5"
+    publisher = broker.publisher("another-queue")
+
+    @broker.subscriber("in")
+    async def handle(msg: str) -> None:
+        await publisher.publish(msg, routing_key=f"another-queue.{msg}")
+    ```
+
+=== "NATS"
+    ```python hl_lines="5"
+    publisher = broker.publisher("another-subject")
+
+    @broker.subscriber("in")
+    async def handle(msg: str) -> None:
+        await publisher.publish(msg, subject=f"another-subject.{msg}")
+    ```
+
+=== "Redis"
+    ```python hl_lines="5"
+    publisher = broker.publisher("another-channel")
+
+    @broker.subscriber("in")
+    async def handle(msg: str) -> None:
+        await publisher.publish(msg, channel=f"another-channel.{msg}")
+    ```
+
+=== "MQTT"
+    ```python hl_lines="5"
+    publisher = broker.publisher("another-topic")
+
+    @broker.subscriber("in")
+    async def handle(msg: str) -> None:
+        await publisher.publish(msg, topic=f"another-topic/{msg}")
+    ```
+
+The constructor argument still matters: the **AsyncAPI** schema describes the publisher by it, and the [test mock](./test.md){.internal-link} is attached to it. If a publisher never publishes to its default destination, it is probably [broker publish](./broker.md){.internal-link} you want.
+
 !!! note
     When using this method, **FastStream** doesn't reuse the incoming `correlation_id` to mark outgoing messages with it. You should set it manually if it is required:
 

--- a/docs/docs/en/getting-started/publishing/direct.md
+++ b/docs/docs/en/getting-started/publishing/direct.md
@@ -20,7 +20,7 @@ This method creates a reusable Publisher object that can be used directly to pub
 
     :material-checkbox-marked:{.checked_mark} **Testing support** - This method has full [`Testing`](./test.md) support.
 
-    :material-checkbox-marked:{.checked_mark} **Broker availability from Context** - You can leverage **FastStream's** [`Context`](../context/index.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
+    :material-checkbox-marked:{.checked_mark} **Broker availability from Context** - You can leverage **FastStream's** [`Context`](../context.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
 
     :material-checkbox-marked:{.checked_mark} **Optional publication** - You can create optional publications.
 

--- a/docs/docs/en/getting-started/publishing/object.md
+++ b/docs/docs/en/getting-started/publishing/object.md
@@ -23,7 +23,7 @@ Additionally, this object can be used as a decorator. The order of Subscriber an
 
     :material-checkbox-marked:{.checked_mark} **Testing support** - This method has full [`Testing`](./test.md) support.
 
-    :material-checkbox-marked:{.checked_mark} **Broker availability from Context** - You can leverage **FastStream's** [`Context`](../context/index.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
+    :material-checkbox-marked:{.checked_mark} **Broker availability from Context** - You can leverage **FastStream's** [`Context`](../context.md), a built-in Dependency Injection (DI) container, to work with brokers or other external services.
 
     :material-checkbox-marked:{.checked_mark} **Reusable** - This method is reusable.
 

--- a/docs/docs/en/getting-started/publishing/test.md
+++ b/docs/docs/en/getting-started/publishing/test.md
@@ -176,3 +176,5 @@ In addition, the publisher has the same `assert_called_once_with` method as a [s
     In order for publishers to be properly patched by the test broker, you need to create them before running the test broker
 
 Additionally, *TestBroker* can be used with a real external broker to make your tests end-to-end suitable. For more information, please visit the [subscriber testing page](../subscription/test.md#real-broker-testing){.internal-link}.
+
+If a publisher is triggered from a lifespan hook rather than from a subscriber, the hooks have to run inside the test as well. **TestApp** does that: see [Events Testing](../lifespan/test.md){.internal-link}.

--- a/docs/docs/en/getting-started/serialization/index.md
+++ b/docs/docs/en/getting-started/serialization/index.md
@@ -28,3 +28,7 @@ The parser declared at the `broker` level will be applied to all subscribers. Th
 ### Message Decoding
 
 At this stage, the body of the **StreamMessage** is transformed into a format suitable for processing within your subscriber function. This is the stage you may need to redefine more often.
+
+!!! tip "Need the message itself?"
+    Type annotations only control how the decoded body is validated and cast for your handler.
+    If you need the message as it came from the broker — its raw bytes, headers, or the decoded body before any casting — don't fight the annotation: inject the **StreamMessage** with `#!python Context("message")` instead. See [Existing Context Fields](../context.md#existing-fields){.internal-link}.

--- a/docs/docs/en/getting-started/subscription/dynamic.md
+++ b/docs/docs/en/getting-started/subscription/dynamic.md
@@ -6,7 +6,7 @@ In these cases, you cannot use the regular **FastStream's** `#!python @broker.su
 However, the framework still allows you to do so in a suitable manner.
 
 !!! warning
-    Dynamic subscribers are not supported by [TestBroker](../test){.internal-link}.
+    Dynamic subscribers are not supported by [TestBroker](test.md){.internal-link}.
 
     The examples below will not work.
 
@@ -215,12 +215,12 @@ It would be much better to use the built-in iteration mechanism:
     ```
 
 !!! tip "Technical Details"
-    Both ways support all **FastStream** features, such as  [middlewares](../../middlewares){.internal-link}, [OpenTelemetry tracing](../../observability/opentelemetry){.internal-link} and [Prometheus metrics](../../observability/prometheus){.internal-link}.
+    Both ways support all **FastStream** features, such as  [middlewares](../middlewares/index.md){.internal-link}, [OpenTelemetry tracing](../observability/opentelemetry/index.md){.internal-link} and [Prometheus metrics](../observability/prometheus.md){.internal-link}.
 
 
 ## Acknowledgement
 
-Note that the default **FastStream** [acknowledgement](../../acknowledgement){.internal-link} logic does not work here. You will need to acknowledge a consumed message manually.
+Note that the default **FastStream** [acknowledgement](../acknowledgement.md){.internal-link} logic does not work here. You will need to acknowledge a consumed message manually.
 
 ```python
 msg = await subscriber.get_one()

--- a/docs/docs/en/getting-started/subscription/index.md
+++ b/docs/docs/en/getting-started/subscription/index.md
@@ -169,7 +169,7 @@ async def handle_str(
     ...
 ```
 
-You can also access some extra features through the function arguments, such as [Depends](../dependencies/index.md){.internal-link} and [Context](../context/existed.md){.internal-link} if required.
+You can also access some extra features through the function arguments, such as [Depends](../dependencies/index.md){.internal-link} and [Context](../context.md#existing-fields){.internal-link} if required.
 
 However, you can easily disable **Pydantic** validation by creating a broker with the following option `#!python Broker(apply_types=False)`
 

--- a/docs/docs/en/getting-started/subscription/test.md
+++ b/docs/docs/en/getting-started/subscription/test.md
@@ -392,3 +392,9 @@ WITH_REAL=True/False pytest ...
 ```
 
 To learn more about managing your application configuration visit [this page](../config/index.md){.internal-link}.
+
+## What's Next
+
+The same patched broker also captures what your handlers publish, so you can assert on outgoing messages without a real broker. See [Publisher Testing](../publishing/test.md){.internal-link}.
+
+If your test needs the `on_startup` / `on_shutdown` hooks or the `lifespan` context to run, wrap the application in **TestApp**. See [Events Testing](../lifespan/test.md){.internal-link}.

--- a/docs/docs/en/llms.txt
+++ b/docs/docs/en/llms.txt
@@ -34,7 +34,7 @@ If you know FastAPI, you already know FastStream: the same decorators, type-driv
 
 ## Context
 - [Context](https://faststream.ag2.ai/latest/getting-started/context/): FastStreams has its own Dependency Injection container - Context, used to store application runtime objects and variables.
-- [Existing Fields](https://faststream.ag2.ai/latest/getting-started/context/existed/): Context includes global objects such as the current broker, the context itself for custom fields, a logger that tags messages with message_id, and the raw message, while ensuring that the message is local to your current consumer scope through contextlib.ContextVar.
+- [Existing Fields](https://faststream.ag2.ai/latest/getting-started/context/#existing-fields): Context includes global objects such as the current broker, the context itself for custom fields, a logger that tags messages with message_id, and the raw message, while ensuring that the message is local to your current consumer scope through contextlib.ContextVar.
 - [Custom Context](https://faststream.ag2.ai/latest/getting-started/context/custom/): You can also store your own objects in the Global and Local Context.
 - [Fields Access](https://faststream.ag2.ai/latest/getting-started/context/fields/): Sometimes, you may need to use a different name for the argument (not the one under which it is stored in the context) or get access to specific parts of the object. To do this, simply specify the name of what you want to access, and the context will provide you with the object.
 - [Extra Options](https://faststream.ag2.ai/latest/getting-started/context/extra/): Additionally, Context provides you with some extra capabilities for working with containing objects.

--- a/docs/docs/en/rabbit/examples/fanout.md
+++ b/docs/docs/en/rabbit/examples/fanout.md
@@ -12,7 +12,7 @@ search:
 
 The **Fanout** Exchange is an even simpler, but slightly less popular way of routing in *RabbitMQ*. This type of `exchange` sends messages to all queues subscribed to it, ignoring any arguments of the message.
 
-At the same time, if the queue listens to several consumers, messages will also be distributed among them (default [scaling mechanism](../direct#scaling){.internal-link}).
+At the same time, if the queue listens to several consumers, messages will also be distributed among them (default [scaling mechanism](direct.md#scaling){.internal-link}).
 
 ## Example
 

--- a/docs/docs/en/rabbit/examples/headers.md
+++ b/docs/docs/en/rabbit/examples/headers.md
@@ -12,7 +12,7 @@ search:
 
 The **Header** Exchange is the most complex and flexible way to route messages in *RabbitMQ*. This `exchange` type sends messages to queues according by matching the queue binding arguments with message headers.
 
-At the same time, if the queue listens to several consumers, messages will also be distributed among them (default [scaling mechanism](../direct#scaling){.internal-link}).
+At the same time, if the queue listens to several consumers, messages will also be distributed among them (default [scaling mechanism](direct.md#scaling){.internal-link}).
 
 ## Example
 

--- a/docs/docs/en/rabbit/examples/topic.md
+++ b/docs/docs/en/rabbit/examples/topic.md
@@ -12,7 +12,7 @@ search:
 
 The **Topic** Exchange is a powerful *RabbitMQ* routing tool. This type of `exchange` sends messages to the queue in accordance with the *pattern* specified when they are connected to `exchange` and the `routing_key` of the message itself.
 
-At the same time, if the queue listens to several consumers, messages will also be distributed among them (default [scaling mechanism](../direct#scaling){.internal-link}).
+At the same time, if the queue listens to several consumers, messages will also be distributed among them (default [scaling mechanism](direct.md#scaling){.internal-link}).
 
 ## Example
 

--- a/faststream/_internal/configs/broker.py
+++ b/faststream/_internal/configs/broker.py
@@ -37,7 +37,7 @@ class BrokerConfig:
 
     # subscriber options
     broker_dependencies: Iterable["Dependant"] = ()
-    graceful_timeout: float | None = None
+    graceful_timeout: float | None = 15.0
     ack_policy: "AckPolicy" = field(default_factory=lambda: EMPTY)
     extra_context: dict[str, Any] = field(default_factory=dict)
 

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -237,7 +237,7 @@ class NatsBroker(
         ws_connection_headers: dict[str, list[str]] | None = None,
         reconnect_to_server_handler: ReconnectToServerHandler | None = None,
         js_options: Union["JsInitOptions", dict[str, Any], None] = None,
-        graceful_timeout: float | None = None,
+        graceful_timeout: float | None = 15.0,
         ack_policy: AckPolicy = EMPTY,
         id_generator: IdGenerator = gen_cor_id,
         decoder: Optional["CustomCallable"] = None,

--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -92,7 +92,7 @@ class RabbitBroker(
         default_channel: Optional["Channel"] = None,
         app_id: str | None = SERVICE_NAME,
         # broker base args
-        graceful_timeout: float | None = None,
+        graceful_timeout: float | None = 15.0,
         ack_policy: AckPolicy = EMPTY,
         id_generator: IdGenerator = gen_cor_id,
         decoder: Optional["CustomCallable"] = None,


### PR DESCRIPTION
# Description

The lifespan docs list the four hooks but never say what happens between `on_shutdown` and `after_shutdown`, and `graceful_timeout` is mentioned only in the release notes. This adds a **Graceful Shutdown** section to the hooks page with the actual order:

1. `on_shutdown` hooks
2. subscribers stop consuming
3. wait for in-flight handlers, up to `graceful_timeout`
4. broker disconnects
5. `after_shutdown` hooks
6. `lifespan` context exits

While writing it down, the default turned out to differ per broker: Kafka, Confluent, Redis and MQTT waited 15 s, while `NatsBroker` and `RabbitBroker` defaulted to `None` and dropped the connection under running handlers. Their FastAPI routers already used 15 s. This PR aligns the two brokers and the base `BrokerConfig` on `15.0`, so the docs can state one default.

**Behavior change:** NATS and RabbitMQ applications now wait up to 15 s for running handlers on shutdown instead of exiting immediately. Pass `graceful_timeout=None` to get the old behavior.

Smaller things on the side:

- the subscriber, publisher and events testing pages now link to each other; the publisher page pointed at the subscriber one, but nothing pointed back and Events Testing was reachable only from the nav
- a tip on the serialization page pointing people who want the raw message at `Context("message")` rather than at their annotation
- the Context link on the subscription page (and in `llms.txt`) targeted `context/existed.md`, which no longer exists; it now points at `context.md#existing-fields`

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] Both new and existing unit tests pass successfully on my local environment (`test_graceful_timeout` for NATS and RabbitMQ)
- [x] I have ensured that static analysis tests are passing (mypy on the touched files)
