### PR TITLE
fix(mqtt): `subscriber()` is typed by `max_workers`, so a decorated handler stays typed

### DIFF
--- a/faststream/mqtt/broker/registrator.py
+++ b/faststream/mqtt/broker/registrator.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
-from typing_extensions import override
+from typing_extensions import overload, override
 from zmqtt import QoS
 
 from faststream._internal.broker.registrator import Registrator
@@ -30,8 +30,52 @@ if TYPE_CHECKING:
 class MQTTRegistrator(Registrator["zmqtt.Message", MQTTBrokerConfig]):
     """Includable to MQTTBroker router."""
 
+    @overload  # type: ignore[override]
+    def subscriber(
+        self,
+        topic: str,
+        *,
+        qos: QoS = QoS.AT_MOST_ONCE,
+        shared: str | None = None,
+        # broker arguments
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        dependencies: Iterable["Dependant"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
+        max_workers: Literal[1] = 1,
+        persistent: bool = True,
+        # AsyncAPI information
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+    ) -> "MQTTDefaultSubscriber": ...
+
+    @overload
+    def subscriber(
+        self,
+        topic: str,
+        *,
+        qos: QoS = QoS.AT_MOST_ONCE,
+        shared: str | None = None,
+        # broker arguments
+        ack_policy: AckPolicy = EMPTY,
+        no_reply: bool = False,
+        dependencies: Iterable["Dependant"] = (),
+        parser: Optional["CustomCallable"] = None,
+        decoder: Optional["CustomCallable"] = None,
+        codec: Optional["CodecProto"] = None,
+        max_workers: int = ...,
+        persistent: bool = True,
+        # AsyncAPI information
+        title: str | None = None,
+        description: str | None = None,
+        include_in_schema: bool = True,
+    ) -> "MQTTConcurrentSubscriber": ...
+
     @override
-    def subscriber(  # type: ignore[override]
+    def subscriber(
         self,
         topic: str,
         *,

--- a/tests/mypy/mqtt.py
+++ b/tests/mypy/mqtt.py
@@ -1,4 +1,18 @@
-from faststream.mqtt import MQTTBroker, QoS, TestMQTTBroker, Will, WillProperties
+from typing_extensions import assert_type
+
+from faststream._internal.endpoint.call_wrapper import HandlerCallWrapper
+from faststream.mqtt import (
+    MQTTBroker,
+    MQTTRouter,
+    QoS,
+    TestMQTTBroker,
+    Will,
+    WillProperties,
+)
+from faststream.mqtt.subscriber.usecase import (
+    MQTTConcurrentSubscriber,
+    MQTTDefaultSubscriber,
+)
 
 
 async def on_connection_recovery_failed() -> None:
@@ -33,3 +47,20 @@ async def check_multiple_test_brokers() -> None:
     ) as (br1, br2):
         await br1.publish(None, "test")
         await br2.publish(None, "test")
+
+
+def check_subscriber_instance_type(broker: MQTTBroker | MQTTRouter) -> None:
+    sub1 = broker.subscriber("test")
+    assert_type(sub1, MQTTDefaultSubscriber)
+
+    sub2 = broker.subscriber("test", max_workers=2)
+    assert_type(sub2, MQTTConcurrentSubscriber)
+
+
+def check_decorated_handler_type(broker: MQTTBroker | MQTTRouter) -> None:
+    # A union-typed `subscriber()` counts as an untyped decorator under strict mypy;
+    # a sync handler, since mypy and pyright spell an `async def`'s return differently
+    @broker.subscriber("test")
+    def handle() -> None: ...
+
+    assert_type(handle, HandlerCallWrapper[[], None])


### PR DESCRIPTION
# Description

`MQTTRegistrator.subscriber` returns `MQTTDefaultSubscriber | MQTTConcurrentSubscriber`. Strict mypy treats a union-typed decorator as untyped, so any handler under `@broker.subscriber(...)` on an `MQTTBroker` or `MQTTRouter` reports `untyped-decorator`, and the handler loses its type:

```python
@broker.subscriber("t")
def handle() -> None: ...
# error: Untyped decorator makes function "handle" untyped  [untyped-decorator]
```

The registrator gains the two `max_workers` overloads the MQTT FastAPI router already has: `max_workers: Literal[1]` returns `MQTTDefaultSubscriber`, any other `int` returns `MQTTConcurrentSubscriber`. `tests/mypy/mqtt.py` pins both subscriber types and the decorated handler's type; both checks go red on the old registrator.

Split out of #3120, where the MQTT Call assertions needed it; it is a fix on its own.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
