### PR TITLE
fix(redis): stop warning that StreamSub.no_ack has no effect with consumer groups

### DIFF
--- a/faststream/redis/schemas/stream_sub.py
+++ b/faststream/redis/schemas/stream_sub.py
@@ -115,13 +115,6 @@ class StreamSub(NameRequired):
                         stacklevel=1,
                     )
 
-            elif no_ack:
-                warnings.warn(
-                    message="`no_ack` has no effect with consumer group",
-                    category=RuntimeWarning,
-                    stacklevel=1,
-                )
-
         if claim_min_idle_time is not None:
             if not REDIS_V710:
                 msg = (

--- a/tests/brokers/redis/test_config.py
+++ b/tests/brokers/redis/test_config.py
@@ -158,3 +158,20 @@ def test_sub_overrides_broker_and_router() -> None:
         ack_policy=AckPolicy.ACK_FIRST,
     )
     assert sub.ack_policy is AckPolicy.ACK_FIRST
+
+
+@pytest.mark.redis()
+def test_stream_sub_no_ack_with_group_default_last_id() -> None:
+    """no_ack is forwarded to XREADGROUP NOACK when last_id is `>`."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        stream = StreamSub(
+            "test_stream",
+            group="test_group",
+            consumer="test_consumer",
+            no_ack=True,
+        )
+    assert stream.no_ack is True
+    assert stream.last_id == ">"


### PR DESCRIPTION
## Summary

`StreamSub(..., group=..., consumer=..., no_ack=True)` no longer emits
`RuntimeWarning: \`no_ack\` has no effect with consumer group` when `last_id` is `>` (the default for a consumer group).

Fixes #3126

## Motivation

The warning is leftover from a time when `no_ack` was not forwarded. It *does* have an effect: `stream_subscriber.py` passes `noack=stream.no_ack` into `XREADGROUP`, so entries never enter the PEL. The warning was incorrect and made a working option look broken.

The existing warning for `no_ack` with `last_id != ">"` is unchanged — that combination is still unsupported.

## Implementation

Removed the `elif no_ack:` `RuntimeWarning` branch in `StreamSub.__init__` that fired whenever a consumer group used the default `last_id` of `>`.

## Testing

- Isolated constructor check (no Redis): `StreamSub(..., group, consumer, no_ack=True)` raises no `RuntimeWarning` and sets `last_id == ">"`.
- Same constructor with `last_id="$"` still warns: `` `no_ack` is not supported by consumer group with last_id other than `>` ``.
- Added `test_stream_sub_no_ack_with_group_default_last_id` in `tests/brokers/redis/test_config.py`.
- Existing `test_stream_sub_with_no_ack_group` (last_id `$`) left as-is.

Could not install the full package in this environment (PyPI 502), so the Redis-marked suite was not run end-to-end here.
